### PR TITLE
Switch from direct network printing to CUPS driver

### DIFF
--- a/custom_components/escpos_printer/__init__.py
+++ b/custom_components/escpos_printer/__init__.py
@@ -5,7 +5,6 @@ import os
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 
@@ -16,6 +15,7 @@ from .const import (
     CONF_DEFAULT_CUT,
     CONF_KEEPALIVE,
     CONF_LINE_WIDTH,
+    CONF_PRINTER_NAME,
     CONF_PROFILE,
     CONF_STATUS_INTERVAL,
     CONF_TIMEOUT,
@@ -107,8 +107,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.debug("Registered global services for %s", DOMAIN)
 
     config = PrinterConfig(
-        host=entry.data[CONF_HOST],
-        port=entry.data.get(CONF_PORT, 9100),
+        printer_name=entry.data[CONF_PRINTER_NAME],
         timeout=float(entry.options.get(CONF_TIMEOUT, entry.data.get(CONF_TIMEOUT, 4.0))),
         codepage=entry.options.get(CONF_CODEPAGE) or entry.data.get(CONF_CODEPAGE),
         profile=entry.options.get(CONF_PROFILE) or entry.data.get(CONF_PROFILE),

--- a/custom_components/escpos_printer/config_flow.py
+++ b/custom_components/escpos_printer/config_flow.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import logging
-import socket
 from typing import Any
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
-from homeassistant.const import CONF_HOST, CONF_PORT
 import voluptuous as vol
 
 from .capabilities import (
@@ -28,37 +26,19 @@ from .const import (
     CONF_DEFAULT_CUT,
     CONF_KEEPALIVE,
     CONF_LINE_WIDTH,
+    CONF_PRINTER_NAME,
     CONF_PROFILE,
     CONF_STATUS_INTERVAL,
     CONF_TIMEOUT,
     DEFAULT_ALIGN,
     DEFAULT_CUT,
     DEFAULT_LINE_WIDTH,
-    DEFAULT_PORT,
     DEFAULT_TIMEOUT,
     DOMAIN,
 )
+from .printer import get_cups_printers, is_cups_printer_available
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _can_connect(host: str, port: int, timeout: float) -> bool:
-    """Test TCP connectivity to a host and port.
-
-    Args:
-        host: Hostname or IP address to connect to
-        port: Port number to connect to
-        timeout: Connection timeout in seconds
-
-    Returns:
-        True if connection succeeds, False otherwise
-    """
-    try:
-        # Using a raw socket here to validate TCP reachability
-        with socket.create_connection((host, port), timeout=timeout):
-            return True
-    except OSError:
-        return False
 
 
 class EscposConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -73,7 +53,7 @@ class EscposConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle step 1: Connection details and profile selection.
+        """Handle step 1: CUPS printer selection and profile selection.
 
         Args:
             user_input: User provided configuration data
@@ -82,27 +62,29 @@ class EscposConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             FlowResult containing the next step or final result
         """
         errors: dict[str, str] = {}
+
+        # Get available CUPS printers
+        available_printers = await self.hass.async_add_executor_job(get_cups_printers)
+
         if user_input is not None:
             _LOGGER.debug("Config flow user step input: %s", user_input)
-            host = user_input[CONF_HOST]
-            port = user_input.get(CONF_PORT, DEFAULT_PORT)
+            printer_name = user_input[CONF_PRINTER_NAME]
             timeout = float(user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT))
 
-            await self.async_set_unique_id(f"{host}:{port}")
+            await self.async_set_unique_id(f"cups_{printer_name}")
             self._abort_if_unique_id_configured()
 
             _LOGGER.debug(
-                "Attempting connection test to %s:%s (timeout=%s)", host, port, timeout
+                "Checking CUPS printer availability: %s", printer_name
             )
-            ok = await self.hass.async_add_executor_job(_can_connect, host, port, timeout)
+            ok = await self.hass.async_add_executor_job(is_cups_printer_available, printer_name)
             if ok:
-                _LOGGER.debug("Connection test succeeded for %s:%s", host, port)
+                _LOGGER.debug("CUPS printer '%s' is available", printer_name)
 
                 # Store data and determine next step
                 profile = user_input.get(CONF_PROFILE, PROFILE_AUTO)
                 self._user_data = {
-                    CONF_HOST: host,
-                    CONF_PORT: port,
+                    CONF_PRINTER_NAME: printer_name,
                     CONF_TIMEOUT: timeout,
                     CONF_PROFILE: profile,
                 }
@@ -114,16 +96,21 @@ class EscposConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # Otherwise go to codepage step
                 return await self.async_step_codepage()
 
-            _LOGGER.warning("Connection test failed for %s:%s", host, port)
+            _LOGGER.warning("CUPS printer '%s' not available", printer_name)
             errors["base"] = "cannot_connect"
 
         # Build profile choices dynamically
         profile_choices = await self.hass.async_add_executor_job(get_profile_choices_dict)
 
+        # Build printer choices from available CUPS printers
+        if available_printers:
+            printer_choices = {p: p for p in available_printers}
+        else:
+            printer_choices = {}
+
         data_schema = vol.Schema(
             {
-                vol.Required(CONF_HOST): str,
-                vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
+                vol.Required(CONF_PRINTER_NAME): vol.In(printer_choices) if printer_choices else str,
                 vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.Coerce(float),
                 vol.Optional(CONF_PROFILE, default=PROFILE_AUTO): vol.In(profile_choices),
             }
@@ -223,18 +210,16 @@ class EscposConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_DEFAULT_CUT: user_input.get(CONF_DEFAULT_CUT, DEFAULT_CUT),
             }
 
-            host = data[CONF_HOST]
-            port = data[CONF_PORT]
+            printer_name = data[CONF_PRINTER_NAME]
 
             _LOGGER.debug(
-                "Creating config entry for %s:%s with profile=%s codepage=%s",
-                host,
-                port,
+                "Creating config entry for CUPS printer '%s' with profile=%s codepage=%s",
+                printer_name,
                 data.get(CONF_PROFILE),
                 data.get(CONF_CODEPAGE),
             )
 
-            return self.async_create_entry(title=f"{host}:{port}", data=data)
+            return self.async_create_entry(title=printer_name, data=data)
 
         # Get profile-specific options
         profile = self._user_data.get(CONF_PROFILE, PROFILE_AUTO)
@@ -313,10 +298,9 @@ class EscposConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_CODEPAGE: custom_codepage,
                 }
 
-                host = data[CONF_HOST]
-                port = data[CONF_PORT]
+                printer_name = data[CONF_PRINTER_NAME]
 
-                return self.async_create_entry(title=f"{host}:{port}", data=data)
+                return self.async_create_entry(title=printer_name, data=data)
 
         data_schema = vol.Schema(
             {
@@ -364,10 +348,9 @@ class EscposConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_LINE_WIDTH: width_int,
                 }
 
-                host = data[CONF_HOST]
-                port = data[CONF_PORT]
+                printer_name = data[CONF_PRINTER_NAME]
 
-                return self.async_create_entry(title=f"{host}:{port}", data=data)
+                return self.async_create_entry(title=printer_name, data=data)
 
         data_schema = vol.Schema(
             {

--- a/custom_components/escpos_printer/const.py
+++ b/custom_components/escpos_printer/const.py
@@ -1,8 +1,7 @@
 DOMAIN = "escpos_printer"
 
 # Configuration keys
-CONF_HOST = "host"
-CONF_PORT = "port"
+CONF_PRINTER_NAME = "printer_name"
 CONF_TIMEOUT = "timeout"
 CONF_CODEPAGE = "codepage"
 CONF_DEFAULT_ALIGN = "default_align"
@@ -13,7 +12,6 @@ CONF_PROFILE = "profile"
 CONF_LINE_WIDTH = "line_width"
 
 # Default values
-DEFAULT_PORT = 9100
 DEFAULT_TIMEOUT = 4.0
 DEFAULT_ALIGN = "left"
 DEFAULT_CUT = "none"

--- a/custom_components/escpos_printer/diagnostics.py
+++ b/custom_components/escpos_printer/diagnostics.py
@@ -4,19 +4,19 @@ from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 
 from .const import (
     CONF_CODEPAGE,
     CONF_KEEPALIVE,
     CONF_LINE_WIDTH,
+    CONF_PRINTER_NAME,
     CONF_PROFILE,
     CONF_STATUS_INTERVAL,
     DOMAIN,
 )
 
-TO_REDACT = {CONF_HOST}
+TO_REDACT: set[str] = set()
 
 
 async def async_get_config_entry_diagnostics(
@@ -40,8 +40,7 @@ async def async_get_config_entry_diagnostics(
             "profile": config.profile if config else None,
             "codepage": config.codepage if config else None,
             "line_width": config.line_width if config else None,
-            "host": config.host if config else None,
-            "port": config.port if config else None,
+            "printer_name": config.printer_name if config else None,
             "keepalive": getattr(adapter, "_keepalive", None),
             "status_interval": getattr(adapter, "_status_interval", None),
         }
@@ -50,8 +49,7 @@ async def async_get_config_entry_diagnostics(
         "entry": {
             "title": entry.title,
             "data": {
-                CONF_HOST: data.get(CONF_HOST),
-                CONF_PORT: data.get(CONF_PORT),
+                CONF_PRINTER_NAME: data.get(CONF_PRINTER_NAME),
                 CONF_CODEPAGE: data.get(CONF_CODEPAGE),
                 CONF_PROFILE: data.get(CONF_PROFILE),
                 CONF_LINE_WIDTH: data.get(CONF_LINE_WIDTH),

--- a/custom_components/escpos_printer/manifest.json
+++ b/custom_components/escpos_printer/manifest.json
@@ -14,6 +14,7 @@
   ],
   "requirements": [
     "python-escpos==3.1",
+    "pycups==2.0.4",
     "Pillow==12.0.0",
     "qrcode==8.2",
     "python-barcode==0.16.1"

--- a/custom_components/escpos_printer/strings.json
+++ b/custom_components/escpos_printer/strings.json
@@ -3,18 +3,16 @@
   "config": {
     "step": {
       "user": {
-        "title": "Configure printer connection",
-        "description": "Enter the connection details for your ESC/POS network printer.",
+        "title": "Configure CUPS printer",
+        "description": "Select your ESC/POS printer from the available CUPS printers.",
         "data": {
-          "host": "Host",
-          "port": "Port",
+          "printer_name": "CUPS Printer",
           "timeout": "Timeout (seconds)",
           "profile": "Printer profile"
         },
         "data_description": {
-          "host": "IP address or hostname of the printer.",
-          "port": "Network port (usually 9100).",
-          "timeout": "Connection timeout in seconds.",
+          "printer_name": "Select the CUPS printer to use.",
+          "timeout": "Operation timeout in seconds.",
           "profile": "Select your printer model or Auto-detect. Choose 'Custom' to enter a profile name manually."
         }
       },
@@ -66,7 +64,7 @@
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to printer.",
+      "cannot_connect": "CUPS printer not available.",
       "already_configured": "This printer is already configured.",
       "invalid_profile": "Invalid printer profile name.",
       "invalid_codepage": "Invalid codepage/encoding.",
@@ -89,13 +87,13 @@
           "status_interval": "Status check interval (seconds)"
         },
         "data_description": {
-          "timeout": "Connection timeout in seconds.",
+          "timeout": "Operation timeout in seconds.",
           "profile": "Select your printer model. Changing this will reset encoding options.",
           "codepage": "Character encoding/codepage for text.",
           "line_width": "Number of characters per line (columns).",
           "default_align": "Default text alignment for printing.",
           "default_cut": "Default paper cut mode after printing.",
-          "keepalive": "Keep the connection open between print jobs.",
+          "keepalive": "Keep the CUPS connection open between print jobs.",
           "status_interval": "How often to check printer status (0 to disable)."
         }
       },

--- a/custom_components/escpos_printer/translations/en.json
+++ b/custom_components/escpos_printer/translations/en.json
@@ -3,18 +3,16 @@
   "config": {
     "step": {
       "user": {
-        "title": "Configure printer connection",
-        "description": "Enter the connection details for your ESC/POS network printer.",
+        "title": "Configure CUPS printer",
+        "description": "Select your ESC/POS printer from the available CUPS printers.",
         "data": {
-          "host": "Host",
-          "port": "Port",
+          "printer_name": "CUPS Printer",
           "timeout": "Timeout (seconds)",
           "profile": "Printer profile"
         },
         "data_description": {
-          "host": "IP address or hostname of the printer.",
-          "port": "Network port (usually 9100).",
-          "timeout": "Connection timeout in seconds.",
+          "printer_name": "Select the CUPS printer to use.",
+          "timeout": "Operation timeout in seconds.",
           "profile": "Select your printer model or Auto-detect. Choose 'Custom' to enter a profile name manually."
         }
       },
@@ -66,7 +64,7 @@
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to printer.",
+      "cannot_connect": "CUPS printer not available.",
       "already_configured": "This printer is already configured.",
       "invalid_profile": "Invalid printer profile name.",
       "invalid_codepage": "Invalid codepage/encoding.",
@@ -89,13 +87,13 @@
           "status_interval": "Status check interval (seconds)"
         },
         "data_description": {
-          "timeout": "Connection timeout in seconds.",
+          "timeout": "Operation timeout in seconds.",
           "profile": "Select your printer model. Changing this will reset encoding options.",
           "codepage": "Character encoding/codepage for text.",
           "line_width": "Number of characters per line (columns).",
           "default_align": "Default text alignment for printing.",
           "default_cut": "Default paper cut mode after printing.",
-          "keepalive": "Keep the connection open between print jobs.",
+          "keepalive": "Keep the CUPS connection open between print jobs.",
           "status_interval": "How often to check printer status (0 to disable)."
         }
       },

--- a/tests/test_barcode_force_software.py
+++ b/tests/test_barcode_force_software.py
@@ -39,7 +39,7 @@ class FakePrinterRejectFS(FakePrinterAcceptFS):
 async def test_barcode_passes_force_software(monkeypatch: Any) -> None:
     created: list[FakePrinterAcceptFS] = []
 
-    def fake_network() -> Any:
+    def fake_cups() -> Any:
         def _factory(*args: Any, **kwargs: Any) -> FakePrinterAcceptFS:
             inst = FakePrinterAcceptFS()
             created.append(inst)
@@ -48,9 +48,9 @@ async def test_barcode_passes_force_software(monkeypatch: Any) -> None:
 
     from custom_components.escpos_printer import printer as printer_mod
 
-    monkeypatch.setattr(printer_mod, "_get_network_printer", fake_network)
+    monkeypatch.setattr(printer_mod, "_get_cups_printer", fake_cups)
 
-    adapter = EscposPrinterAdapter(PrinterConfig(host="127.0.0.1", port=9100))
+    adapter = EscposPrinterAdapter(PrinterConfig(printer_name="TestPrinter"))
     hass = HassStub()
 
     await adapter.print_barcode(
@@ -76,7 +76,7 @@ async def test_barcode_passes_force_software(monkeypatch: Any) -> None:
 async def test_barcode_retries_without_force_software(monkeypatch: Any) -> None:
     created: list[FakePrinterRejectFS] = []
 
-    def fake_network() -> Any:
+    def fake_cups() -> Any:
         def _factory(*args: Any, **kwargs: Any) -> FakePrinterRejectFS:
             inst = FakePrinterRejectFS()
             created.append(inst)
@@ -85,9 +85,9 @@ async def test_barcode_retries_without_force_software(monkeypatch: Any) -> None:
 
     from custom_components.escpos_printer import printer as printer_mod
 
-    monkeypatch.setattr(printer_mod, "_get_network_printer", fake_network)
+    monkeypatch.setattr(printer_mod, "_get_cups_printer", fake_cups)
 
-    adapter = EscposPrinterAdapter(PrinterConfig(host="127.0.0.1", port=9100))
+    adapter = EscposPrinterAdapter(PrinterConfig(printer_name="TestPrinter"))
     hass = HassStub()
 
     await adapter.print_barcode(

--- a/tests/test_config_flow_negative.py
+++ b/tests/test_config_flow_negative.py
@@ -1,20 +1,25 @@
 from unittest.mock import patch
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST, CONF_PORT
 
-from custom_components.escpos_printer.const import DOMAIN
+from custom_components.escpos_printer.const import CONF_PRINTER_NAME, DOMAIN
 
 
 async def test_config_flow_cannot_connect(hass):  # type: ignore[no-untyped-def]
-    with patch(
-        "custom_components.escpos_printer.config_flow._can_connect",
-        return_value=False,
+    with (
+        patch(
+            "custom_components.escpos_printer.config_flow.get_cups_printers",
+            return_value=["TestPrinter"],
+        ),
+        patch(
+            "custom_components.escpos_printer.config_flow.is_cups_printer_available",
+            return_value=False,
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_USER},
-            data={CONF_HOST: "1.2.3.4", CONF_PORT: 9100, "timeout": 1.0},
+            data={CONF_PRINTER_NAME: "TestPrinter", "timeout": 1.0},
         )
     assert result["type"] == "form"
     assert result["errors"].get("base") == "cannot_connect"

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -4,18 +4,18 @@ from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.escpos_printer.const import DOMAIN
+from custom_components.escpos_printer.const import CONF_PRINTER_NAME, DOMAIN
 
 
 async def test_notify_sends_text(hass):  # type: ignore[no-untyped-def]
     entry = MockConfigEntry(
         domain=DOMAIN,
-        title="1.2.3.4:9100",
-        data={"host": "1.2.3.4", "port": 9100},
-        unique_id="1.2.3.4:9100",
+        title="TestPrinter",
+        data={CONF_PRINTER_NAME: "TestPrinter"},
+        unique_id="cups_TestPrinter",
     )
     entry.add_to_hass(hass)
-    with patch("escpos.printer.Network"):
+    with patch("escpos.printer.CupsPrinter"):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
@@ -26,7 +26,7 @@ async def test_notify_sends_text(hass):  # type: ignore[no-untyped-def]
     entity_id = entities[0].entity_id
 
     fake = MagicMock()
-    with patch("escpos.printer.Network", return_value=fake):
+    with patch("escpos.printer.CupsPrinter", return_value=fake):
         await hass.services.async_call(
             NOTIFY_DOMAIN,
             "send_message",

--- a/tests/test_optional_services_and_errors.py
+++ b/tests/test_optional_services_and_errors.py
@@ -4,18 +4,18 @@ import aiohttp
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.escpos_printer.const import DOMAIN
+from custom_components.escpos_printer.const import CONF_PRINTER_NAME, DOMAIN
 
 
 async def _setup_entry(hass):  # type: ignore[no-untyped-def]
     entry = MockConfigEntry(
         domain=DOMAIN,
-        title="1.2.3.4:9100",
-        data={"host": "1.2.3.4", "port": 9100},
-        unique_id="1.2.3.4:9100",
+        title="TestPrinter",
+        data={CONF_PRINTER_NAME: "TestPrinter"},
+        unique_id="cups_TestPrinter",
     )
     entry.add_to_hass(hass)
-    with patch("escpos.printer.Network"):
+    with patch("escpos.printer.CupsPrinter"):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
     return entry
@@ -29,7 +29,7 @@ async def test_print_image_url_download_error(hass, caplog):  # type: ignore[no-
     async def _raise(*args, **kwargs):  # type: ignore[no-untyped-def]
         raise aiohttp.ClientError("download failed")
 
-    with patch("escpos.printer.Network", return_value=fake), \
+    with patch("escpos.printer.CupsPrinter", return_value=fake), \
         patch("aiohttp.ClientSession.get", new=AsyncMock(side_effect=_raise)):
         with pytest.raises(Exception):
             await hass.services.async_call(
@@ -46,7 +46,7 @@ async def test_encoding_codepage_warning(hass, caplog):  # type: ignore[no-untyp
     fake = MagicMock()
     # Cause _set_codepage to raise
     fake._set_codepage.side_effect = RuntimeError("bad codepage")
-    with patch("escpos.printer.Network", return_value=fake):
+    with patch("escpos.printer.CupsPrinter", return_value=fake):
         await hass.services.async_call(
             DOMAIN,
             "print_text",
@@ -59,7 +59,7 @@ async def test_encoding_codepage_warning(hass, caplog):  # type: ignore[no-untyp
 async def test_print_barcode_service_calls_escpos(hass):  # type: ignore[no-untyped-def]
     await _setup_entry(hass)
     fake = MagicMock()
-    with patch("escpos.printer.Network", return_value=fake):
+    with patch("escpos.printer.CupsPrinter", return_value=fake):
         await hass.services.async_call(
             DOMAIN,
             "print_barcode",
@@ -74,7 +74,7 @@ async def test_beep_service_logs_when_unsupported(hass, caplog):  # type: ignore
     fake = MagicMock()
     # Simulate unsupported buzzer by raising AttributeError
     fake.buzzer.side_effect = AttributeError()
-    with patch("escpos.printer.Network", return_value=fake):
+    with patch("escpos.printer.CupsPrinter", return_value=fake):
         await hass.services.async_call(DOMAIN, "beep", {"times": 2, "duration": 3}, blocking=True)
     # Should warn if not supported
     assert any("does not support buzzer" in rec.message for rec in caplog.records)

--- a/tests/test_services_image.py
+++ b/tests/test_services_image.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 from PIL import Image
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.escpos_printer.const import DOMAIN
+from custom_components.escpos_printer.const import CONF_PRINTER_NAME, DOMAIN
 
 
 async def test_print_image_service_local(hass, tmp_path):  # type: ignore[no-untyped-def]
@@ -12,17 +12,17 @@ async def test_print_image_service_local(hass, tmp_path):  # type: ignore[no-unt
 
     entry = MockConfigEntry(
         domain=DOMAIN,
-        title="1.2.3.4:9100",
-        data={"host": "1.2.3.4", "port": 9100},
-        unique_id="1.2.3.4:9100",
+        title="TestPrinter",
+        data={CONF_PRINTER_NAME: "TestPrinter"},
+        unique_id="cups_TestPrinter",
     )
     entry.add_to_hass(hass)
-    with patch("escpos.printer.Network"):
+    with patch("escpos.printer.CupsPrinter"):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     fake = MagicMock()
-    with patch("escpos.printer.Network", return_value=fake):
+    with patch("escpos.printer.CupsPrinter", return_value=fake):
         await hass.services.async_call(
             DOMAIN,
             "print_image",

--- a/tests/test_services_qr.py
+++ b/tests/test_services_qr.py
@@ -2,23 +2,23 @@ from unittest.mock import MagicMock, patch
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.escpos_printer.const import DOMAIN
+from custom_components.escpos_printer.const import CONF_PRINTER_NAME, DOMAIN
 
 
 async def test_print_qr_service(hass):  # type: ignore[no-untyped-def]
     entry = MockConfigEntry(
         domain=DOMAIN,
-        title="1.2.3.4:9100",
-        data={"host": "1.2.3.4", "port": 9100},
-        unique_id="1.2.3.4:9100",
+        title="TestPrinter",
+        data={CONF_PRINTER_NAME: "TestPrinter"},
+        unique_id="cups_TestPrinter",
     )
     entry.add_to_hass(hass)
-    with patch("escpos.printer.Network"):
+    with patch("escpos.printer.CupsPrinter"):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     fake = MagicMock()
-    with patch("escpos.printer.Network", return_value=fake):
+    with patch("escpos.printer.CupsPrinter", return_value=fake):
         await hass.services.async_call(
             DOMAIN,
             "print_qr",

--- a/tests/test_services_text.py
+++ b/tests/test_services_text.py
@@ -1,20 +1,19 @@
 from unittest.mock import MagicMock, patch
 
-from homeassistant.const import CONF_HOST, CONF_PORT
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.escpos_printer.const import DOMAIN
+from custom_components.escpos_printer.const import CONF_PRINTER_NAME, DOMAIN
 
 
 async def _setup_entry(hass):  # type: ignore[no-untyped-def]
     entry = MockConfigEntry(
         domain=DOMAIN,
-        title="1.2.3.4:9100",
-        data={CONF_HOST: "1.2.3.4", CONF_PORT: 9100},
-        unique_id="1.2.3.4:9100",
+        title="TestPrinter",
+        data={CONF_PRINTER_NAME: "TestPrinter"},
+        unique_id="cups_TestPrinter",
     )
     entry.add_to_hass(hass)
-    with patch("escpos.printer.Network"):
+    with patch("escpos.printer.CupsPrinter"):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
     return entry
@@ -24,7 +23,7 @@ async def test_print_text_service(hass):  # type: ignore[no-untyped-def]
     await _setup_entry(hass)
 
     fake = MagicMock()
-    with patch("escpos.printer.Network", return_value=fake):
+    with patch("escpos.printer.CupsPrinter", return_value=fake):
         await hass.services.async_call(
             DOMAIN,
             "print_text",


### PR DESCRIPTION
Replace the direct TCP network connection (escpos.printer.Network) with CUPS printing (escpos.printer.CupsPrinter). This change:

- Uses pycups to enumerate and manage CUPS printers
- Replaces host/port configuration with CUPS printer name selection
- Updates status checking to use CUPS printer state queries
- Adds pycups==2.0.4 dependency to manifest.json
- Updates all UI strings for CUPS printer terminology
- Updates all unit tests to use the new CupsPrinter mock