### PR TITLE
chore(deps): ignore dbus-fast in Dependabot (HA-pinned)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,9 @@ updates:
       # creates an unresolvable conflict. Let the HA test harness drive the
       # pytest version; revisit if upstream loosens the pin.
       - dependency-name: "pytest"
+      # dbus-fast is pinned by Home Assistant core (package_constraints.txt)
+      # and the HA bluetooth integration manifest. Bumping it independently
+      # breaks HA installs. Let HA core drive the version; revisit when HA
+      # bumps it.
+      - dependency-name: "dbus-fast"
 


### PR DESCRIPTION
## Summary
- HA core's `package_constraints.txt` pins `dbus-fast==4.0.4`
- HA's bluetooth integration manifest also pins it
- Independent dbus-fast bumps break HA installs (see #73)
- Let HA core drive this version

## Test plan
- [ ] CI passes (config-only change)
- [ ] Verify no further `Bump dbus-fast from ...` PRs are opened by Dependabot

🤖 Generated with [Claude Code](https://claude.com/claude-code)