### PR TITLE
chore(deps): ignore pytest in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,10 @@ updates:
     # Dependabot will update pins in pyproject.toml. A companion workflow
     # auto-syncs Home Assistant manifest requirements on Dependabot PRs.
     open-pull-requests-limit: 10
+    ignore:
+      # pytest-homeassistant-custom-component hard-pins pytest==9.0.0 (and
+      # any future pin set by that package), so bumping pytest independently
+      # creates an unresolvable conflict. Let the HA test harness drive the
+      # pytest version; revisit if upstream loosens the pin.
+      - dependency-name: "pytest"
 


### PR DESCRIPTION
## Summary
- pytest-homeassistant-custom-component hard-pins `pytest==9.0.0` (still true in latest 0.13.316 as of this PR)
- Independent pytest bumps therefore fail dependency resolution — see #34
- Tell Dependabot to skip pytest until the upstream HA test harness loosens the pin

## Test plan
- [ ] CI passes (no changes to runtime/test code)
- [ ] Verify no further `Bump pytest from ...` PRs are opened by Dependabot

🤖 Generated with [Claude Code](https://claude.com/claude-code)