### PR TITLE
Bump wcwidth from 0.2.13 to 0.7.0

### DIFF
--- a/custom_components/escpos_printer/manifest.json
+++ b/custom_components/escpos_printer/manifest.json
@@ -20,7 +20,7 @@
     "python-barcode==0.16.1",
     "pyusb==1.3.1",
     "dbus-fast>=3.1.2,<6",
-    "wcwidth==0.2.13"
+    "wcwidth==0.7.0"
   ],
   "usb": [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   # Visual-width measurement for the text-effects box / table padders so
   # CJK / fullwidth / emoji columns line up under the 1-col-per-glyph
   # text mode (instead of silently misaligning via len()).
-  "wcwidth==0.2.13",
+  "wcwidth==0.7.0",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -900,7 +900,7 @@ wheels = [
 
 [[package]]
 name = "diff-cover"
-version = "9.5.0"
+version = "10.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chardet" },
@@ -908,9 +908,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/8b/59525456c2607982a30f809f7ad02b26b0c18951aff95d5b14c37e61d346/diff_cover-9.5.0.tar.gz", hash = "sha256:70c49fae0476652a21b6ba0a90871ce7870a17866c36db7b2465be8b37dba81b", size = 98680, upload-time = "2025-07-10T02:25:10.751Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/b4/eee71d1e338bc1f9bd3539b46b70e303dac061324b759c9a80fa3c96d90d/diff_cover-10.2.0.tar.gz", hash = "sha256:61bf83025f10510c76ef6a5820680cf61b9b974e8f81de70c57ac926fa63872a", size = 102473, upload-time = "2026-01-09T01:59:07.605Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/83/7a6e97b56f4a46b6bebd7015e920eaf739f827095338da53b638215f2742/diff_cover-9.5.0-py3-none-any.whl", hash = "sha256:9f0eb2cf916bb3f7b7945b3a6067cc33f74abdbe685d479f996a6cf8df408af4", size = 54943, upload-time = "2025-07-10T02:25:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2c/61eeb887055a37150db824b6bf830e821a736580769ac2fea4eadb0d613f/diff_cover-10.2.0-py3-none-any.whl", hash = "sha256:59c328595e0b8948617cc5269af9e484c86462e2844bfcafa3fb37f8fca0af87", size = 56748, upload-time = "2026-01-09T01:59:06.028Z" },
 ]
 
 [[package]]
@@ -1108,7 +1108,7 @@ requires-dist = [
     { name = "bandit-sarif-formatter", marker = "extra == 'dev'", specifier = "==1.1.1" },
     { name = "bandit-sarif-formatter", marker = "extra == 'security'", specifier = "==1.1.1" },
     { name = "dbus-fast", specifier = "==3.1.2" },
-    { name = "diff-cover", marker = "extra == 'dev'", specifier = "==9.5.0" },
+    { name = "diff-cover", marker = "extra == 'dev'", specifier = "==10.2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "pillow", specifier = "==12.1.1" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = "==2.10.0" },
@@ -1122,7 +1122,7 @@ requires-dist = [
     { name = "qrcode", specifier = "==8.2" },
     { name = "respx", marker = "extra == 'dev'", specifier = "==0.22.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.13" },
-    { name = "wcwidth", specifier = "==0.2.13" },
+    { name = "wcwidth", specifier = "==0.7.0" },
 ]
 provides-extras = ["dev", "security"]
 
@@ -3012,11 +3012,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.2.13"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `wcwidth` `0.2.13 → 0.7.0` (pyproject + uv.lock + manifest).
- Supersedes #90 (which couldn't auto-sync `manifest.json` and was a major version bridge worth manual review).

## API compatibility review

`text_effects/width.py` only imports `wcwidth.wcwidth` and `wcwidth.wcswidth`. Both functions retain their `0.2.x` signature and return semantics across the 0.3 → 0.7 line. Behaviour changes worth noting (all in additive / edge-case territory):

| Version | Change | Impact on us |
|---------|--------|--------------|
| 0.2.14 | U+00AD SOFT HYPHEN measures as 1 (was 0) | Negligible — not used in receipt layouts |
| 0.3.0 | Default_Ignorable_Code_Point chars → width 0 | Negligible |
| 0.3.0 | Bugfix Prepended_Concatenation_Mark | Bugfix — strict improvement |
| 0.5.0 | `unicode_version='auto'` argument ignored | Not used |
| 0.5.0 | `list_versions()` returns single-element tuple | Not used |
| 0.5.2 | Standalone emoji support | Bugfix — strict improvement |
| 0.5.3 | Virama conjunct (Brahmic scripts) | Bugfix — strict improvement |
| 0.7.0 | New `clip()` params, kitty OSC 66 | New API; not used |

## HA 2026.3 compatibility

- `requires-python>=3.8` (well below our `>=3.14.2`).
- No new transitive deps.
- `wcwidth` is a pure-Python install — HA core doesn't pin it, so the new version flows through `manifest.json` (`wcwidth==0.7.0`) without conflicting with HA 2026.3, 2026.4, or 2026.5.

## Test plan
- [x] `uv run pytest -q` → 779 passed (including 91 in `tests/text_effects/`)
- [x] `uv run ruff check .` → clean
- [x] `uv run mypy custom_components/` → no issues
- [x] `scripts/check_requirements_sync.py` + `scripts/sync_manifest_requirements.py --check` → both ✅

Closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)