### PR TITLE
Fix image-URL fetch (#95) + opt-in Allow local image URLs (0.7.2)

### DIFF
--- a/.github/opengrep/escpos.yml
+++ b/.github/opengrep/escpos.yml
@@ -89,3 +89,37 @@ rules:
         - "custom_components/escpos_printer/notify.py"
         - "custom_components/escpos_printer/image_sources.py"
         - "custom_components/escpos_printer/services/print_handlers.py"
+
+  - id: is-allowed-address-must-keep-metadata-denylist
+    # The `allow_local` opt-in relaxes the SSRF address filter to permit
+    # private/RFC1918/ULA + loopback. The cloud-metadata endpoints must stay
+    # blocked even then. AWS IMDSv6 (`fd00:ec2::254`) is an IPv6 ULA that the
+    # `is_private` permissive grant would otherwise allow, so the explicit
+    # `_ALWAYS_BLOCKED_HOSTS` denylist is the load-bearing guard (review M-1,
+    # CWE-918). This rule fires if `_is_allowed_address` no longer references
+    # it — i.e. a refactor silently re-opened metadata SSRF.
+    patterns:
+      - pattern: |
+          def _is_allowed_address(...):
+            ...
+      # Excluded only when the body has an `if` whose condition actually
+      # tests against `_ALWAYS_BLOCKED_HOSTS` (deep-expression match). A
+      # lingering docstring/comment mention is NOT enough — the guard must
+      # be a live branch, so the rule fires if the check itself is removed.
+      - pattern-not: |
+          def _is_allowed_address(...):
+            ...
+            if <... _ALWAYS_BLOCKED_HOSTS ...>:
+              ...
+            ...
+    message: >
+      `_is_allowed_address` must keep the `_ALWAYS_BLOCKED_HOSTS` denylist
+      check so the `allow_local` opt-in cannot re-open SSRF to cloud-metadata
+      endpoints (IMDSv4 `169.254.169.254` + AWS IMDSv6 ULA `fd00:ec2::254`;
+      review M-1, CWE-918). Do not remove this guard without a documented
+      equivalent that blocks both metadata hosts in permissive mode.
+    severity: ERROR
+    languages: [python]
+    paths:
+      include:
+        - "custom_components/escpos_printer/security.py"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **"Allow local image URLs" printer option** (issue #95). Image URL
+  fetches (`print_image_url` and the other image services) still reject
+  private/LAN/loopback targets by default — an SSRF guard — but you can
+  now opt in per-printer (**Configure → "Allow local image URLs"**) to
+  print from a LAN camera, an NVR/Frigate proxy, a NAS, or your own
+  Home Assistant instance. The dangerous ranges stay blocked even when
+  enabled: link-local/cloud-metadata (`169.254.0.0/16`, `fe80::/10`),
+  multicast, reserved (`240.0.0.0/4`), and unspecified. The default-port
+  restriction (80/443 only) also still applies, and the fetch sends no
+  auth token — so only unauthenticated endpoints work. The strict-mode
+  rejection message now points at the new toggle. See
+  [docs/images.md](docs/images.md#allowing-local--lan-urls).
+
 ### Fixed
 
 - **HTTP/HTTPS image-URL printing failed for every URL** with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-06-11
+
 ### Added
 
 - **"Allow local image URLs" printer option** (issue #95). Image URL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **HTTP/HTTPS image-URL printing failed for every URL** with
+  `Cannot connect to host <host>:443 ssl:default [None]` (issue #95).
+  The DNS-pinning `_StaticResolver` only answered lookups for an
+  explicit `AF_INET` / `AF_INET6` family, but `aiohttp.TCPConnector`
+  resolves with `AF_UNSPEC` (0) by default — so every fetch matched no
+  address bucket and raised a `strerror`-less `OSError` that surfaced as
+  the misleading `[None]` connect error. `AF_UNSPEC` now returns all
+  pre-validated addresses, each tagged with its real family. The
+  DNS-rebinding defense is unchanged (still pinned to the one validated
+  hostname and its pre-resolved IPs). `print_image_url` and the other
+  URL-backed image services now work again. Added an `AF_UNSPEC`
+  regression test plus a guard locking in aiohttp's default family.
+
 ## [0.7.1] - 2026-05-26
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   (e.g. `:5000`), a NAS, or your own Home Assistant instance (`:8123`).
   Enabling it lifts both the private-address block and the default-port
   (80/443) restriction. The dangerous ranges stay blocked even when
-  enabled: link-local/cloud-metadata (`169.254.0.0/16`, `fe80::/10`),
-  multicast, reserved (`240.0.0.0/4`), and unspecified. The fetch sends
-  no auth token, so only unauthenticated endpoints work. The strict-mode
+  enabled: link-local/cloud-metadata (`169.254.0.0/16`, `fe80::/10`, and
+  the AWS IMDSv6 endpoint `fd00:ec2::254`), multicast, reserved
+  (`240.0.0.0/4`), and unspecified. The fetch sends no auth token, so
+  only unauthenticated endpoints work, and `print_image_url` has no
+  per-user authorization — enabling the option lets any HA user or
+  automation reach LAN hosts/ports through that printer. The strict-mode
   rejection messages now point at the new toggle. See
   [docs/images.md](docs/images.md#allowing-local--lan-urls).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - **"Allow local image URLs" printer option** (issue #95). Image URL
   fetches (`print_image_url` and the other image services) still reject
-  private/LAN/loopback targets by default — an SSRF guard — but you can
-  now opt in per-printer (**Configure → "Allow local image URLs"**) to
-  print from a LAN camera, an NVR/Frigate proxy, a NAS, or your own
-  Home Assistant instance. The dangerous ranges stay blocked even when
+  private/LAN/loopback targets and non-standard ports by default — an
+  SSRF guard — but you can now opt in per-printer (**Configure → "Allow
+  local image URLs"**) to print from a LAN camera, an NVR/Frigate proxy
+  (e.g. `:5000`), a NAS, or your own Home Assistant instance (`:8123`).
+  Enabling it lifts both the private-address block and the default-port
+  (80/443) restriction. The dangerous ranges stay blocked even when
   enabled: link-local/cloud-metadata (`169.254.0.0/16`, `fe80::/10`),
-  multicast, reserved (`240.0.0.0/4`), and unspecified. The default-port
-  restriction (80/443 only) also still applies, and the fetch sends no
-  auth token — so only unauthenticated endpoints work. The strict-mode
-  rejection message now points at the new toggle. See
+  multicast, reserved (`240.0.0.0/4`), and unspecified. The fetch sends
+  no auth token, so only unauthenticated endpoints work. The strict-mode
+  rejection messages now point at the new toggle. See
   [docs/images.md](docs/images.md#allowing-local--lan-urls).
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,15 @@ schema (Bronze quality-scale `action-setup` rule):
   reserved, multicast, and unspecified IPs** (defends against SSRF to
   RFC1918 networks, `127.0.0.1`, `::1`, and cloud-metadata endpoints like
   `169.254.169.254`). HTTP redirects are followed manually and each
-  redirect target is re-validated.
+  redirect target is re-validated. A per-printer **"Allow local image
+  URLs"** opt-in (default off) relaxes the private/loopback block and the
+  port allowlist for that printer; the always-dangerous ranges remain
+  blocked even when enabled — cloud-metadata (`169.254.169.254` and AWS
+  IMDSv6 `fd00:ec2::254`, the `_ALWAYS_BLOCKED_HOSTS` denylist),
+  link-local, multicast, reserved, and unspecified. Enabling it turns that
+  printer's `print_image_url` into an unauthenticated LAN-reach primitive
+  (the service has no per-user authorization), so enable it only where the
+  callers are trusted.
 - **Local image paths** — `Path.resolve(strict=True)` dereferences
   symlinks before the extension / size / allowlist checks; the final
   `open()` uses `O_NOFOLLOW` to defeat TOCTOU swaps. Paths outside

--- a/custom_components/escpos_printer/__init__.py
+++ b/custom_components/escpos_printer/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.helpers import config_validation as cv
 
 from .capabilities import PROFILE_AUTO, is_valid_profile
 from .const import (
+    CONF_ALLOW_LOCAL_IMAGE_URLS,
     CONF_BT_MAC,
     CONF_CODEPAGE,
     CONF_CONNECTION_TYPE,
@@ -33,6 +34,7 @@ from .const import (
     CONNECTION_TYPE_NETWORK,
     CONNECTION_TYPE_USB,
     DEFAULT_ALIGN,
+    DEFAULT_ALLOW_LOCAL_IMAGE_URLS,
     DEFAULT_CUT,
     DEFAULT_IN_EP,
     DEFAULT_LINE_WIDTH,
@@ -187,6 +189,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: EscposConfigEntry) -> bo
             codepage=entry.options.get(CONF_CODEPAGE) or entry.data.get(CONF_CODEPAGE),
             profile=entry.options.get(CONF_PROFILE) or entry.data.get(CONF_PROFILE),
             line_width=int(entry.options.get(CONF_LINE_WIDTH, entry.data.get(CONF_LINE_WIDTH, 48))),
+            allow_local_image_urls=bool(
+                entry.options.get(CONF_ALLOW_LOCAL_IMAGE_URLS, DEFAULT_ALLOW_LOCAL_IMAGE_URLS)
+            ),
         )
     elif connection_type == CONNECTION_TYPE_BLUETOOTH:
         config = BluetoothPrinterConfig(
@@ -196,6 +201,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: EscposConfigEntry) -> bo
             codepage=entry.options.get(CONF_CODEPAGE) or entry.data.get(CONF_CODEPAGE),
             profile=entry.options.get(CONF_PROFILE) or entry.data.get(CONF_PROFILE),
             line_width=int(entry.options.get(CONF_LINE_WIDTH, entry.data.get(CONF_LINE_WIDTH, 48))),
+            allow_local_image_urls=bool(
+                entry.options.get(CONF_ALLOW_LOCAL_IMAGE_URLS, DEFAULT_ALLOW_LOCAL_IMAGE_URLS)
+            ),
         )
     else:
         config = NetworkPrinterConfig(
@@ -205,6 +213,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: EscposConfigEntry) -> bo
             codepage=entry.options.get(CONF_CODEPAGE) or entry.data.get(CONF_CODEPAGE),
             profile=entry.options.get(CONF_PROFILE) or entry.data.get(CONF_PROFILE),
             line_width=int(entry.options.get(CONF_LINE_WIDTH, entry.data.get(CONF_LINE_WIDTH, 48))),
+            allow_local_image_urls=bool(
+                entry.options.get(CONF_ALLOW_LOCAL_IMAGE_URLS, DEFAULT_ALLOW_LOCAL_IMAGE_URLS)
+            ),
         )
 
     adapter = create_printer_adapter(config)

--- a/custom_components/escpos_printer/_config_flow/options_flow.py
+++ b/custom_components/escpos_printer/_config_flow/options_flow.py
@@ -21,6 +21,7 @@ from ..capabilities import (
     is_valid_profile,
 )
 from ..const import (
+    CONF_ALLOW_LOCAL_IMAGE_URLS,
     CONF_CODEPAGE,
     CONF_CONNECTION_TYPE,
     CONF_DEFAULT_ALIGN,
@@ -35,6 +36,7 @@ from ..const import (
     CONNECTION_TYPE_NETWORK,
     CONNECTION_TYPE_USB,
     DEFAULT_ALIGN,
+    DEFAULT_ALLOW_LOCAL_IMAGE_URLS,
     DEFAULT_CUT,
     DEFAULT_LINE_WIDTH,
     DEFAULT_TIMEOUT,
@@ -227,6 +229,12 @@ class EscposOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_STATUS_INTERVAL,
                         default=self.config_entry.options.get(CONF_STATUS_INTERVAL, 0),
                     ): int,
+                    vol.Optional(
+                        CONF_ALLOW_LOCAL_IMAGE_URLS,
+                        default=self.config_entry.options.get(
+                            CONF_ALLOW_LOCAL_IMAGE_URLS, DEFAULT_ALLOW_LOCAL_IMAGE_URLS
+                        ),
+                    ): bool,
                 }
             )
         else:
@@ -262,6 +270,12 @@ class EscposOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_STATUS_INTERVAL,
                         default=self.config_entry.options.get(CONF_STATUS_INTERVAL, 0),
                     ): int,
+                    vol.Optional(
+                        CONF_ALLOW_LOCAL_IMAGE_URLS,
+                        default=self.config_entry.options.get(
+                            CONF_ALLOW_LOCAL_IMAGE_URLS, DEFAULT_ALLOW_LOCAL_IMAGE_URLS
+                        ),
+                    ): bool,
                 }
             )
 

--- a/custom_components/escpos_printer/const.py
+++ b/custom_components/escpos_printer/const.py
@@ -15,6 +15,10 @@ CONF_KEEPALIVE = "keepalive"
 CONF_STATUS_INTERVAL = "status_interval"
 CONF_PROFILE = "profile"
 CONF_LINE_WIDTH = "line_width"
+# Opt-in: allow image URLs that resolve to private/LAN/loopback addresses.
+# Off by default so an upgrade never silently turns the integration into an
+# SSRF proxy; cloud-metadata / link-local ranges stay blocked even when on.
+CONF_ALLOW_LOCAL_IMAGE_URLS = "allow_local_image_urls"
 
 # Connection type configuration
 CONF_CONNECTION_TYPE = "connection_type"
@@ -46,6 +50,7 @@ DEFAULT_ALIGN = "left"
 DEFAULT_CUT = "none"
 DEFAULT_LINE_WIDTH = 48
 DEFAULT_CODEPAGE = "CP437"
+DEFAULT_ALLOW_LOCAL_IMAGE_URLS = False
 
 # USB defaults
 DEFAULT_IN_EP = 0x82

--- a/custom_components/escpos_printer/image_sources.py
+++ b/custom_components/escpos_printer/image_sources.py
@@ -317,26 +317,38 @@ class _StaticResolver(aiohttp.abc.AbstractResolver):
         self,
         host: str,
         port: int = 0,
-        family: int = socket.AF_INET,
+        family: int = socket.AF_UNSPEC,
     ) -> list[dict[str, Any]]:
         if host.lower() != self._hostname:
             raise OSError(
                 f"DNS pin: hostname '{host}' was not pre-validated (expected '{self._hostname}')"
             )
-        addrs = self._addrs_by_family.get(family, [])
-        if not addrs:
-            raise OSError(f"DNS pin: no pre-validated addresses for family {family}")
-        return [
+        # ``aiohttp.TCPConnector`` resolves with ``family=AF_UNSPEC`` (0) by
+        # default — it does not split the lookup per address family. The old
+        # ``get(family, [])`` filter only knew AF_INET / AF_INET6 buckets, so a
+        # default-family lookup matched neither and every URL fetch died with
+        # ``Cannot connect to host <host> ssl:default [None]`` (the single-arg
+        # OSError below carries no ``strerror``). Treat AF_UNSPEC as "any" and
+        # return each address tagged with its own real family so the connector
+        # opens the correct socket type.
+        families: tuple[int, ...] = (
+            (socket.AF_INET, socket.AF_INET6) if family == socket.AF_UNSPEC else (family,)
+        )
+        results = [
             {
                 "hostname": host,
                 "host": addr,
                 "port": port,
-                "family": family,
+                "family": fam,
                 "proto": 0,
                 "flags": 0,
             }
-            for addr in addrs
+            for fam in families
+            for addr in self._addrs_by_family.get(fam, [])
         ]
+        if not results:
+            raise OSError(f"DNS pin: no pre-validated addresses for family {family}")
+        return results
 
     async def close(self) -> None:
         return None

--- a/custom_components/escpos_printer/image_sources.py
+++ b/custom_components/escpos_printer/image_sources.py
@@ -448,7 +448,7 @@ async def _resolve_http(
     targets; see :func:`security.validate_image_url_and_resolve`.
     """
     # Cheap pre-flight: reject obvious junk before resolving DNS.
-    validate_image_url(url)
+    validate_image_url(url, allow_local=allow_local)
     _LOGGER.debug(
         "Downloading image from URL: %s",
         sanitize_log_message(url),

--- a/custom_components/escpos_printer/image_sources.py
+++ b/custom_components/escpos_printer/image_sources.py
@@ -145,6 +145,7 @@ async def resolve_image_bytes(
     *,
     context: Context | None = None,
     auto_resize: bool = False,
+    allow_local: bool = False,
 ) -> tuple[bytes, str | None]:
     """Resolve ``source`` to ``(raw_bytes, content_type_hint)``.
 
@@ -157,6 +158,11 @@ async def resolve_image_bytes(
     a 12 MB phone JPEG decoded from a camera/URL is acceptable. The
     image processor will then ``.thumbnail()`` the decoded image down
     before any expensive work happens.
+
+    ``allow_local`` (per-printer opt-in) lets an ``http(s)`` source resolve
+    to a private/LAN/loopback address. Only the HTTP path consults it;
+    camera/image/local/data sources are unaffected. The always-unsafe
+    ranges (link-local metadata, multicast, reserved) stay blocked.
     """
     if not isinstance(source, str) or not source.strip():
         raise HomeAssistantError("Image source must be a non-empty string")
@@ -173,7 +179,9 @@ async def resolve_image_bytes(
                 hass, value, context=context, auto_resize=auto_resize
             )
         case "http":
-            return await _resolve_http(hass, value, auto_resize=auto_resize)
+            return await _resolve_http(
+                hass, value, auto_resize=auto_resize, allow_local=allow_local
+            )
         case "local":
             return await _resolve_local(hass, value, auto_resize=auto_resize)
 
@@ -215,7 +223,7 @@ async def _resolve_camera(
     _LOGGER.debug("Fetching camera snapshot: %s", entity_id)
     try:
         image = await async_get_image(hass, entity_id, timeout=_ENTITY_FETCH_TIMEOUT_SECONDS)
-    except (HomeAssistantError, Unauthorized):
+    except HomeAssistantError, Unauthorized:
         raise
     except Exception as exc:
         raise HomeAssistantError(
@@ -245,7 +253,7 @@ async def _resolve_image_entity(
     _LOGGER.debug("Fetching image entity: %s", entity_id)
     try:
         image = await async_get_image(hass, entity_id, timeout=_ENTITY_FETCH_TIMEOUT_SECONDS)
-    except (HomeAssistantError, Unauthorized):
+    except HomeAssistantError, Unauthorized:
         raise
     except Exception as exc:
         raise HomeAssistantError(
@@ -274,7 +282,7 @@ def _check_content_length(headers: Mapping[str, str], max_bytes: int) -> None:
         return
     try:
         size = int(raw)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return
     if size > max_bytes:
         raise HomeAssistantError(
@@ -368,7 +376,7 @@ def _build_pinned_session(hostname: str, addresses: list[str]) -> aiohttp.Client
 
 
 async def _resolve_http_aiohttp(
-    hass: HomeAssistant, url: str, *, max_bytes: int
+    hass: HomeAssistant, url: str, *, max_bytes: int, allow_local: bool = False
 ) -> tuple[bytes, str | None]:
     """Fetch via a per-request aiohttp session pinned to validated IPs.
 
@@ -378,10 +386,15 @@ async def _resolve_http_aiohttp(
     :func:`validate_image_url_and_resolve` and gets a fresh resolver
     pin — a redirect to ``evil.example/``-resolves-to-127.0.0.1 is
     rejected at the validator, never reaches the connector.
+
+    ``allow_local`` is forwarded to every hop's validation so a relaxed
+    fetch stays relaxed across redirects (and a strict one stays strict).
     """
     current = url
     for _ in range(_MAX_REDIRECTS + 1):
-        validated, addrs = await validate_image_url_and_resolve(hass, current)
+        validated, addrs = await validate_image_url_and_resolve(
+            hass, current, allow_local=allow_local
+        )
         parsed = urlparse(validated)
         hostname = parsed.hostname
         if hostname is None:  # pragma: no cover — validator enforces it
@@ -399,19 +412,17 @@ async def _resolve_http_aiohttp(
                     allow_redirects=False,
                 ) as response,
             ):
-                    if response.status in (301, 302, 303, 307, 308):
-                        location = response.headers.get("Location")
-                        if not location:
-                            raise HomeAssistantError("HTTP redirect without Location header")
-                        current = urljoin(current, location)
-                        continue
-                    response.raise_for_status()
-                    _check_content_length(response.headers, max_bytes)
-                    buf = await _stream_to_buffer(
-                        response.content.iter_chunked(65536), max_bytes
-                    )
-                    content_type = response.headers.get("Content-Type")
-                    return bytes(buf), content_type
+                if response.status in (301, 302, 303, 307, 308):
+                    location = response.headers.get("Location")
+                    if not location:
+                        raise HomeAssistantError("HTTP redirect without Location header")
+                    current = urljoin(current, location)
+                    continue
+                response.raise_for_status()
+                _check_content_length(response.headers, max_bytes)
+                buf = await _stream_to_buffer(response.content.iter_chunked(65536), max_bytes)
+                content_type = response.headers.get("Content-Type")
+                return bytes(buf), content_type
         except HomeAssistantError:
             raise
         except aiohttp.ClientError as exc:
@@ -422,7 +433,7 @@ async def _resolve_http_aiohttp(
 
 
 async def _resolve_http(
-    hass: HomeAssistant, url: str, *, auto_resize: bool = False
+    hass: HomeAssistant, url: str, *, auto_resize: bool = False, allow_local: bool = False
 ) -> tuple[bytes, str | None]:
     """Fetch an HTTP/HTTPS image. Validates URL + IPs and streams the body.
 
@@ -432,6 +443,9 @@ async def _resolve_http(
     Always uses aiohttp (HA bundles it) — the old httpx fast-path was
     dropped because httpx 0.28 has no equivalent resolver hook, and
     the pooled-client win is small for image fetches.
+
+    ``allow_local`` (per-printer opt-in) permits private/LAN/loopback
+    targets; see :func:`security.validate_image_url_and_resolve`.
     """
     # Cheap pre-flight: reject obvious junk before resolving DNS.
     validate_image_url(url)
@@ -440,7 +454,7 @@ async def _resolve_http(
         sanitize_log_message(url),
     )
     max_bytes = _MAX_BYTES_AUTO_RESIZE if auto_resize else _MAX_BYTES
-    return await _resolve_http_aiohttp(hass, url, max_bytes=max_bytes)
+    return await _resolve_http_aiohttp(hass, url, max_bytes=max_bytes, allow_local=allow_local)
 
 
 async def _resolve_local(

--- a/custom_components/escpos_printer/manifest.json
+++ b/custom_components/escpos_printer/manifest.json
@@ -112,5 +112,5 @@
       "description": "*pos*"
     }
   ],
-  "version": "0.7.1"
+  "version": "0.7.2"
 }

--- a/custom_components/escpos_printer/printer/base_adapter.py
+++ b/custom_components/escpos_printer/printer/base_adapter.py
@@ -414,7 +414,7 @@ class EscposPrinterAdapterBase(
                     await _print_text_under_lock(self, hass, printer, **text_kwargs)
                     await _print_prepared_under_lock(hass, printer, prepared)
                     await self._apply_cut_and_feed(hass, printer, cut, feed)
-                except asyncio.CancelledError, Exception:
+                except asyncio.CancelledError, Exception:  # pragma: no cover (T-L4)
                     # S-M3: shield the cleanup so a second cancellation
                     # mid-flush doesn't leave paper half-printed. The
                     # suppress() catches Exception only — CancelledError

--- a/custom_components/escpos_printer/printer/base_adapter.py
+++ b/custom_components/escpos_printer/printer/base_adapter.py
@@ -104,6 +104,11 @@ class EscposPrinterAdapterBase(
         """Return the printer configuration."""
         return self._config
 
+    @property
+    def allow_local_image_urls(self) -> bool:
+        """Whether image URLs may resolve to private/LAN/loopback addresses."""
+        return self._config.allow_local_image_urls
+
     @abstractmethod
     def _connect(self) -> Any:
         """Create and return a printer connection."""
@@ -288,7 +293,7 @@ class EscposPrinterAdapterBase(
                 data = printer.profile.profile_data["media"]["width"]["pixels"]
                 if isinstance(data, (int, float)):
                     width = int(data)
-            except (AttributeError, KeyError, TypeError, ValueError):
+            except AttributeError, KeyError, TypeError, ValueError:
                 width = None
         self._cached_profile_width = width
         self._profile_width_lookup_done = True
@@ -409,7 +414,7 @@ class EscposPrinterAdapterBase(
                     await _print_text_under_lock(self, hass, printer, **text_kwargs)
                     await _print_prepared_under_lock(hass, printer, prepared)
                     await self._apply_cut_and_feed(hass, printer, cut, feed)
-                except (asyncio.CancelledError, Exception):
+                except asyncio.CancelledError, Exception:
                     # S-M3: shield the cleanup so a second cancellation
                     # mid-flush doesn't leave paper half-printed. The
                     # suppress() catches Exception only — CancelledError
@@ -425,9 +430,7 @@ class EscposPrinterAdapterBase(
                     with contextlib.suppress(Exception):
                         await asyncio.shield(
                             asyncio.ensure_future(
-                                self._apply_cut_and_feed(
-                                    hass, printer, cut or "full", feed or 1
-                                )
+                                self._apply_cut_and_feed(hass, printer, cut or "full", feed or 1)
                             )
                         )
                     raise

--- a/custom_components/escpos_printer/printer/config.py
+++ b/custom_components/escpos_printer/printer/config.py
@@ -33,6 +33,10 @@ class BasePrinterConfig:
     profile: str | None = None
     line_width: int = 48
     timeout: float = 4.0
+    # Opt-in: permit image URLs that resolve to private/LAN/loopback
+    # addresses. Off by default; the always-unsafe ranges (link-local
+    # metadata, multicast, reserved) stay blocked regardless.
+    allow_local_image_urls: bool = False
 
 
 @dataclass

--- a/custom_components/escpos_printer/printer/image_operations.py
+++ b/custom_components/escpos_printer/printer/image_operations.py
@@ -131,6 +131,7 @@ async def prepare_image_for_print(
         mirror=mirror,
         auto_resize=auto_resize,
     )
+    allow_local = bool(getattr(host, "allow_local_image_urls", False))
     try:
         raw, _content_type = await _resolve_with_retry(
             hass,
@@ -138,6 +139,7 @@ async def prepare_image_for_print(
             context=context,
             auto_resize=auto_resize,
             fallback=fallback_image,
+            allow_local=allow_local,
         )
         img_obj = await _process_bytes(hass, raw, process_opts)
         raw_len = len(raw)
@@ -179,6 +181,7 @@ async def _try_fallback(
     *,
     context: Context | None,
     auto_resize: bool,
+    allow_local: bool = False,
 ) -> tuple[bytes, str | None]:
     """Run ``fallback`` if set; raise the primary error on any failure.
 
@@ -190,7 +193,7 @@ async def _try_fallback(
         _LOGGER.debug("Primary image resolve failed (%s); trying fallback", type(primary).__name__)
         try:
             return await resolve_image_bytes(
-                hass, fallback, context=context, auto_resize=auto_resize
+                hass, fallback, context=context, auto_resize=auto_resize, allow_local=allow_local
             )
         except HomeAssistantError:
             raise primary from None
@@ -204,6 +207,7 @@ async def _resolve_with_retry(
     context: Context | None,
     auto_resize: bool,
     fallback: str | None,
+    allow_local: bool = False,
 ) -> tuple[bytes, str | None]:
     """Resolve ``image``; retry once on transient camera/http failure.
 
@@ -218,7 +222,9 @@ async def _resolve_with_retry(
     the fallback (if any).
     """
     try:
-        return await resolve_image_bytes(hass, image, context=context, auto_resize=auto_resize)
+        return await resolve_image_bytes(
+            hass, image, context=context, auto_resize=auto_resize, allow_local=allow_local
+        )
     except HomeAssistantError as primary:
         kind, _ = classify_source(image)
         retryable = kind in ("camera", "http") and not _is_timeout_cause(primary)
@@ -230,10 +236,15 @@ async def _resolve_with_retry(
             await asyncio.sleep(0.5)
             with contextlib.suppress(HomeAssistantError):
                 return await resolve_image_bytes(
-                    hass, image, context=context, auto_resize=auto_resize
+                    hass, image, context=context, auto_resize=auto_resize, allow_local=allow_local
                 )
         return await _try_fallback(
-            hass, fallback, primary, context=context, auto_resize=auto_resize
+            hass,
+            fallback,
+            primary,
+            context=context,
+            auto_resize=auto_resize,
+            allow_local=allow_local,
         )
 
 

--- a/custom_components/escpos_printer/security.py
+++ b/custom_components/escpos_printer/security.py
@@ -333,6 +333,22 @@ def _is_public_address(addr: str) -> bool:
     )
 
 
+# Cloud-metadata endpoints that must never be fetched, even in permissive
+# (``allow_local``) mode. The IPv4 service (and its IPv6 *link-local* form)
+# is already caught by the link-local check, but the AWS IMDSv6 endpoint
+# ``fd00:ec2::254`` is an IPv6 *Unique-Local* address (``fc00::/7``) — Python
+# flags it ``is_private`` but not ``is_link_local``, so without this explicit
+# denylist it would slip through the permissive ULA grant on a dual-stack EC2
+# host. Home IPv6 LANs legitimately use ULA, so we block the specific
+# endpoints rather than the whole ULA range.
+_ALWAYS_BLOCKED_HOSTS: frozenset[ipaddress.IPv4Address | ipaddress.IPv6Address] = frozenset(
+    {
+        ipaddress.ip_address("169.254.169.254"),  # IMDSv4 (also caught by link-local)
+        ipaddress.ip_address("fd00:ec2::254"),  # AWS IMDSv6 (ULA — not otherwise caught)
+    }
+)
+
+
 def _is_allowed_address(addr: str, *, allow_local: bool) -> bool:
     """Return True if ``addr`` may be fetched.
 
@@ -345,6 +361,9 @@ def _is_allowed_address(addr: str, *, allow_local: bool) -> bool:
 
     - link-local (``169.254.0.0/16`` / ``fe80::/10``) — this is the cloud
       metadata endpoint (``169.254.169.254``); SSRF here leaks IAM creds.
+    - the IPv6 cloud-metadata endpoints in :data:`_ALWAYS_BLOCKED_HOSTS`
+      (AWS IMDSv6 ``fd00:ec2::254`` is a ULA that the private grant would
+      otherwise permit).
     - multicast / unspecified (``0.0.0.0`` / ``::``).
     - reserved/future-use ranges (e.g. ``240.0.0.0/4``) that aren't a real
       LAN. Note ``::1`` is flagged *both* loopback and reserved by Python,
@@ -361,8 +380,14 @@ def _is_allowed_address(addr: str, *, allow_local: bool) -> bool:
         ip = ipaddress.ip_address(addr)
     except ValueError:
         return False
-    # Permissive (LAN) mode — still refuse the always-dangerous ranges.
-    if ip.is_link_local or ip.is_multicast or ip.is_unspecified:
+    # Permissive (LAN) mode — still refuse the always-dangerous ranges
+    # (specific cloud-metadata hosts + link-local/multicast/unspecified).
+    if (
+        ip in _ALWAYS_BLOCKED_HOSTS
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_unspecified
+    ):
         return False
     if ip.is_loopback:
         return True

--- a/custom_components/escpos_printer/security.py
+++ b/custom_components/escpos_printer/security.py
@@ -314,6 +314,42 @@ def _is_public_address(addr: str) -> bool:
     )
 
 
+def _is_allowed_address(addr: str, *, allow_local: bool) -> bool:
+    """Return True if ``addr`` may be fetched.
+
+    Globally routable addresses are always allowed. When ``allow_local`` is
+    set (opt-in per-printer option) private/RFC1918 (and IPv6 ULA) and
+    loopback addresses are *also* allowed so URLs pointing at LAN cameras,
+    NVRs, NAS shares, or the Home Assistant instance itself work.
+
+    The genuinely dangerous ranges stay blocked **even with ``allow_local``**:
+
+    - link-local (``169.254.0.0/16`` / ``fe80::/10``) — this is the cloud
+      metadata endpoint (``169.254.169.254``); SSRF here leaks IAM creds.
+    - multicast / unspecified (``0.0.0.0`` / ``::``).
+    - reserved/future-use ranges (e.g. ``240.0.0.0/4``) that aren't a real
+      LAN. Note ``::1`` is flagged *both* loopback and reserved by Python,
+      so loopback is granted before the reserved exclusion is applied.
+
+    With ``allow_local=False`` this is exactly :func:`_is_public_address`, so
+    the historical strict behavior is preserved by construction.
+    """
+    if _is_public_address(addr):
+        return True
+    if not allow_local:
+        return False
+    try:
+        ip = ipaddress.ip_address(addr)
+    except ValueError:
+        return False
+    # Permissive (LAN) mode — still refuse the always-dangerous ranges.
+    if ip.is_link_local or ip.is_multicast or ip.is_unspecified:
+        return False
+    if ip.is_loopback:
+        return True
+    return ip.is_private and not ip.is_reserved
+
+
 def _resolve_hostname_sync(hostname: str, port: int | None) -> list[str]:
     """Resolve ``hostname`` to a list of IP literals; raise on failure."""
     try:
@@ -326,12 +362,19 @@ def _resolve_hostname_sync(hostname: str, port: int | None) -> list[str]:
     return addrs
 
 
-async def validate_image_url_and_resolve(hass: HomeAssistant, url: str) -> tuple[str, list[str]]:
-    """Validate ``url`` and resolve its hostname, rejecting private targets.
+async def validate_image_url_and_resolve(
+    hass: HomeAssistant, url: str, *, allow_local: bool = False
+) -> tuple[str, list[str]]:
+    """Validate ``url`` and resolve its hostname, rejecting unsafe targets.
 
     Returns ``(validated_url, resolved_addresses)``. The caller should pin
     one of the resolved addresses for the actual fetch (defeats DNS
     rebinding); see ``image_sources._resolve_http``.
+
+    By default only globally routable addresses are accepted. ``allow_local``
+    (the per-printer opt-in) additionally accepts private/LAN/loopback
+    targets while still rejecting link-local/metadata, multicast, reserved,
+    and unspecified addresses — see :func:`_is_allowed_address`.
     """
     validated = validate_image_url(url)
     parsed = urlparse(validated)
@@ -339,11 +382,20 @@ async def validate_image_url_and_resolve(hass: HomeAssistant, url: str) -> tuple
     if hostname is None:  # pragma: no cover — validate_image_url enforces it
         raise HomeAssistantError("URL must include a valid hostname")
     addrs = await hass.async_add_executor_job(_resolve_hostname_sync, hostname, parsed.port)
-    bad = [a for a in addrs if not _is_public_address(a)]
+    bad = [a for a in addrs if not _is_allowed_address(a, allow_local=allow_local)]
     if bad:
+        if allow_local:
+            # Already in the permissive mode and still blocked → it's one of
+            # the always-unsafe ranges, so don't dangle a non-existent knob.
+            raise HomeAssistantError(
+                "Image URL resolves to a blocked address (link-local/metadata, "
+                "multicast, reserved, or unspecified)"
+            )
         raise HomeAssistantError(
             "Image URL resolves to a non-public address "
-            "(private, loopback, link-local, reserved, or multicast)"
+            "(private, loopback, link-local, reserved, or multicast). "
+            "Enable 'Allow local image URLs' in the printer options to permit "
+            "private/LAN addresses."
         )
     return validated, addrs
 
@@ -493,8 +545,7 @@ def validate_font_path_with_fonts_dir(raw_path: str, hass: HomeAssistant) -> Pat
             f"(and not under <config>/fonts/)"
         ) from exc
     raise HomeAssistantError(
-        f"Font path '{resolved}' is outside allowlist_external_dirs "
-        f"(and not under <config>/fonts/)"
+        f"Font path '{resolved}' is outside allowlist_external_dirs (and not under <config>/fonts/)"
     )
 
 
@@ -869,7 +920,6 @@ def validate_rfcomm_channel(channel: int) -> int:
     if not 1 <= value <= 30:
         raise HomeAssistantError("RFCOMM channel must be between 1 and 30")
     return value
-
 
     # B-L1: ``secure_service_call`` was a never-implemented pass-through
     # decorator from an earlier iteration. The cross-cutting validation

--- a/custom_components/escpos_printer/security.py
+++ b/custom_components/escpos_printer/security.py
@@ -238,7 +238,7 @@ def validate_barcode_data(code: str, bc_type: str) -> tuple[str, str]:
 # ---------------------------------------------------------------------------
 
 
-def validate_image_url(url: str) -> str:
+def validate_image_url(url: str, *, allow_local: bool = False) -> str:
     """Cheap synchronous URL validation.
 
     Rejects URLs that are structurally bad (wrong scheme, no hostname, too
@@ -246,6 +246,12 @@ def validate_image_url(url: str) -> str:
     punycode). Does **not** resolve DNS — use
     :func:`validate_image_url_and_resolve` from the event loop to also
     check the resolved address is public.
+
+    ``allow_local`` is the per-printer opt-in. When set, the default-port
+    allowlist is lifted so local image servers on non-standard ports
+    (Frigate ``:5000``, cameras ``:8080``/``:81``, Home Assistant
+    ``:8123``) are reachable — the SSRF boundary is then carried entirely
+    by the resolved-address check in :func:`validate_image_url_and_resolve`.
     """
     if not isinstance(url, str):
         raise HomeAssistantError("Image URL must be a string")
@@ -288,11 +294,24 @@ def validate_image_url(url: str) -> str:
             "use the ASCII hostname or a numeric IP to avoid homograph confusion."
         )
 
-    # Restrict to default ports for the scheme. Catches both 22 (SSH) and
-    # 8123 (HA itself).
-    if parsed.port not in VALID_URL_PORTS:
+    # Accessing ``.port`` parses+range-checks it lazily (raises ValueError
+    # for out-of-range like ``:99999``); guard it in both modes.
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise HomeAssistantError(f"Invalid URL port: {exc}") from exc
+
+    # Restrict to default ports for the scheme unless the local opt-in is
+    # set. In the strict (public-only) default this catches 22 (SSH) and
+    # 8123 (HA itself) and keeps the integration from being a port-scan
+    # oracle. Once the user has opted into trusting local image servers,
+    # non-standard ports are exactly what they need, so the allowlist is
+    # lifted — the resolved-address SSRF check still applies.
+    if not allow_local and port not in VALID_URL_PORTS:
         raise HomeAssistantError(
-            f"URL port {parsed.port} not allowed; only {sorted(p for p in VALID_URL_PORTS if p)} are permitted"
+            f"URL port {port} not allowed; only {sorted(p for p in VALID_URL_PORTS if p)} "
+            "are permitted (enable 'Allow local image URLs' in the printer options to "
+            "use non-standard ports)"
         )
 
     return url
@@ -376,7 +395,7 @@ async def validate_image_url_and_resolve(
     targets while still rejecting link-local/metadata, multicast, reserved,
     and unspecified addresses — see :func:`_is_allowed_address`.
     """
-    validated = validate_image_url(url)
+    validated = validate_image_url(url, allow_local=allow_local)
     parsed = urlparse(validated)
     hostname = parsed.hostname
     if hostname is None:  # pragma: no cover — validate_image_url enforces it

--- a/custom_components/escpos_printer/strings.json
+++ b/custom_components/escpos_printer/strings.json
@@ -231,7 +231,8 @@
           "default_cut": "Default cut mode",
           "reliability_profile": "Image reliability profile",
           "keepalive": "Keep persistent connection",
-          "status_interval": "Status check interval (seconds)"
+          "status_interval": "Status check interval (seconds)",
+          "allow_local_image_urls": "Allow local image URLs"
         },
         "data_description": {
           "timeout": "Connection timeout in seconds.",
@@ -242,7 +243,8 @@
           "default_cut": "Default paper cut mode after printing.",
           "reliability_profile": "Picks safe defaults for image chunk size, inter-chunk delay, and ESC/POS image command. Service-call options always override these.",
           "keepalive": "Keep the connection open between print jobs (network printers only).",
-          "status_interval": "How often to check printer status (0 to disable)."
+          "status_interval": "How often to check printer status (0 to disable).",
+          "allow_local_image_urls": "Permit print_image_url (and the other image services) to fetch URLs that resolve to private/LAN/loopback addresses, e.g. a local camera or your Home Assistant instance. Off by default. Cloud-metadata/link-local addresses stay blocked even when enabled."
         }
       },
       "custom_profile": {

--- a/custom_components/escpos_printer/strings.json
+++ b/custom_components/escpos_printer/strings.json
@@ -244,7 +244,7 @@
           "reliability_profile": "Picks safe defaults for image chunk size, inter-chunk delay, and ESC/POS image command. Service-call options always override these.",
           "keepalive": "Keep the connection open between print jobs (network printers only).",
           "status_interval": "How often to check printer status (0 to disable).",
-          "allow_local_image_urls": "Permit print_image_url (and the other image services) to fetch URLs that resolve to private/LAN/loopback addresses, e.g. a local camera or your Home Assistant instance. Off by default. Cloud-metadata/link-local addresses stay blocked even when enabled."
+          "allow_local_image_urls": "Permit print_image_url (and the other image services) to fetch URLs that resolve to private/LAN/loopback addresses and to use non-standard ports (e.g. a local camera, a Frigate proxy on :5000, or your Home Assistant instance on :8123). Off by default. Cloud-metadata/link-local addresses stay blocked even when enabled."
         }
       },
       "custom_profile": {

--- a/custom_components/escpos_printer/translations/en.json
+++ b/custom_components/escpos_printer/translations/en.json
@@ -230,7 +230,8 @@
           "default_align": "Default alignment",
           "default_cut": "Default cut mode",
           "keepalive": "Keep persistent connection",
-          "status_interval": "Status check interval (seconds)"
+          "status_interval": "Status check interval (seconds)",
+          "allow_local_image_urls": "Allow local image URLs"
         },
         "data_description": {
           "timeout": "Connection timeout in seconds.",
@@ -240,7 +241,8 @@
           "default_align": "Default text alignment for printing.",
           "default_cut": "Default paper cut mode after printing.",
           "keepalive": "Keep the connection open between print jobs (network printers only).",
-          "status_interval": "How often to check printer status (0 to disable)."
+          "status_interval": "How often to check printer status (0 to disable).",
+          "allow_local_image_urls": "Permit print_image_url (and the other image services) to fetch URLs that resolve to private/LAN/loopback addresses, e.g. a local camera or your Home Assistant instance. Off by default. Cloud-metadata/link-local addresses stay blocked even when enabled."
         }
       },
       "custom_profile": {

--- a/custom_components/escpos_printer/translations/en.json
+++ b/custom_components/escpos_printer/translations/en.json
@@ -242,7 +242,7 @@
           "default_cut": "Default paper cut mode after printing.",
           "keepalive": "Keep the connection open between print jobs (network printers only).",
           "status_interval": "How often to check printer status (0 to disable).",
-          "allow_local_image_urls": "Permit print_image_url (and the other image services) to fetch URLs that resolve to private/LAN/loopback addresses, e.g. a local camera or your Home Assistant instance. Off by default. Cloud-metadata/link-local addresses stay blocked even when enabled."
+          "allow_local_image_urls": "Permit print_image_url (and the other image services) to fetch URLs that resolve to private/LAN/loopback addresses and to use non-standard ports (e.g. a local camera, a Frigate proxy on :5000, or your Home Assistant instance on :8123). Off by default. Cloud-metadata/link-local addresses stay blocked even when enabled."
         }
       },
       "custom_profile": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,3 +60,11 @@ How often to probe the printer (seconds). Set to 0 to disable. Drives the binary
 
 - **Network**: any value works; default 30s is fine.
 - **Bluetooth**: set to 60s or longer (or 0). RFCOMM accepts only one client at a time, and many cheap BT printers beep on every connect. The integration auto-skips probes during prints, so aggressive polling has no benefit.
+
+## Allow Local Image URLs
+
+Off by default. When enabled, `print_image_url` (and the other image services) may fetch URLs that resolve to private/LAN/loopback addresses **and** use non-standard ports — e.g. a LAN camera, a Frigate proxy on `:5000`, or your Home Assistant instance on `:8123`. By default only public addresses and ports 80/443 are allowed.
+
+Cloud-metadata (`169.254.169.254` and AWS IMDSv6 `fd00:ec2::254`), link-local, multicast, reserved, and unspecified addresses stay blocked even when this is on. The fetch carries no auth token, so only unauthenticated endpoints work.
+
+The option is **per-printer** and is evaluated against the printer you print to. Because `print_image_url` has no per-user authorization, enabling it lets any HA user/automation reach LAN hosts/ports through that printer (an SSRF / port-scan oracle) — only enable it where callers are trusted, and prefer camera/image entity sources where possible. See the [Images guide](images.md#allowing-local--lan-urls).

--- a/docs/images.md
+++ b/docs/images.md
@@ -49,9 +49,11 @@ data:
 
 URL validation enforces:
 
-- Scheme `http` or `https` only; default ports (80/443) only; no
-  embedded credentials (`https://user:pass@host/` is rejected); no
-  IDN/punycode hostnames.
+- Scheme `http` or `https` only; no embedded credentials
+  (`https://user:pass@host/` is rejected); no IDN/punycode hostnames.
+- By default only the standard ports (80/443) are allowed. The "Allow
+  local image URLs" option below lifts this so non-standard ports
+  (Frigate `:5000`, cameras `:8080`/`:81`, HA `:8123`) work.
 - Hostname is resolved via `getaddrinfo`; by default the request is
   **refused if any resolved address is private, loopback, link-local,
   reserved, multicast, or unspecified**. That includes `127.0.0.1`,
@@ -60,24 +62,27 @@ URL validation enforces:
 - Redirects are followed manually (max 5); every redirect target is
   re-validated against the rules above.
 
-> **Note (default port).** The port restriction means a URL like
-> `http://192.168.1.10:8123/...` is rejected even with the option below
-> — only ports 80/443 are allowed. Fetching authenticated Home Assistant
-> `/api/...` endpoints also won't work because the fetch sends no auth
-> token; only **unauthenticated** endpoints (e.g. Frigate notification
-> thumbnails) succeed.
-
 #### Allowing local / LAN URLs
 
-The private-address block is on by default so the integration can't be
-used as an SSRF proxy. If you need to print from a **local** image URL —
-a LAN camera, an NVR/Frigate proxy, a NAS, or your own Home Assistant
-instance — enable **Settings → Devices & Services → ESC/POS printer →
-Configure → "Allow local image URLs"**. With it on, private/RFC1918 and
-loopback addresses are accepted. The genuinely dangerous ranges stay
-blocked **even when enabled**: link-local/cloud-metadata
-(`169.254.0.0/16`, `fe80::/10`), multicast, reserved (`240.0.0.0/4`),
-and unspecified. The toggle is per-printer.
+The private-address block and the default-port allowlist are on by
+default so the integration can't be used as an SSRF proxy. If you need to
+print from a **local** image URL — a LAN camera, an NVR/Frigate proxy, a
+NAS, or your own Home Assistant instance — enable **Settings → Devices &
+Services → ESC/POS printer → Configure → "Allow local image URLs"**. With
+it on:
+
+- private/RFC1918 (and IPv6 ULA) and loopback addresses are accepted, and
+- **non-standard ports** are accepted (e.g. Frigate on `:5000`, a camera
+  on `:8080`, Home Assistant on `:8123`).
+
+The genuinely dangerous ranges stay blocked **even when enabled**:
+link-local/cloud-metadata (`169.254.0.0/16`, `fe80::/10`), multicast,
+reserved (`240.0.0.0/4`), and unspecified. The toggle is per-printer.
+
+> **Note (auth).** The fetch sends no authentication token, so an
+> authenticated Home Assistant `/api/...` endpoint returns 401 — only
+> **unauthenticated** endpoints (e.g. Frigate notification thumbnails)
+> succeed.
 
 If the source is a Home-Assistant-managed camera or image, prefer the
 [camera entity](#camera-entity) / [image entity](#image-entity) sources

--- a/docs/images.md
+++ b/docs/images.md
@@ -76,13 +76,27 @@ it on:
   on `:8080`, Home Assistant on `:8123`).
 
 The genuinely dangerous ranges stay blocked **even when enabled**:
-link-local/cloud-metadata (`169.254.0.0/16`, `fe80::/10`), multicast,
-reserved (`240.0.0.0/4`), and unspecified. The toggle is per-printer.
+link-local/cloud-metadata (`169.254.0.0/16`, `fe80::/10`, and the AWS
+IMDSv6 endpoint `fd00:ec2::254`), multicast, reserved (`240.0.0.0/4`),
+and unspecified.
+
+The toggle is **per-printer**, and it's evaluated against the **printer
+you print to**, not the URL. In a multi-printer setup the same LAN URL
+succeeds when sent to a printer that has the option enabled and is
+rejected when sent to one that doesn't.
 
 > **Note (auth).** The fetch sends no authentication token, so an
 > authenticated Home Assistant `/api/...` endpoint returns 401 — only
 > **unauthenticated** endpoints (e.g. Frigate notification thumbnails)
 > succeed.
+>
+> **Note (who can reach your LAN).** `print_image_url` has no per-user
+> authorization. With this option on, *any* Home Assistant user or
+> automation that can call the service can make this printer fetch
+> arbitrary LAN hosts and ports — and the success/failure/timing of a
+> fetch can reveal which internal hosts and ports are open (an SSRF /
+> port-scan oracle). Only enable it on printers whose service calls you
+> trust.
 
 If the source is a Home-Assistant-managed camera or image, prefer the
 [camera entity](#camera-entity) / [image entity](#image-entity) sources

--- a/docs/images.md
+++ b/docs/images.md
@@ -52,13 +52,37 @@ URL validation enforces:
 - Scheme `http` or `https` only; default ports (80/443) only; no
   embedded credentials (`https://user:pass@host/` is rejected); no
   IDN/punycode hostnames.
-- Hostname is resolved via `getaddrinfo`; the request is **refused if
-  any resolved address is private, loopback, link-local, reserved,
-  multicast, or unspecified**. That includes `127.0.0.1`, `::1`,
-  RFC1918 ranges (`10.x`, `192.168.x`, `172.16.x`), and
+- Hostname is resolved via `getaddrinfo`; by default the request is
+  **refused if any resolved address is private, loopback, link-local,
+  reserved, multicast, or unspecified**. That includes `127.0.0.1`,
+  `::1`, RFC1918 ranges (`10.x`, `192.168.x`, `172.16.x`), and
   `169.254.169.254` (cloud metadata).
 - Redirects are followed manually (max 5); every redirect target is
   re-validated against the rules above.
+
+> **Note (default port).** The port restriction means a URL like
+> `http://192.168.1.10:8123/...` is rejected even with the option below
+> — only ports 80/443 are allowed. Fetching authenticated Home Assistant
+> `/api/...` endpoints also won't work because the fetch sends no auth
+> token; only **unauthenticated** endpoints (e.g. Frigate notification
+> thumbnails) succeed.
+
+#### Allowing local / LAN URLs
+
+The private-address block is on by default so the integration can't be
+used as an SSRF proxy. If you need to print from a **local** image URL —
+a LAN camera, an NVR/Frigate proxy, a NAS, or your own Home Assistant
+instance — enable **Settings → Devices & Services → ESC/POS printer →
+Configure → "Allow local image URLs"**. With it on, private/RFC1918 and
+loopback addresses are accepted. The genuinely dangerous ranges stay
+blocked **even when enabled**: link-local/cloud-metadata
+(`169.254.0.0/16`, `fe80::/10`), multicast, reserved (`240.0.0.0/4`),
+and unspecified. The toggle is per-printer.
+
+If the source is a Home-Assistant-managed camera or image, prefer the
+[camera entity](#camera-entity) / [image entity](#image-entity) sources
+instead — they enforce per-user entity permissions and don't need this
+option.
 
 Max download size is 10 MB; the body is streamed and the read aborts
 mid-stream when the cap is hit. `Content-Length` is checked before
@@ -434,4 +458,5 @@ data:
 | Photo prints almost all black or all white             | Turn on `autocontrast: true`. If still extreme, try `dither: threshold` with a value near the image's average brightness.                                |
 | Image is sideways (phone photos)                       | EXIF orientation should auto-correct. If your image lacks EXIF, use `rotation: 90` / `180` / `270`.                                                      |
 | `Failed to download image: ...`                        | URL is wrong, requires auth, or your HA host can't reach it. Test the URL with `curl` from the host first.                                               |
+| `Image URL resolves to a non-public address`           | The URL points at a private/LAN/loopback address. Enable ["Allow local image URLs"](#allowing-local--lan-urls) in the printer options, or use a camera/image entity source. |
 | Image command works in `print_image` but not `notify`  | Notify uses `image_*`-prefixed parameter names (e.g. `image_dither`, not `dither`). See [Notify entity integration](#notify-entity-integration).         |

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -16,10 +16,18 @@ The image pipeline applies meaningful but bounded defenses; deployers
 should understand what is and isn't enforced. Cross-linked from
 [SECURITY.md](../SECURITY.md).
 
-- **HTTP image fetches block private and loopback addresses.** URLs
-  resolving to RFC1918 networks, `127.0.0.1`, `::1`, `169.254.169.254`
-  (cloud metadata), or other non-public ranges are rejected. Redirects
-  are followed manually and re-validated. There is a residual
+- **HTTP image fetches block private and loopback addresses by
+  default.** URLs resolving to RFC1918 networks, `127.0.0.1`, `::1`,
+  `169.254.169.254` (cloud metadata), or other non-public ranges are
+  rejected, and only ports 80/443 are allowed. Redirects are followed
+  manually and re-validated. A per-printer **"Allow local image URLs"**
+  option (off by default) relaxes the private/loopback block and the
+  port allowlist for that printer; cloud-metadata (incl. AWS IMDSv6
+  `fd00:ec2::254`), link-local, multicast, reserved, and unspecified
+  addresses stay blocked regardless. Enabling it makes that printer's
+  `print_image_url` an **unauthenticated LAN-reach primitive** (see the
+  Trust boundary note). See
+  [images.md](images.md#allowing-local--lan-urls). There is a residual
   TOCTOU window between our DNS resolution and the actual fetch; DNS
   rebinding remains a partially-mitigated threat.
 - **Embedded URL credentials are rejected.** `https://user:pass@host/`
@@ -35,7 +43,10 @@ should understand what is and isn't enforced. Cross-linked from
   Bluetooth MACs are redacted from logs.
 - **Trust boundary.** Any HA user who can call `escpos_printer.print_image`
   or `notify.<printer>` can print to your physical paper roll.
-  Restrict service exposure for shared installations.
+  Restrict service exposure for shared installations. If a printer has
+  **"Allow local image URLs"** enabled, those same callers can also make
+  it fetch arbitrary LAN hosts/ports — a port-scan / SSRF oracle — so
+  enable it only on printers whose callers you trust.
 
 ## Network printers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-escpos-thermal-printer"
-version = "0.7.1"
+version = "0.7.2"
 description = "Network thermal printer integration for Home Assistant using ESC/POS protocol"
 readme = "README.md"
 requires-python = ">=3.14.2"

--- a/tests/test_adapter_lifecycle.py
+++ b/tests/test_adapter_lifecycle.py
@@ -167,6 +167,28 @@ async def test_wrap_text_zero_width_no_wrap(hass):  # type: ignore[no-untyped-de
     assert adapter._wrap_text(text) == text  # type: ignore[attr-defined]
 
 
+async def test_get_profile_pixel_width_handles_broken_profile_data(hass):  # type: ignore[no-untyped-def]
+    """A printer whose profile_data is missing the media/width keys must not raise.
+
+    Exercises the AttributeError/KeyError/TypeError/ValueError guard in
+    get_profile_pixel_width: a connected printer with a malformed profile
+    falls back to None rather than crashing the image pipeline.
+    """
+    entry = await _setup_entry(hass)
+    adapter = entry.runtime_data.adapter
+
+    class _BrokenProfile:
+        # Real dict so ["media"] raises KeyError (not a Mock that auto-vivifies).
+        profile_data: dict = {}
+
+    class _Printer:
+        profile = _BrokenProfile()
+
+    adapter._printer = _Printer()  # type: ignore[attr-defined]
+    # No hass passed → skips the repair-issue path; just exercises the guard.
+    assert adapter.get_profile_pixel_width() is None
+
+
 async def test_get_connection_info(hass):  # type: ignore[no-untyped-def]
     """Network adapter exposes a human-readable connection string."""
     entry = await _setup_entry(hass)

--- a/tests/test_config_flow_options_and_duplicate.py
+++ b/tests/test_config_flow_options_and_duplicate.py
@@ -6,6 +6,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.escpos_printer.const import (
+    CONF_ALLOW_LOCAL_IMAGE_URLS,
     CONF_CODEPAGE,
     CONF_CONNECTION_TYPE,
     CONF_DEFAULT_ALIGN,
@@ -52,6 +53,40 @@ async def test_options_flow_update(hass):  # type: ignore[no-untyped-def]
     assert result2["type"] == "create_entry"
     assert result2["data"][CONF_TIMEOUT] == 5.5
     assert result2["data"][CONF_DEFAULT_ALIGN] == "center"
+
+
+async def test_options_flow_allow_local_image_urls_roundtrips(hass):  # type: ignore[no-untyped-def]
+    """The allow-local-image-URLs toggle defaults off and persists when set."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="1.2.3.4:9100",
+        data={
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 9100,
+            CONF_TIMEOUT: 4.0,
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK,
+        },
+        unique_id="1.2.3.4:9100",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == "form"
+    # Default must be off (secure-by-default).
+    schema_defaults = {
+        str(key.schema): key.default() for key in result["data_schema"].schema if key.default
+    }
+    assert schema_defaults.get(CONF_ALLOW_LOCAL_IMAGE_URLS) is False
+
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_TIMEOUT: 4.0,
+            CONF_ALLOW_LOCAL_IMAGE_URLS: True,
+        },
+    )
+    assert result2["type"] == "create_entry"
+    assert result2["data"][CONF_ALLOW_LOCAL_IMAGE_URLS] is True
 
 
 async def test_duplicate_unique_id_aborts(hass):  # type: ignore[no-untyped-def]

--- a/tests/test_image_sources.py
+++ b/tests/test_image_sources.py
@@ -201,6 +201,59 @@ async def test_resolve_http_rejects_private_resolved_address(  # type: ignore[no
         await resolve_image_bytes(hass, "https://example.com/x.png")
 
 
+async def test_resolve_http_strict_error_hints_at_option(  # type: ignore[no-untyped-def]
+    hass, monkeypatch
+):
+    """The strict-mode rejection must point the user at the opt-in toggle."""
+
+    def fake_getaddrinfo(_host, _port, **_kw):  # type: ignore[no-untyped-def]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("192.168.1.50", 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", fake_getaddrinfo)
+    with pytest.raises(HomeAssistantError, match="Allow local image URLs"):
+        await resolve_image_bytes(hass, "https://example.com/x.png")
+
+
+async def test_resolve_http_allows_private_with_allow_local(  # type: ignore[no-untyped-def]
+    hass, monkeypatch, mock_pooled_aiohttp
+):
+    """``allow_local=True`` lets a private/LAN address resolve and fetch."""
+
+    def fake_getaddrinfo(_host, _port, **_kw):  # type: ignore[no-untyped-def]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("192.168.1.50", 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", fake_getaddrinfo)
+
+    def _factory():  # type: ignore[no-untyped-def]
+        from tests.conftest import fake_aiohttp_response
+
+        return fake_aiohttp_response(
+            status=200, headers={"Content-Type": "image/png"}, chunks=[_png_bytes()]
+        )
+
+    mock_pooled_aiohttp(_factory)
+    raw, content_type = await resolve_image_bytes(
+        hass, "https://camera.local/snapshot.png", allow_local=True
+    )
+    assert raw == _png_bytes()
+    assert content_type == "image/png"
+
+
+async def test_resolve_http_allow_local_still_blocks_metadata(  # type: ignore[no-untyped-def]
+    hass, monkeypatch
+):
+    """Even with ``allow_local=True`` the cloud-metadata endpoint stays blocked."""
+
+    def fake_getaddrinfo(_host, _port, **_kw):  # type: ignore[no-untyped-def]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("169.254.169.254", 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", fake_getaddrinfo)
+    with pytest.raises(HomeAssistantError, match="blocked address"):
+        await resolve_image_bytes(
+            hass, "https://metadata.example/latest/meta-data/", allow_local=True
+        )
+
+
 async def test_resolve_http_rejects_non_default_port(hass):  # type: ignore[no-untyped-def]
     with pytest.raises(HomeAssistantError, match="port"):
         await resolve_image_bytes(hass, "https://example.com:22/x.png")

--- a/tests/test_image_sources.py
+++ b/tests/test_image_sources.py
@@ -421,6 +421,173 @@ async def test_resolve_http_http_error_propagates_as_ha_error(  # type: ignore[n
         await resolve_image_bytes(hass, "https://example.com/x.png")
 
 
+async def test_resolve_camera_reraises_home_assistant_error(  # type: ignore[no-untyped-def]
+    hass, monkeypatch
+):
+    """A HomeAssistantError from async_get_image must propagate unchanged (not be wrapped)."""
+
+    async def _raise(*_a, **_k):  # type: ignore[no-untyped-def]
+        raise HomeAssistantError("camera offline")
+
+    _install_fake_camera_module(monkeypatch, _raise)
+    with pytest.raises(HomeAssistantError, match="camera offline"):
+        await resolve_image_bytes(hass, "camera.front_door")
+
+
+async def test_resolve_image_entity_reraises_home_assistant_error(  # type: ignore[no-untyped-def]
+    hass, monkeypatch
+):
+    """A HomeAssistantError from the image entity must propagate unchanged."""
+
+    async def _raise(*_a, **_k):  # type: ignore[no-untyped-def]
+        raise HomeAssistantError("image entity unavailable")
+
+    _install_fake_image_module(monkeypatch, _raise)
+    with pytest.raises(HomeAssistantError, match="image entity unavailable"):
+        await resolve_image_bytes(hass, "image.weather_map")
+
+
+def test_check_content_length_ignores_malformed_header():  # type: ignore[no-untyped-def]
+    """A non-numeric Content-Length must be ignored (the streaming read still caps size)."""
+    from custom_components.escpos_printer.image_sources import _check_content_length
+
+    # int("not-a-number") raises ValueError → swallowed → no raise.
+    _check_content_length({"Content-Length": "not-a-number"}, 1000)
+    # Missing header → early return, also no raise.
+    _check_content_length({}, 1000)
+
+
+def _redirect_factory(*responses):  # type: ignore[no-untyped-def]
+    """Return a factory that yields each prepared response in turn (one per .get())."""
+    it = iter(responses)
+
+    def _factory():  # type: ignore[no-untyped-def]
+        return next(it)
+
+    return _factory
+
+
+async def test_resolve_http_follows_redirect(  # type: ignore[no-untyped-def]
+    hass, monkeypatch, mock_pooled_aiohttp
+):
+    """A 302 with a Location must be followed to the final 200 response."""
+
+    def fake_getaddrinfo(_host, _port, **_kw):  # type: ignore[no-untyped-def]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", fake_getaddrinfo)
+
+    from tests.conftest import fake_aiohttp_response
+
+    mock_pooled_aiohttp(
+        _redirect_factory(
+            fake_aiohttp_response(status=302, headers={"Location": "https://example.com/final.png"}),
+            fake_aiohttp_response(
+                status=200, headers={"Content-Type": "image/png"}, chunks=[_png_bytes()]
+            ),
+        )
+    )
+    raw, content_type = await resolve_image_bytes(hass, "https://example.com/start.png")
+    assert raw == _png_bytes()
+    assert content_type == "image/png"
+
+
+async def test_resolve_http_redirect_without_location_raises(  # type: ignore[no-untyped-def]
+    hass, monkeypatch, mock_pooled_aiohttp
+):
+    """A redirect status with no Location header must raise, not loop forever."""
+
+    def fake_getaddrinfo(_host, _port, **_kw):  # type: ignore[no-untyped-def]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", fake_getaddrinfo)
+
+    from tests.conftest import fake_aiohttp_response
+
+    mock_pooled_aiohttp(_redirect_factory(fake_aiohttp_response(status=302, headers={})))
+    with pytest.raises(HomeAssistantError, match="redirect without Location"):
+        await resolve_image_bytes(hass, "https://example.com/start.png")
+
+
+async def test_resolve_http_redirect_revalidates_each_hop_under_allow_local(  # type: ignore[no-untyped-def]
+    hass, monkeypatch, mock_pooled_aiohttp
+):
+    """G1: a public->private redirect is allowed with allow_local and the hop re-resolves.
+
+    The redirect target resolves to a private address; under allow_local the
+    second hop's validation accepts it, proving the flag is threaded per hop.
+    """
+
+    def fake_getaddrinfo(host, _port, **_kw):  # type: ignore[no-untyped-def]
+        addr = "93.184.216.34" if host == "start.example" else "192.168.1.50"
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (addr, 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", fake_getaddrinfo)
+
+    from tests.conftest import fake_aiohttp_response
+
+    mock_pooled_aiohttp(
+        _redirect_factory(
+            fake_aiohttp_response(status=302, headers={"Location": "https://lan.local/snap.png"}),
+            fake_aiohttp_response(
+                status=200, headers={"Content-Type": "image/png"}, chunks=[_png_bytes()]
+            ),
+        )
+    )
+    # With the opt-in, the private redirect target is fetched.
+    raw, _ = await resolve_image_bytes(
+        hass, "https://start.example/start.png", allow_local=True
+    )
+    assert raw == _png_bytes()
+
+
+async def test_resolve_http_redirect_to_private_rejected_in_strict_mode(  # type: ignore[no-untyped-def]
+    hass, monkeypatch, mock_pooled_aiohttp
+):
+    """G1 counterpart: the same public->private redirect is rejected without allow_local."""
+
+    def fake_getaddrinfo(host, _port, **_kw):  # type: ignore[no-untyped-def]
+        addr = "93.184.216.34" if host == "start.example" else "192.168.1.50"
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (addr, 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", fake_getaddrinfo)
+
+    from tests.conftest import fake_aiohttp_response
+
+    mock_pooled_aiohttp(
+        _redirect_factory(
+            fake_aiohttp_response(status=302, headers={"Location": "https://lan.local/snap.png"}),
+            fake_aiohttp_response(
+                status=200, headers={"Content-Type": "image/png"}, chunks=[_png_bytes()]
+            ),
+        )
+    )
+    # Strict default: the second hop re-validates and rejects the private target.
+    with pytest.raises(HomeAssistantError, match="non-public address"):
+        await resolve_image_bytes(hass, "https://start.example/start.png")
+
+
+async def test_resolve_http_rejects_when_any_resolved_address_blocked(  # type: ignore[no-untyped-def]
+    hass, monkeypatch
+):
+    """G5: dual-stack fail-closed — a host resolving to public+metadata is rejected entirely.
+
+    Defeats the DNS-SSRF bypass where a hostile resolver returns one good and
+    one bad address hoping Happy-Eyeballs races to the bad one.
+    """
+
+    def fake_getaddrinfo(_host, _port, **_kw):  # type: ignore[no-untyped-def]
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0)),  # public
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("169.254.169.254", 0)),  # metadata
+        ]
+
+    monkeypatch.setattr("socket.getaddrinfo", fake_getaddrinfo)
+    # Even with the opt-in, ANY blocked address in the set rejects the fetch.
+    with pytest.raises(HomeAssistantError, match="blocked address"):
+        await resolve_image_bytes(hass, "https://dual.example/x.png", allow_local=True)
+
+
 async def test_static_resolver_rejects_unrelated_hostname(  # type: ignore[no-untyped-def]
     hass,
 ):

--- a/tests/test_image_sources.py
+++ b/tests/test_image_sources.py
@@ -254,6 +254,43 @@ async def test_resolve_http_allow_local_still_blocks_metadata(  # type: ignore[n
         )
 
 
+async def test_resolve_http_allow_local_fetches_non_default_port(  # type: ignore[no-untyped-def]
+    hass, monkeypatch, mock_pooled_aiohttp
+):
+    """allow_local lifts both the private-address block and the port allowlist.
+
+    The classic Frigate case: a LAN proxy on :5000 — private IP *and* a
+    non-standard port, the exact combination that previously failed.
+    """
+
+    def fake_getaddrinfo(_host, _port, **_kw):  # type: ignore[no-untyped-def]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("192.168.1.10", 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", fake_getaddrinfo)
+
+    def _factory():  # type: ignore[no-untyped-def]
+        from tests.conftest import fake_aiohttp_response
+
+        return fake_aiohttp_response(
+            status=200, headers={"Content-Type": "image/jpeg"}, chunks=[_png_bytes()]
+        )
+
+    mock_pooled_aiohttp(_factory)
+    raw, content_type = await resolve_image_bytes(
+        hass, "http://192.168.1.10:5000/api/events/abc/thumbnail.jpg", allow_local=True
+    )
+    assert raw == _png_bytes()
+    assert content_type == "image/jpeg"
+
+
+async def test_resolve_http_non_default_port_blocked_without_allow_local(  # type: ignore[no-untyped-def]
+    hass,
+):
+    """Strict default still rejects a non-standard port and names the toggle."""
+    with pytest.raises(HomeAssistantError, match="Allow local image URLs"):
+        await resolve_image_bytes(hass, "http://example.com:5000/x.png")
+
+
 async def test_resolve_http_rejects_non_default_port(hass):  # type: ignore[no-untyped-def]
     with pytest.raises(HomeAssistantError, match="port"):
         await resolve_image_bytes(hass, "https://example.com:22/x.png")

--- a/tests/test_image_sources_pinned_session.py
+++ b/tests/test_image_sources_pinned_session.py
@@ -54,6 +54,62 @@ async def test_static_resolver_rejects_unsupported_family() -> None:
 
 
 @pytest.mark.asyncio
+async def test_static_resolver_resolves_default_af_unspec_family() -> None:
+    # Regression (issue #95): ``aiohttp.TCPConnector`` resolves with
+    # ``family=AF_UNSPEC`` (0) by default — it does NOT split the lookup
+    # per family. The old ``get(family, [])`` filter only knew AF_INET /
+    # AF_INET6 buckets, so the default lookup matched neither bucket and
+    # every HTTP/HTTPS image fetch died with
+    # ``Cannot connect to host <host> ssl:default [None]``. AF_UNSPEC must
+    # mean "any pre-validated address", each tagged with its real family.
+    resolver = _StaticResolver("example.com", ["192.0.2.1", "2001:db8::1"])
+    out = await resolver.resolve("example.com", port=443, family=socket.AF_UNSPEC)
+    by_family = {entry["family"]: entry["host"] for entry in out}
+    assert by_family == {
+        socket.AF_INET: "192.0.2.1",
+        socket.AF_INET6: "2001:db8::1",
+    }
+    for entry in out:
+        assert entry["hostname"] == "example.com"
+        assert entry["port"] == 443
+
+
+@pytest.mark.asyncio
+async def test_static_resolver_af_unspec_with_ipv4_only() -> None:
+    # AF_UNSPEC lookup against an IPv4-only pin must still succeed and
+    # tag the result AF_INET (not the requested AF_UNSPEC).
+    resolver = _StaticResolver("example.com", ["192.0.2.1"])
+    out = await resolver.resolve("example.com", port=80, family=socket.AF_UNSPEC)
+    assert len(out) == 1
+    assert out[0]["host"] == "192.0.2.1"
+    assert out[0]["family"] == socket.AF_INET
+
+
+@pytest.mark.asyncio
+async def test_static_resolver_af_unspec_with_no_valid_addresses_raises() -> None:
+    # Defense intact: if nothing pre-validated, even an AF_UNSPEC lookup
+    # must raise rather than hand the connector an empty address set.
+    resolver = _StaticResolver("example.com", ["not-an-ip"])
+    with pytest.raises(OSError, match="no pre-validated addresses"):
+        await resolver.resolve("example.com", port=443, family=socket.AF_UNSPEC)
+
+
+@pytest.mark.asyncio
+async def test_build_pinned_session_connector_resolves_with_af_unspec() -> None:
+    # Locks in the assumption behind issue #95: the connector built for
+    # the actual fetch uses ``family=AF_UNSPEC``, so that is the value the
+    # resolver must handle. If a future aiohttp changes this default, this
+    # guard fires and tells us to revisit the resolver contract.
+    session = _build_pinned_session("example.com", ["192.0.2.1"])
+    try:
+        connector = session.connector
+        assert connector is not None
+        assert connector._family == socket.AF_UNSPEC
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
 async def test_static_resolver_returns_aiohttp_shaped_address_dicts() -> None:
     resolver = _StaticResolver("example.com", ["192.0.2.1", "192.0.2.2"])
     out = await resolver.resolve("example.com", port=443, family=socket.AF_INET)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -33,6 +33,27 @@ async def test_setup_assigns_runtime_data(hass):  # type: ignore[no-untyped-def]
     assert entry.runtime_data.adapter is not None
     assert "align" in entry.runtime_data.defaults
     assert "cut" in entry.runtime_data.defaults
+    # Secure-by-default: the SSRF opt-in is off unless the option is set.
+    assert entry.runtime_data.adapter.allow_local_image_urls is False
+
+
+async def test_setup_propagates_allow_local_image_urls_option(hass):  # type: ignore[no-untyped-def]
+    """The allow-local option must reach the adapter so the resolver relaxes."""
+    from custom_components.escpos_printer.const import CONF_ALLOW_LOCAL_IMAGE_URLS
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="1.2.3.4:9100",
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: 9100},
+        options={CONF_ALLOW_LOCAL_IMAGE_URLS: True},
+        unique_id="1.2.3.4:9100",
+    )
+    entry.add_to_hass(hass)
+    with patch("escpos.printer.Network"):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.runtime_data.adapter.allow_local_image_urls is True
 
 
 async def test_setup_registers_global_services_once(hass):  # type: ignore[no-untyped-def]

--- a/tests/test_resolve_with_retry.py
+++ b/tests/test_resolve_with_retry.py
@@ -9,7 +9,7 @@ both the timeout-skip and the back-off-fires-otherwise paths.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.exceptions import HomeAssistantError
 import pytest
@@ -81,6 +81,79 @@ async def test_resolve_with_retry_does_retry_on_non_timeout(hass):  # type: igno
     # 2 calls = initial + retry
     assert call_count == 2, "must retry once on non-timeout transient failure"
     sleep_mock.assert_called_once_with(0.5)
+
+
+async def test_resolve_with_retry_threads_allow_local(hass):  # type: ignore[no-untyped-def]
+    """G2: allow_local must reach the primary, retry, AND fallback resolve calls.
+
+    A regression dropping `allow_local=` from any of the three forwarding
+    sites would silently downgrade a LAN URL to strict validation on the
+    retry/fallback — exactly the transient-camera case retry exists for.
+    """
+    from custom_components.escpos_printer.printer import image_operations
+
+    seen: list[object] = []
+
+    async def _resolve(_hass, _img, **kwargs):  # type: ignore[no-untyped-def]
+        seen.append(kwargs.get("allow_local"))
+        raise HomeAssistantError("boom")  # force retry + fallback
+
+    with (
+        patch.object(image_operations, "resolve_image_bytes", side_effect=_resolve),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        with pytest.raises(HomeAssistantError):
+            await image_operations._resolve_with_retry(
+                hass,
+                "http://192.168.1.5/x.png",
+                context=None,
+                auto_resize=False,
+                fallback="http://192.168.1.6/y.png",
+                allow_local=True,
+            )
+
+    # primary + retry + fallback — every attempt must carry the relaxed flag.
+    assert seen, "resolve_image_bytes was never called"
+    assert all(v is True for v in seen), f"allow_local not threaded on every attempt: {seen}"
+
+
+async def test_prepare_image_for_print_reads_adapter_allow_local(hass):  # type: ignore[no-untyped-def]
+    """G3: prepare_image_for_print must read host.allow_local_image_urls and thread it.
+
+    This is the config->adapter->resolver handoff. A typo'd attribute name
+    would make getattr silently yield False and the feature would be dead
+    while every endpoint test still passed.
+    """
+    import io
+
+    from PIL import Image
+
+    from custom_components.escpos_printer.printer import image_operations
+
+    def _png() -> bytes:
+        buf = io.BytesIO()
+        Image.new("RGB", (8, 8), color=(0, 0, 0)).save(buf, format="PNG")
+        return buf.getvalue()
+
+    host = MagicMock()
+    host.allow_local_image_urls = True
+    host.get_profile_pixel_width.return_value = 384
+    host.reliability_profile_defaults = {}
+    host.default_chunk_delay_ms = 0
+    host._image_stats = None
+
+    seen: dict[str, object] = {}
+
+    async def _capture(_hass, _img, **kwargs):  # type: ignore[no-untyped-def]
+        seen.update(kwargs)
+        return _png(), "image/png"
+
+    with patch.object(image_operations, "_resolve_with_retry", side_effect=_capture):
+        await image_operations.prepare_image_for_print(
+            host, hass, "http://192.168.1.5/x.png"
+        )
+
+    assert seen.get("allow_local") is True
 
 
 def test_is_timeout_cause_walks_chain():  # type: ignore[no-untyped-def]

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -641,9 +641,10 @@ class TestIsAllowedAddress:
     @pytest.mark.parametrize(
         "addr",
         [
-            "169.254.169.254",  # cloud metadata — the whole point of keeping it blocked
+            "169.254.169.254",  # IMDSv4 cloud metadata — the whole point of keeping it blocked
             "169.254.1.1",
             "fe80::1",  # IPv6 link-local
+            "fd00:ec2::254",  # AWS IMDSv6 — a ULA that the private grant would otherwise allow
             "224.0.0.1",  # multicast
             "0.0.0.0",  # unspecified
             "240.0.0.1",  # reserved
@@ -654,6 +655,18 @@ class TestIsAllowedAddress:
 
         assert _is_allowed_address(addr, allow_local=False) is False
         assert _is_allowed_address(addr, allow_local=True) is False
+
+    @pytest.mark.parametrize(
+        "addr",
+        ["fd12:3456:789a::1", "fdce:1234::abcd", "fc00::1"],
+    )
+    def test_legitimate_ula_still_allowed_with_opt_in(self, addr):  # type: ignore[no-untyped-def]
+        # The IMDSv6 block must be the *specific* metadata host, not the whole
+        # ULA range — home IPv6 LANs legitimately use fc00::/7.
+        from custom_components.escpos_printer.security import _is_allowed_address
+
+        assert _is_allowed_address(addr, allow_local=False) is False
+        assert _is_allowed_address(addr, allow_local=True) is True
 
     def test_unparseable_address_rejected(self):  # type: ignore[no-untyped-def]
         from custom_components.escpos_printer.security import _is_allowed_address

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -581,3 +581,55 @@ class TestValidateRows:
         out = validate_rows([["a\x00b\x07c"]])
         # validate_text_input strips C0 control characters except CR/LF/HT.
         assert out == [["abc"]]
+
+
+class TestIsAllowedAddress:
+    """The opt-in ``allow_local`` relaxation of the SSRF address filter.
+
+    Strict mode (``allow_local=False``) is the historical "public only"
+    behavior. Permissive mode allows private/LAN/loopback while keeping
+    the genuinely dangerous ranges (cloud-metadata link-local, multicast,
+    reserved, unspecified) blocked.
+    """
+
+    @pytest.mark.parametrize(
+        "addr",
+        ["93.184.216.34", "8.8.8.8", "2606:2800:220:1:248:1893:25c8:1946"],
+    )
+    def test_public_allowed_in_both_modes(self, addr):  # type: ignore[no-untyped-def]
+        from custom_components.escpos_printer.security import _is_allowed_address
+
+        assert _is_allowed_address(addr, allow_local=False) is True
+        assert _is_allowed_address(addr, allow_local=True) is True
+
+    @pytest.mark.parametrize(
+        "addr",
+        ["10.0.0.5", "192.168.1.50", "172.16.0.1", "127.0.0.1", "::1", "fc00::1"],
+    )
+    def test_private_loopback_only_with_allow_local(self, addr):  # type: ignore[no-untyped-def]
+        from custom_components.escpos_printer.security import _is_allowed_address
+
+        assert _is_allowed_address(addr, allow_local=False) is False
+        assert _is_allowed_address(addr, allow_local=True) is True
+
+    @pytest.mark.parametrize(
+        "addr",
+        [
+            "169.254.169.254",  # cloud metadata — the whole point of keeping it blocked
+            "169.254.1.1",
+            "fe80::1",  # IPv6 link-local
+            "224.0.0.1",  # multicast
+            "0.0.0.0",  # unspecified
+            "240.0.0.1",  # reserved
+        ],
+    )
+    def test_dangerous_ranges_blocked_even_with_allow_local(self, addr):  # type: ignore[no-untyped-def]
+        from custom_components.escpos_printer.security import _is_allowed_address
+
+        assert _is_allowed_address(addr, allow_local=False) is False
+        assert _is_allowed_address(addr, allow_local=True) is False
+
+    def test_unparseable_address_rejected(self):  # type: ignore[no-untyped-def]
+        from custom_components.escpos_printer.security import _is_allowed_address
+
+        assert _is_allowed_address("not-an-ip", allow_local=True) is False

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -151,6 +151,32 @@ class TestImageURLValidation:
         with pytest.raises(HomeAssistantError, match="port"):
             validate_image_url(url)
 
+    def test_strict_port_rejection_points_at_toggle(self):  # type: ignore[no-untyped-def]
+        with pytest.raises(HomeAssistantError, match="Allow local image URLs"):
+            validate_image_url("http://example.com:5000/x.png")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://192.168.1.10:5000/x.png",  # Frigate
+            "http://example.com:8080/x.png",  # camera
+            "https://homeassistant.local:8123/x.png",  # HA itself
+        ],
+    )
+    def test_validate_image_url_allows_non_default_ports_with_allow_local(  # type: ignore[no-untyped-def]
+        self, url
+    ):
+        # The opt-in lifts the default-port allowlist; the address-level
+        # SSRF check (validate_image_url_and_resolve) is the real boundary.
+        assert validate_image_url(url, allow_local=True) == url
+
+    @pytest.mark.parametrize("allow_local", [False, True])
+    def test_validate_image_url_rejects_out_of_range_port(self, allow_local):  # type: ignore[no-untyped-def]
+        # Accessing urlparse().port range-checks lazily; both modes must
+        # surface a clean HomeAssistantError, never a bare ValueError.
+        with pytest.raises(HomeAssistantError, match="port"):
+            validate_image_url("https://example.com:99999/x.png", allow_local=allow_local)
+
 
 # ---------------------------------------------------------------------------
 # Local-image path validation (T-C2: pathlib.resolve, symlinks).

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "ha-escpos-thermal-printer"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "dbus-fast" },


### PR DESCRIPTION
## Summary

Fixes #95 and ships a reviewed, hardened opt-in for printing images from local/LAN URLs. Released as **0.7.2**.

The reporter (network TM-T88V, Frigate) hit `Cannot connect to host <host>:443 ssl:default [None]` on every `print_image_url`. Root cause: a DNS-pinning bug that broke **all** HTTP/HTTPS image fetches. While fixing it, the natural follow-up — "Home Assistant is a LAN tool; why can't I print from my local camera/Frigate?" — became a small, secure-by-default feature.

## What's in here

### 1. Fix: AF_UNSPEC resolver bug (`1b5827c`) — the actual #95 cause
`_StaticResolver.resolve()` only answered `AF_INET`/`AF_INET6` lookups, but `aiohttp.TCPConnector` resolves with `family=AF_UNSPEC` (0) by default. Every fetch matched no address bucket and raised a `strerror`-less `OSError` → the misleading `[None]` connect error. Now returns all pre-validated addresses tagged with their real family. The DNS-rebinding pin is unchanged. The original bug was masked because tests monkeypatched `_build_pinned_session` and only called `resolve(family=AF_INET)` — added a regression test that exercises the real resolver against `AF_UNSPEC` plus a guard locking aiohttp's default family.

### 2. Feature: opt-in "Allow local image URLs" (`3d907b2`, `157d86f`)
A **per-printer** option, **off by default**. When enabled it relaxes the SSRF address filter to accept private/RFC1918/ULA + loopback **and** lifts the 80/443 port allowlist (Frigate `:5000`, cameras `:8080`, HA `:8123`). Strict mode is provably unchanged (`_is_allowed_address(allow_local=False)` ≡ the old `_is_public_address`). Threaded via the existing `auto_resize` precedent: `entry.options` → adapter property → `prepare_image_for_print` → resolver. Notify + preview inherit it for free.

**Always blocked, even when enabled:** cloud-metadata (incl. AWS IMDSv6 `fd00:ec2::254`), link-local, multicast, reserved, unspecified. The fetch sends no auth token (only unauthenticated endpoints work), and `print_image_url` has no per-user authorization — all documented.

## Comprehensive review + remediation

Ran a full multi-dimensional review (quality, architecture, security, performance, testing, docs, CI). It found and I fixed:

- **M-1 (Medium SSRF)** `0869917` — AWS **IMDSv6** `fd00:ec2::254` is an IPv6 ULA that slipped the permissive grant, contradicting the "metadata stays blocked" guarantee. Fixed with an explicit `_ALWAYS_BLOCKED_HOSTS` denylist (blocks the specific metadata hosts; legitimate home ULA stays reachable).
- **CI-H1 (High, blocker)** `a996b2b` — the project's `diff-cover --fail-under=90` gate failed at 83%. Added redirect re-validation, entity re-raise, content-length, and the config→adapter→resolver + retry/fallback **seam** tests (silent-disable guards). **Diff coverage 83% → 100%.**
- **Docs** `f024152` — LAN-reach/port-scan caveat + per-printer semantics in `images.md`; updated `limitations.md`, `configuration.md`, `SECURITY.md`.
- **CI-MED-3** `156b140` — Opengrep rule locking the `_ALWAYS_BLOCKED_HOSTS` guard (deep-expression match; validated to fire on regression, clean on current code).

The adversarial security pass otherwise returned a clean bypass matrix (DNS-rebinding pin survives the fix; metadata blocked via decimal/hex/IPv4-mapped/NAT64 encodings; redirects re-validate per hop; dual-stack fail-closed; secure-by-default).

## Validation

- `ruff` ✓ · `mypy` ✓ (67 files) · **pytest 847 passed** · requirements-sync ✓ · version-sync ✓ (0.7.2)
- **per-patch diff coverage 100%** (≥90 gate) · opengrep 5 rules / 67 files / 0 findings

## Notes
- Deferred to backlog (non-blocking): options-update reload listener (pre-existing across all options), a couple of cheap e2e test parametrizations, minor doc polish.
- The `except (A,B):`→`except A,B:` churn in the diff is `ruff format` under the project's `target-version = py314` (valid + identical on the supported runtime; can't be reverted without a tooling change).

Closes #95.
