### PR TITLE
Fix Critical/High/Medium review findings (0.7.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ coverage.json
 
 # Local Claude Code review artifacts
 .full-review/
+.full-review-archive/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,104 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-06-12
+
+### Fixed
+
+- **Configured printer profile was never applied, and image width fell
+  back to 512 px on nearly every install.** `_get_profile_obj()`
+  imported `get_profile` from the removed `escpos.profile` module
+  (python-escpos 3.x moved it to `escpos.capabilities`); the
+  `ImportError` was swallowed, so the profile was silently dropped at
+  connect time. Separately, `get_profile_pixel_width()` read the width
+  from the live connection, which is `None` for USB, Bluetooth, and
+  non-keepalive network printers — so the width lookup always missed and
+  filed a spurious Repairs issue. Width is now read from the configured
+  profile object, and the fallback warning/Repairs issue only fires when
+  you actually selected a profile that lacks a pixel width (the
+  auto/default profile falls back silently, as intended).
+- **Options changes (codepage, profile, line width, keepalive,
+  reliability profile, "Allow local image URLs", …) now take effect
+  immediately** instead of requiring an HA restart. The entry reloads on
+  an options update.
+- **Codepage / profile can be reset back to "(Default - Auto)" in
+  options.** The previous `options or data` fallback treated the empty
+  "auto" value as falsy and snapped the original setup value back.
+- **`fallback_image` now actually works** on all image services and the
+  notify `print_message`. The schema produced a `Template` object that
+  the resolver rejected, so the fallback could never fire.
+- **A keepalive connection is dropped after a failed operation** instead
+  of being reused. A single transient error (power-cycle, idle timeout)
+  no longer bricks all subsequent prints until the entry is reloaded.
+- **`print_text`'s `encoding` override no longer prints mojibake.** It
+  called the removed `_set_codepage`; it now selects the codepage via
+  `charcode`.
+- **Setup now retries with backoff** (`ConfigEntryNotReady`) when the
+  printer is unreachable at startup, instead of hard-failing the entry.
+- **Multi-printer service calls attempt every target** even if one
+  fails, and report an aggregate error naming the failed printer(s) and
+  how many succeeded. Targeted devices that aren't loaded are logged
+  instead of silently skipped.
+- **`print_barcode`'s `align` option is honoured** (it was accepted and
+  advertised but ignored).
+- **Focused image services feed the advertised number of lines** for
+  script/automation callers (the schema now injects the per-service
+  `feed` default, matching the UI).
+- **The `beep` service UI now advertises its real defaults** (2 beeps,
+  duration 4) instead of 1/1.
+- **Config flow: selecting both "Custom codepage" and "Custom line
+  width" at setup no longer drops the custom width.**
+- **Diagnostics correctly label Bluetooth entries** (was reported as
+  `network` with null host) and redact the BT MAC, host, and the entry
+  title (which embeds the host:port or MAC).
+- **Network config flow normalises the unique ID** (case-insensitive
+  host) so the same printer isn't added twice, and validates the port
+  range.
+- **USB auto-discovery now covers the generic POS-printer VID `0x0FE6`**,
+  syncing `manifest.json` with the known-VID list in `const.py` (a sync
+  test now guards against future drift).
+
+### Security
+
+- **Barcode data with embedded control bytes is rejected.**
+  `print_barcode` did not strip ESC/GS/NUL/C0 bytes (unlike text input)
+  and defaulted `check=False`, so a crafted payload could terminate the
+  barcode early and inject raw ESC/POS commands (e.g. a cash-drawer
+  kick).
+- **The "Allow local image URLs" opt-in no longer lifts the port
+  allowlist for public targets.** Non-standard ports are now permitted
+  only for resolved private/LAN addresses, closing a blind port-scan
+  oracle against arbitrary internet hosts.
+- **Notify `print_message` enforces the calling user's entity
+  permissions** for `camera.*` / `image.*` sources. The service context
+  was lost on the entity-service path, so the per-entity read ACL was
+  bypassed. The context is captured before any `await` so concurrent
+  calls can't race it.
+- **Multi-printer calls fail closed on authorization/validation errors.**
+  An `Unauthorized` or `ServiceValidationError` on any target propagates
+  immediately with its context instead of being aggregated into a
+  generic "N of M failed" message.
+
+### Changed
+
+- **Pillow's process-global decompression-bomb limit is no longer
+  lowered.** The 20 M-pixel cap is enforced per-decode against the image
+  header instead, so other Home Assistant integrations sharing the
+  process keep Pillow's default limit on legitimate large photos. With
+  `auto_resize` the per-decode ceiling rises to 40 M pixels (the image is
+  downscaled after decode), preserving the large-source workflow.
+- **`iot_class` corrected to `local_polling`** (reachability is polled).
+- Status reachability probes now hold the operation lock atomically
+  (closing a check-then-probe race with in-flight prints), and the
+  adapter is torn down on the executor thread under the lock.
+- **The integration is no longer geo-restricted in HACS** (`country`
+  removed from `hacs.json`).
+- Service descriptions in Developer Tools now come from `services.yaml`
+  for every service; a stale partial translation block that overrode
+  nine of them with worse text was removed. Added the missing Repairs
+  and `reliability_profile` option translations. Made the network
+  `cannot_connect` error actionable.
+
 ## [0.7.2] - 2026-06-11
 
 ### Added
@@ -819,7 +917,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 Earlier releases — see git history.
 
-[Unreleased]: https://github.com/cognitivegears/ha-escpos-thermal-printer/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/cognitivegears/ha-escpos-thermal-printer/compare/v0.7.3...HEAD
+[0.7.3]: https://github.com/cognitivegears/ha-escpos-thermal-printer/compare/v0.7.2...v0.7.3
+[0.7.2]: https://github.com/cognitivegears/ha-escpos-thermal-printer/compare/v0.7.1...v0.7.2
+[0.7.1]: https://github.com/cognitivegears/ha-escpos-thermal-printer/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/cognitivegears/ha-escpos-thermal-printer/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/cognitivegears/ha-escpos-thermal-printer/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/cognitivegears/ha-escpos-thermal-printer/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/cognitivegears/ha-escpos-thermal-printer/compare/v0.5.0...v0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   nine of them with worse text was removed. Added the missing Repairs
   and `reliability_profile` option translations. Made the network
   `cannot_connect` error actionable.
+- **The RFCOMM channel field on the Bluetooth setup form moved into a
+  collapsed "Advanced options" section.** It was previously shown only
+  when "Advanced mode" was enabled on your HA user profile; that flag is
+  deprecated (removal in HA 2027.6) and newer HA versions hard-wire it
+  on, which would have surfaced the field for everyone. The section is
+  always available — expand it to set a non-default channel — and a
+  refused default channel still routes to the focused channel-retry
+  step.
 
 ## [0.7.2] - 2026-06-11
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,10 @@ Home Assistant custom integration for ESC/POS thermal receipt printers. Supports
 ## Common Commands
 
 ```bash
-# Install dependencies (use uv)
-uv sync --all-extras --group dev
+# Install dependencies (use uv). Dev/test deps live in
+# [project.optional-dependencies], so --all-extras pulls them in;
+# there is no PEP 735 [dependency-groups] table (see pyproject.toml).
+uv sync --all-extras
 
 # Run tests (excludes integration tests by default)
 uv run pytest -q
@@ -21,9 +23,9 @@ uv run pytest tests/test_services_text.py -v
 # Run integration tests specifically
 uv run pytest -m integration
 
-# Linting and type checking
+# Linting and type checking (mypy needs an explicit target, as CI uses)
 uv run ruff check .
-uv run mypy
+uv run mypy custom_components/
 
 # Pre-commit (runs automatically on commit)
 pre-commit run --all-files
@@ -120,7 +122,7 @@ docker compose down  # to stop
 
 - **pyproject.toml** is source of truth for dependencies.
 - **manifest.json** must mirror runtime deps (synced via `scripts/sync_manifest_requirements.py`).
-- Renovate auto-updates pyproject.toml; a post-upgrade task syncs manifest.json.
+- Dependabot auto-updates pyproject.toml (see `.github/dependabot.yml`); a post-upgrade task syncs manifest.json.
 - Pre-commit hooks block commits if files drift.
 - **Always use pinned versions** (`==`) for all dependencies, not ranges (`>=`). This ensures reproducible builds and better security.
 - **`pytest` is pinned by `pytest-homeassistant-custom-component`** (currently `pytest==9.0.0`). Dependabot is configured to ignore standalone `pytest` bumps (see `.github/dependabot.yml`). When upgrading the HA test harness (`pytest-homeassistant-custom-component`), check whether the new version pins a different `pytest` and bump `pytest` in `pyproject.toml` to match. If upstream ever loosens the pin, remove the `pytest` ignore rule from `dependabot.yml`.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ See [docs/bluetooth.md](docs/bluetooth.md) for the full pairing walkthrough, con
 
 ## Blueprints
 
-The [`blueprints/`](blueprints/) directory ships eight ready-to-import Home Assistant scripts and automations that exercise the text-effects services. They cover the common day-to-day workflows so you don't need to write YAML from scratch.
+The [`blueprints/`](blueprints/) directory ships 13 ready-to-import Home Assistant scripts and automations that exercise the text-effects services. They cover the common day-to-day workflows so you don't need to write YAML from scratch.
 
 | Blueprint | Type | Use case |
 |-----------|------|----------|
@@ -208,8 +208,13 @@ The [`blueprints/`](blueprints/) directory ships eight ready-to-import Home Assi
 | [Weather Forecast](blueprints/script/escpos_printer/weather_forecast.yaml) | Script | Print an N-day forecast table. |
 | [Receipt](blueprints/script/escpos_printer/receipt.yaml) | Script | Itemised receipt with subtotal / tax / total. |
 | [Recipe Card](blueprints/script/escpos_printer/recipe_card.yaml) | Script | Kitchen card — name, servings, ingredients, numbered steps. |
+| [Guest Wi-Fi QR](blueprints/script/escpos_printer/guest_wifi_qr.yaml) | Script | Print a scannable Wi-Fi join QR code for guests. |
 | [Sensor Alert](blueprints/automation/escpos_printer/sensor_alert.yaml) | Automation | Print a bordered alert when a sensor reaches a target state. |
 | [TODO Item](blueprints/automation/escpos_printer/todo_item.yaml) | Automation | Print a card per item added to a `todo` entity (fridge-printer style). |
+| [TODO Ticket](blueprints/automation/escpos_printer/todo_ticket.yaml) | Automation | Print a ticket (with QR) per item added to a `todo` entity. |
+| [Doorbell Snapshot](blueprints/automation/escpos_printer/doorbell_snapshot.yaml) | Automation | Print a camera snapshot when the doorbell is pressed. |
+| [Morning Briefing](blueprints/automation/escpos_printer/morning_briefing.yaml) | Automation | Print a combined weather + agenda briefing each morning. |
+| [Trash Reminder](blueprints/automation/escpos_printer/trash_reminder.yaml) | Automation | Print a bin / recycling reminder on collection eve. |
 
 See [`blueprints/README.md`](blueprints/README.md) for import instructions, per-blueprint inputs, and troubleshooting notes.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,8 +45,10 @@ schema (Bronze quality-scale `action-setup` rule):
 - **Base64 data URIs** — input length capped *before* regex/decoding
   (no OOM on a 200 MB base64 string); subtype pinned to
   `png|jpe?g|gif|bmp|tiff|webp` (no SVG / XML decoder reach).
-- **Pillow** — `Image.MAX_IMAGE_PIXELS` set process-globally so
-  decompression bombs raise deterministically; `Image.open` is invoked
+- **Pillow** — a decompression-bomb guard is enforced per-decode against
+  the image header dimensions (before any full-bitmap allocation),
+  scoped to this integration so Pillow's process-global limit is left
+  untouched for other Home Assistant consumers; `Image.open` is invoked
   with a pinned `formats=` allow-list.
 - **Numeric input** — every numeric parameter validated within safe
   bounds (`MAX_FEED_LINES`, `IMAGE_FRAGMENT_MIN/MAX`, etc.) declared in
@@ -105,7 +107,8 @@ _LOGGER.debug(log_msg)
 - Maximum barcode data length: 100 characters
 - Maximum image download size: 10 MB (also the **decoded** cap for base64
   data URIs)
-- Maximum decoded pixel count: 20 million (`Image.MAX_IMAGE_PIXELS`)
+- Maximum decoded pixel count: 20 million per decode (40 million with
+  `auto_resize`, since the source is downscaled after decode)
 - Maximum processed image height: 8192 px
 - Maximum image slices per print: 64 (avoids paper-DoS via tall ribbons)
 - Maximum feed lines: 50

--- a/custom_components/escpos_printer/__init__.py
+++ b/custom_components/escpos_printer/__init__.py
@@ -9,6 +9,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 
 from .capabilities import PROFILE_AUTO, is_valid_profile
@@ -51,6 +52,7 @@ from .printer import (
     UsbPrinterConfig,
     create_printer_adapter,
 )
+from .security import sanitize_log_message
 from .services import async_setup_services, async_unload_services
 
 _LOGGER = logging.getLogger(__name__)
@@ -73,6 +75,30 @@ class EscposRuntimeData:
 
 
 type EscposConfigEntry = ConfigEntry[EscposRuntimeData]
+
+
+def _shared_print_config(entry: EscposConfigEntry) -> dict[str, Any]:
+    """Transport-independent print settings, resolved options-over-data.
+
+    Uses ``options.get(key, data.get(key))`` rather than
+    ``options.get(key) or data.get(key)`` so an explicitly-chosen empty
+    value — codepage/profile ``""`` meaning *auto* — is honoured instead
+    of silently snapping back to the original setup value. Shared by all
+    three transports so the resolution rule lives in one place.
+    """
+    opt = entry.options
+    data = entry.data
+    return {
+        "timeout": float(opt.get(CONF_TIMEOUT, data.get(CONF_TIMEOUT, 4.0))),
+        "codepage": opt.get(CONF_CODEPAGE, data.get(CONF_CODEPAGE)),
+        "profile": opt.get(CONF_PROFILE, data.get(CONF_PROFILE)),
+        "line_width": int(opt.get(CONF_LINE_WIDTH, data.get(CONF_LINE_WIDTH, DEFAULT_LINE_WIDTH))),
+        "allow_local_image_urls": bool(
+            opt.get(CONF_ALLOW_LOCAL_IMAGE_URLS, DEFAULT_ALLOW_LOCAL_IMAGE_URLS)
+        ),
+    }
+
+
 
 
 async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
@@ -178,6 +204,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EscposConfigEntry) -> bo
     # Determine connection type and create appropriate config
     connection_type = entry.data.get(CONF_CONNECTION_TYPE, CONNECTION_TYPE_NETWORK)
 
+    shared = _shared_print_config(entry)
     config: UsbPrinterConfig | NetworkPrinterConfig | BluetoothPrinterConfig
     if connection_type == CONNECTION_TYPE_USB:
         config = UsbPrinterConfig(
@@ -185,37 +212,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: EscposConfigEntry) -> bo
             product_id=entry.data.get(CONF_PRODUCT_ID, 0),
             in_ep=entry.data.get(CONF_IN_EP, DEFAULT_IN_EP),
             out_ep=entry.data.get(CONF_OUT_EP, DEFAULT_OUT_EP),
-            timeout=float(entry.options.get(CONF_TIMEOUT, entry.data.get(CONF_TIMEOUT, 4.0))),
-            codepage=entry.options.get(CONF_CODEPAGE) or entry.data.get(CONF_CODEPAGE),
-            profile=entry.options.get(CONF_PROFILE) or entry.data.get(CONF_PROFILE),
-            line_width=int(entry.options.get(CONF_LINE_WIDTH, entry.data.get(CONF_LINE_WIDTH, 48))),
-            allow_local_image_urls=bool(
-                entry.options.get(CONF_ALLOW_LOCAL_IMAGE_URLS, DEFAULT_ALLOW_LOCAL_IMAGE_URLS)
-            ),
+            **shared,
         )
     elif connection_type == CONNECTION_TYPE_BLUETOOTH:
         config = BluetoothPrinterConfig(
             mac=str(entry.data.get(CONF_BT_MAC, "")),
             rfcomm_channel=int(entry.data.get(CONF_RFCOMM_CHANNEL, DEFAULT_RFCOMM_CHANNEL)),
-            timeout=float(entry.options.get(CONF_TIMEOUT, entry.data.get(CONF_TIMEOUT, 4.0))),
-            codepage=entry.options.get(CONF_CODEPAGE) or entry.data.get(CONF_CODEPAGE),
-            profile=entry.options.get(CONF_PROFILE) or entry.data.get(CONF_PROFILE),
-            line_width=int(entry.options.get(CONF_LINE_WIDTH, entry.data.get(CONF_LINE_WIDTH, 48))),
-            allow_local_image_urls=bool(
-                entry.options.get(CONF_ALLOW_LOCAL_IMAGE_URLS, DEFAULT_ALLOW_LOCAL_IMAGE_URLS)
-            ),
+            **shared,
         )
     else:
         config = NetworkPrinterConfig(
             host=entry.data[CONF_HOST],
             port=entry.data.get(CONF_PORT, 9100),
-            timeout=float(entry.options.get(CONF_TIMEOUT, entry.data.get(CONF_TIMEOUT, 4.0))),
-            codepage=entry.options.get(CONF_CODEPAGE) or entry.data.get(CONF_CODEPAGE),
-            profile=entry.options.get(CONF_PROFILE) or entry.data.get(CONF_PROFILE),
-            line_width=int(entry.options.get(CONF_LINE_WIDTH, entry.data.get(CONF_LINE_WIDTH, 48))),
-            allow_local_image_urls=bool(
-                entry.options.get(CONF_ALLOW_LOCAL_IMAGE_URLS, DEFAULT_ALLOW_LOCAL_IMAGE_URLS)
-            ),
+            **shared,
         )
 
     adapter = create_printer_adapter(config)
@@ -235,11 +244,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: EscposConfigEntry) -> bo
 
     # Start adapter background tasks (keepalive/status)
     # Note: USB printers don't support keepalive, but the adapter handles this
-    await adapter.start(
-        hass,
-        keepalive=bool(entry.options.get(CONF_KEEPALIVE, False)),
-        status_interval=int(entry.options.get(CONF_STATUS_INTERVAL, 0)),
-    )
+    try:
+        await adapter.start(
+            hass,
+            keepalive=bool(entry.options.get(CONF_KEEPALIVE, False)),
+            status_interval=int(entry.options.get(CONF_STATUS_INTERVAL, 0)),
+        )
+    except Exception as err:
+        # The only blocking work in start() is the initial keepalive
+        # connect; a printer that's off/asleep at HA boot should retry
+        # with backoff (ConfigEntryNotReady), not hard-fail the entry.
+        # Sanitise the message so a host/MAC in the error doesn't leak.
+        await adapter.stop(hass)
+        raise ConfigEntryNotReady(
+            f"Could not connect to printer: {sanitize_log_message(str(err))}"
+        ) from err
+
+    # Note: options changes are picked up automatically — the options flow
+    # extends ``OptionsFlowWithReload``, which reloads the entry when the
+    # options change (the integration reads them only here at setup).
 
     # Optionally disable platform forwarding (used by unit tests)
     platforms = PLATFORMS
@@ -257,7 +280,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: EscposConfigEntry) -> b
         # Stop adapter background tasks
         try:
             adapter = entry.runtime_data.adapter
-            await adapter.stop()
+            await adapter.stop(hass)
         except Exception:  # best effort on unload
             pass
         _LOGGER.debug("Unloaded entry %s", entry.entry_id)

--- a/custom_components/escpos_printer/_config_flow/bluetooth_steps.py
+++ b/custom_components/escpos_printer/_config_flow/bluetooth_steps.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.data_entry_flow import section
 from homeassistant.exceptions import HomeAssistantError
 import voluptuous as vol
 
@@ -39,6 +40,11 @@ from .bluetooth_helpers import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Schema key of the collapsed section holding the RFCOMM channel on the
+# bluetooth_select form. Mirrored in strings.json / translations under
+# config.step.bluetooth_select.sections.
+SECTION_BT_ADVANCED = "advanced_options"
+
 
 class BluetoothFlowMixin:
     """Mixin providing Bluetooth Classic / RFCOMM configuration steps.
@@ -46,7 +52,6 @@ class BluetoothFlowMixin:
     This mixin expects to be used with a class that has the following attributes
     and methods (typically provided by ConfigFlow and other mixins):
     - hass: HomeAssistant instance
-    - show_advanced_options: bool — HA's "advanced settings" toggle
     - _user_data: dict for storing flow data
     - _paired_bt_devices: list of paired Bluetooth devices
     - _show_all_bt_devices: bool — when True, drop the imaging-only filter
@@ -59,7 +64,6 @@ class BluetoothFlowMixin:
     """
 
     hass: Any
-    show_advanced_options: bool
     _user_data: dict[str, Any]
     _paired_bt_devices: list[dict[str, Any]]
     _show_all_bt_devices: bool
@@ -92,9 +96,16 @@ class BluetoothFlowMixin:
             else:
                 mac = chosen["mac"]
                 timeout = float(user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT))
+                # The channel arrives nested under the collapsed advanced
+                # section; tolerate a flat key for programmatic callers that
+                # bypass the schema.
+                advanced = user_input.get(SECTION_BT_ADVANCED) or {}
                 try:
                     channel = validate_rfcomm_channel(
-                        user_input.get(CONF_RFCOMM_CHANNEL, DEFAULT_RFCOMM_CHANNEL)
+                        advanced.get(
+                            CONF_RFCOMM_CHANNEL,
+                            user_input.get(CONF_RFCOMM_CHANNEL, DEFAULT_RFCOMM_CHANNEL),
+                        )
                     )
                 except HomeAssistantError:
                     errors["base"] = "invalid_rfcomm_channel"
@@ -137,18 +148,25 @@ class BluetoothFlowMixin:
         profile_choices = await self.hass.async_add_executor_job(get_profile_choices_dict)
         default_device = next(iter(device_choices.keys()))
 
+        # Channel lives in a collapsed "Advanced options" section — almost
+        # every ESC/POS printer uses 1, and a refused default channel routes
+        # to bluetooth_channel_retry, which asks for the channel directly.
+        # (A section replaces the former `show_advanced_options` gating: HA
+        # deprecated that flag and hard-wires it to True until its removal
+        # in 2027.6, which would have surfaced the field for everyone.)
         schema_dict: dict[Any, Any] = {
             vol.Required(CONF_BT_DEVICE, default=default_device): vol.In(device_choices),
             vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.Coerce(float),
             vol.Optional(CONF_PROFILE, default=PROFILE_AUTO): vol.In(profile_choices),
+            vol.Required(SECTION_BT_ADVANCED): section(
+                vol.Schema(
+                    {
+                        vol.Optional(CONF_RFCOMM_CHANNEL, default=DEFAULT_RFCOMM_CHANNEL): int,
+                    }
+                ),
+                {"collapsed": True},
+            ),
         }
-        # Channel is hidden by default — almost every ESC/POS printer uses 1.
-        # Surface it only when "Advanced settings" is on in the user's HA
-        # profile, OR when a previous attempt was refused at the default
-        # channel. Otherwise we route to bluetooth_channel_retry on
-        # `bt_channel_refused` to ask for a channel specifically.
-        if self.show_advanced_options:
-            schema_dict[vol.Optional(CONF_RFCOMM_CHANNEL, default=DEFAULT_RFCOMM_CHANNEL)] = int
         data_schema = vol.Schema(schema_dict)
         return self.async_show_form(  # type: ignore[attr-defined,no-any-return]
             step_id="bluetooth_select", data_schema=data_schema, errors=errors

--- a/custom_components/escpos_printer/_config_flow/network_steps.py
+++ b/custom_components/escpos_printer/_config_flow/network_steps.py
@@ -59,15 +59,21 @@ class NetworkFlowMixin:
         errors: dict[str, str] = {}
         if user_input is not None:
             _LOGGER.debug("Config flow network step input: %s", user_input)
-            host = user_input[CONF_HOST]
+            host = str(user_input[CONF_HOST]).strip()
             port = user_input.get(CONF_PORT, DEFAULT_PORT)
             timeout = float(user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT))
 
-            await self.async_set_unique_id(f"{host}:{port}")  # type: ignore[attr-defined]
+            # Normalise the unique_id so "Printer.local" / "printer.local"
+            # (hostnames are case-insensitive) don't create duplicate
+            # entries for the same printer. IP literals are unaffected by
+            # lowercasing.
+            await self.async_set_unique_id(f"{host.lower()}:{port}")  # type: ignore[attr-defined]
             self._abort_if_unique_id_configured()  # type: ignore[attr-defined]
 
             _LOGGER.debug("Attempting connection test to %s:%s (timeout=%s)", host, port, timeout)
-            ok = await self.hass.async_add_executor_job(_can_connect, host, port, timeout)
+            ok = bool(host) and await self.hass.async_add_executor_job(
+                _can_connect, host, port, timeout
+            )
             if ok:
                 _LOGGER.debug("Connection test succeeded for %s:%s", host, port)
 
@@ -97,7 +103,9 @@ class NetworkFlowMixin:
         data_schema = vol.Schema(
             {
                 vol.Required(CONF_HOST): str,
-                vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
+                vol.Optional(CONF_PORT, default=DEFAULT_PORT): vol.All(
+                    vol.Coerce(int), vol.Range(min=1, max=65535)
+                ),
                 vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.Coerce(float),
                 vol.Optional(CONF_PROFILE, default=PROFILE_AUTO): vol.In(profile_choices),
             }

--- a/custom_components/escpos_printer/_config_flow/options_flow.py
+++ b/custom_components/escpos_printer/_config_flow/options_flow.py
@@ -58,8 +58,14 @@ _RELIABILITY_LABELS: dict[str, str] = {
 _LOGGER = logging.getLogger(__name__)
 
 
-class EscposOptionsFlowHandler(config_entries.OptionsFlow):
+class EscposOptionsFlowHandler(config_entries.OptionsFlowWithReload):
     """Options flow handler for ESC/POS Thermal Printer.
+
+    Extends ``OptionsFlowWithReload`` so HA reloads the entry automatically
+    when the options actually change (the integration reads its options
+    only in ``async_setup_entry``). This is the modern replacement for a
+    manual ``add_update_listener`` and, unlike that listener, does NOT
+    reload on a no-op save.
 
     Modern HA (>= 2024.11; this project pins >= 2026.3) injects
     ``config_entry`` via the base class. B-M1: the 2024.8-2024.10

--- a/custom_components/escpos_printer/_config_flow/settings_steps.py
+++ b/custom_components/escpos_printer/_config_flow/settings_steps.py
@@ -137,11 +137,16 @@ class SettingsFlowMixin:
                     CONF_DEFAULT_ALIGN, DEFAULT_ALIGN
                 )
                 self._user_data[CONF_DEFAULT_CUT] = user_input.get(CONF_DEFAULT_CUT, DEFAULT_CUT)
-                self._user_data[CONF_LINE_WIDTH] = (
-                    int(line_width)
-                    if line_width and line_width != OPTION_CUSTOM
-                    else DEFAULT_LINE_WIDTH
-                )
+                # Preserve the custom-line-width sentinel so the custom
+                # codepage step can chain to the custom-line-width step.
+                # (Collapsing it to DEFAULT_LINE_WIDTH here silently
+                # dropped a "custom codepage + custom width" request.)
+                if line_width == OPTION_CUSTOM:
+                    self._user_data[CONF_LINE_WIDTH] = OPTION_CUSTOM
+                else:
+                    self._user_data[CONF_LINE_WIDTH] = (
+                        int(line_width) if line_width else DEFAULT_LINE_WIDTH
+                    )
                 return await self.async_step_custom_codepage()
 
             # Handle custom line width

--- a/custom_components/escpos_printer/diagnostics.py
+++ b/custom_components/escpos_printer/diagnostics.py
@@ -7,6 +7,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 
 from .const import (
+    CONF_BT_MAC,
     CONF_CODEPAGE,
     CONF_CONNECTION_TYPE,
     CONF_IN_EP,
@@ -15,12 +16,14 @@ from .const import (
     CONF_OUT_EP,
     CONF_PRODUCT_ID,
     CONF_PROFILE,
+    CONF_RFCOMM_CHANNEL,
     CONF_STATUS_INTERVAL,
     CONF_VENDOR_ID,
+    CONNECTION_TYPE_BLUETOOTH,
     CONNECTION_TYPE_NETWORK,
     CONNECTION_TYPE_USB,
 )
-from .printer import NetworkPrinterConfig, UsbPrinterConfig
+from .printer import BluetoothPrinterConfig, NetworkPrinterConfig, UsbPrinterConfig
 
 if TYPE_CHECKING:
     from . import EscposConfigEntry
@@ -28,8 +31,13 @@ if TYPE_CHECKING:
 # Fields to redact in diagnostics output
 # - CONF_HOST: network printer hostname/IP
 # - "host": runtime host field
-# - "connection_info": contains host:port for network printers
-TO_REDACT = {CONF_HOST, "host", "connection_info"}
+# - "mac" / CONF_BT_MAC: Bluetooth device address
+# - "connection_info": contains host:port or BT MAC
+# - "title": the default entry title embeds the host:port (network) or
+#   the MAC (Bluetooth), so it would otherwise re-leak the very
+#   identifiers the other keys redact. Diagnostics downloads are commonly
+#   attached to public issues.
+TO_REDACT = {CONF_HOST, "host", "mac", CONF_BT_MAC, "connection_info", "title"}
 
 
 async def async_get_config_entry_diagnostics(
@@ -71,6 +79,9 @@ async def async_get_config_entry_diagnostics(
             runtime["product_id"] = f"0x{config.product_id:04X}" if config.product_id else None
             runtime["in_ep"] = f"0x{config.in_ep:02X}" if config.in_ep else None
             runtime["out_ep"] = f"0x{config.out_ep:02X}" if config.out_ep else None
+        elif isinstance(config, BluetoothPrinterConfig):
+            runtime["mac"] = config.mac
+            runtime["rfcomm_channel"] = config.rfcomm_channel
         elif isinstance(config, NetworkPrinterConfig):
             runtime["host"] = config.host
             runtime["port"] = config.port
@@ -87,6 +98,15 @@ async def async_get_config_entry_diagnostics(
             CONF_PRODUCT_ID: f"0x{data.get(CONF_PRODUCT_ID, 0):04X}",
             CONF_IN_EP: f"0x{data.get(CONF_IN_EP, 0):02X}",
             CONF_OUT_EP: f"0x{data.get(CONF_OUT_EP, 0):02X}",
+            CONF_CODEPAGE: data.get(CONF_CODEPAGE),
+            CONF_PROFILE: data.get(CONF_PROFILE),
+            CONF_LINE_WIDTH: data.get(CONF_LINE_WIDTH),
+        }
+    elif connection_type == CONNECTION_TYPE_BLUETOOTH:
+        entry_data = {
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_BLUETOOTH,
+            CONF_BT_MAC: data.get(CONF_BT_MAC),
+            CONF_RFCOMM_CHANNEL: data.get(CONF_RFCOMM_CHANNEL),
             CONF_CODEPAGE: data.get(CONF_CODEPAGE),
             CONF_PROFILE: data.get(CONF_PROFILE),
             CONF_LINE_WIDTH: data.get(CONF_LINE_WIDTH),

--- a/custom_components/escpos_printer/image_sources.py
+++ b/custom_components/escpos_printer/image_sources.py
@@ -223,7 +223,7 @@ async def _resolve_camera(
     _LOGGER.debug("Fetching camera snapshot: %s", entity_id)
     try:
         image = await async_get_image(hass, entity_id, timeout=_ENTITY_FETCH_TIMEOUT_SECONDS)
-    except HomeAssistantError, Unauthorized:
+    except (HomeAssistantError, Unauthorized):
         raise
     except Exception as exc:
         raise HomeAssistantError(
@@ -253,7 +253,7 @@ async def _resolve_image_entity(
     _LOGGER.debug("Fetching image entity: %s", entity_id)
     try:
         image = await async_get_image(hass, entity_id, timeout=_ENTITY_FETCH_TIMEOUT_SECONDS)
-    except HomeAssistantError, Unauthorized:
+    except (HomeAssistantError, Unauthorized):
         raise
     except Exception as exc:
         raise HomeAssistantError(
@@ -282,7 +282,7 @@ def _check_content_length(headers: Mapping[str, str], max_bytes: int) -> None:
         return
     try:
         size = int(raw)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return
     if size > max_bytes:
         raise HomeAssistantError(
@@ -548,6 +548,7 @@ def extract_image_kwargs(
     printer_defaults: Mapping[str, Any],
     *,
     prefix: str = "",
+    hass: HomeAssistant | None = None,
 ) -> dict[str, Any]:
     """Pull the print_image kwargs from a service-call/notify-call dict.
 
@@ -556,6 +557,13 @@ def extract_image_kwargs(
     never prefixed (both are already namespaced). Only keys present
     in ``data`` are included — missing keys fall through to the
     adapter's signature defaults.
+
+    ``fallback_image`` is run through :func:`render_template` (when
+    ``hass`` is supplied) because the schema validates it with
+    ``cv.template``, producing a ``Template`` *object*; the downstream
+    resolver requires a string, so without this the fallback could never
+    fire — it silently failed the ``isinstance(str)`` guard and the
+    primary error was re-raised.
 
     Selection precedence for each image option:
     1. The prefixed key (``image_dither`` on notify; ``dither`` on
@@ -584,6 +592,10 @@ def extract_image_kwargs(
             # Notify form: accept bare ``dither``/``threshold``/etc. as
             # fallback when ``image_dither`` was not supplied.
             out[target] = data[key]
+
+    fallback = out.get(ATTR_FALLBACK_IMAGE)
+    if fallback is not None and hass is not None:
+        out[ATTR_FALLBACK_IMAGE] = render_template(hass, fallback)
     return out
 
 

--- a/custom_components/escpos_printer/manifest.json
+++ b/custom_components/escpos_printer/manifest.json
@@ -7,7 +7,7 @@
   "config_flow": true,
   "documentation": "https://github.com/cognitivegears/ha-escpos-thermal-printer#readme",
   "integration_type": "service",
-  "iot_class": "local_push",
+  "iot_class": "local_polling",
   "issue_tracker": "https://github.com/cognitivegears/ha-escpos-thermal-printer/issues",
   "loggers": [
     "escpos"
@@ -76,6 +76,10 @@
       "description": "*"
     },
     {
+      "vid": "0FE6",
+      "description": "*"
+    },
+    {
       "vid": "1203",
       "description": "*"
     },
@@ -112,5 +116,5 @@
       "description": "*pos*"
     }
   ],
-  "version": "0.7.2"
+  "version": "0.7.3"
 }

--- a/custom_components/escpos_printer/notify.py
+++ b/custom_components/escpos_printer/notify.py
@@ -102,6 +102,14 @@ class EscposNotifyEntity(NotifyEntity):
 
     async def print_message(self, **kwargs: Any) -> None:
         """Print a formatted message — with optional image — to the printer."""
+        # Capture the calling user's context BEFORE any await. The
+        # entity-service dispatcher sets it on the entity via
+        # ``async_set_context`` immediately before this method runs;
+        # reading it after an await (e.g. the utf8 transcode below) would
+        # race a concurrent call's ``async_set_context`` and could read
+        # another user's context, defeating the camera/image entity ACL.
+        context: Context | None = kwargs.get("context") or self._context
+
         message = kwargs.get("message", "")
         title = kwargs.get("title")
 
@@ -138,7 +146,6 @@ class EscposNotifyEntity(NotifyEntity):
         }
 
         image_source_raw = kwargs.get("image")
-        context: Context | None = kwargs.get("context")
 
         try:
             if image_source_raw is None:
@@ -156,6 +163,7 @@ class EscposNotifyEntity(NotifyEntity):
                 {**kwargs, "image": image_source},
                 defaults,
                 prefix="image_",
+                hass=self._hass,
             )
             await adapter.print_text_with_image(
                 self._hass,

--- a/custom_components/escpos_printer/printer/_host.py
+++ b/custom_components/escpos_printer/printer/_host.py
@@ -50,7 +50,9 @@ class _PrinterHost(Protocol):
     async def _acquire_printer(self, hass: HomeAssistant) -> tuple[Any, bool]:
         """Acquire the underlying connection (returns ``(printer, owned)``)."""
 
-    async def _release_printer(self, hass: HomeAssistant, printer: Any, *, owned: bool) -> None:
+    async def _release_printer(
+        self, hass: HomeAssistant, printer: Any, *, owned: bool, failed: bool = False
+    ) -> None:
         """Release the connection acquired via :meth:`_acquire_printer`."""
 
     async def _apply_cut_and_feed(

--- a/custom_components/escpos_printer/printer/barcode_operations.py
+++ b/custom_components/escpos_printer/printer/barcode_operations.py
@@ -35,7 +35,9 @@ class BarcodeOperationsMixin:
         """Return a printer instance and whether it should be closed by the caller."""
         raise NotImplementedError
 
-    async def _release_printer(self, hass: Any, printer: Any, *, owned: bool) -> None:
+    async def _release_printer(
+        self, hass: Any, printer: Any, *, owned: bool, failed: bool = False
+    ) -> None:
         """Close a printer instance if owned by the caller."""
         raise NotImplementedError
 
@@ -113,8 +115,10 @@ class BarcodeOperationsMixin:
 
         async with self._lock:
             printer, owned = await self._acquire_printer(hass)
+            failed = True
             try:
                 await hass.async_add_executor_job(_do_print, printer)
                 await self._apply_cut_and_feed(hass, printer, cut, feed)
+                failed = False
             finally:
-                await self._release_printer(hass, printer, owned=owned)
+                await self._release_printer(hass, printer, owned=owned, failed=failed)

--- a/custom_components/escpos_printer/printer/base_adapter.py
+++ b/custom_components/escpos_printer/printer/base_adapter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 import asyncio
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 import contextlib
 import logging
 import textwrap
@@ -29,7 +29,7 @@ from .image_operations import (
     prepare_image_for_print,
 )
 from .image_processor import FALLBACK_PROFILE_WIDTH
-from .mapping_utils import map_align, map_cut, map_multiplier, map_underline
+from .mapping_utils import cleanup_cut, map_align, map_cut, map_multiplier, map_underline
 from .print_operations import PrintOperationsMixin, _print_text_under_lock
 
 if TYPE_CHECKING:
@@ -150,15 +150,62 @@ class EscposPrinterAdapterBase(
         if self._status_interval > 0:
             await self._status_check(hass)
 
-    async def stop(self) -> None:
-        """Stop the adapter and clean up resources."""
+    async def stop(self, hass: HomeAssistant | None = None) -> None:
+        """Stop the adapter and clean up resources.
+
+        Acquires the operation lock so an in-flight keepalive print isn't
+        torn out from under the executor thread writing to the socket,
+        and closes the connection on an executor thread (``close()`` does
+        a blocking ``socket.shutdown``) rather than on the event loop.
+        """
         if self._cancel_status:
             self._cancel_status()
         self._cancel_status = None
-        if self._printer is not None:
-            with contextlib.suppress(Exception):
-                self._printer.close()
+
+        async with self._lock:
+            printer = self._printer
             self._printer = None
+            if printer is None:
+                return
+
+            def _close() -> None:
+                with contextlib.suppress(Exception):
+                    printer.close()
+
+            if hass is not None:
+                await hass.async_add_executor_job(_close)
+            else:
+                # No hass available (rare teardown path): close inline as
+                # a last resort rather than leaking the socket.
+                _close()
+
+    @contextlib.asynccontextmanager
+    async def _probe_lock_or_skip(self) -> AsyncIterator[bool]:
+        """Hold the op lock for a status probe, or yield ``False`` if busy.
+
+        A status probe must be mutually exclusive with a print on the
+        same transport (opening a second connection mid-print can flap
+        bandwidth-constrained links or, on USB/BT, disturb the active
+        job). ``if self._lock.locked(): return`` followed by awaiting
+        the probe was TOCTOU — a print could acquire the lock between the
+        check and the probe. Acquiring the lock makes check-and-hold
+        atomic: when the lock is free, asyncio's ``Lock.acquire``
+        completes without suspending, so nothing can interleave between
+        the ``locked()`` test and the acquisition.
+
+        Note the contention now runs both ways: a print arriving while a
+        probe is mid-flight blocks on the lock until the probe finishes
+        (bounded by the probe's ``min(timeout, 3.0)`` ceiling). This is
+        the intended correctness-over-latency trade-off.
+        """
+        if self._lock.locked():
+            yield False
+            return
+        await self._lock.acquire()
+        try:
+            yield True
+        finally:
+            self._lock.release()
 
     def get_status(self) -> bool | None:
         """Return the current printer status."""
@@ -204,16 +251,38 @@ class EscposPrinterAdapterBase(
         printer = await hass.async_add_executor_job(self._connect)
         return printer, True
 
-    async def _release_printer(self, hass: HomeAssistant, printer: Any, *, owned: bool) -> None:
-        """Close a printer instance if owned by the caller."""
-        if not owned:
+    async def _release_printer(
+        self, hass: HomeAssistant, printer: Any, *, owned: bool, failed: bool = False
+    ) -> None:
+        """Release a printer instance after an operation.
+
+        Caller-owned connections (the reconnect-per-operation model) are
+        always closed. A persistent keepalive connection is kept open on
+        success, but **invalidated on failure**: a broken pipe / idle
+        timeout / power-cycle leaves the socket dead, and reusing it
+        would brick every subsequent print until the entry is reloaded.
+        Dropping it here forces the next ``_acquire_printer`` to
+        reconnect. Runs under the operation lock, so nulling
+        ``self._printer`` is race-free.
+        """
+        if owned:
+
+            def _close() -> None:
+                with contextlib.suppress(Exception):
+                    printer.close()
+
+            await hass.async_add_executor_job(_close)
             return
 
-        def _close() -> None:
-            with contextlib.suppress(Exception):
-                printer.close()
+        if failed and self._printer is not None:
+            stale = self._printer
+            self._printer = None
 
-        await hass.async_add_executor_job(_close)
+            def _close_stale() -> None:
+                with contextlib.suppress(Exception):
+                    stale.close()
+
+            await hass.async_add_executor_job(_close_stale)
 
     def _notify_status_change(self, ok: bool) -> None:
         """Notify all status listeners of a status change."""
@@ -264,9 +333,14 @@ class EscposPrinterAdapterBase(
         """Get the escpos profile object for this configuration."""
         if self._config.profile:
             try:
-                from escpos import profile as escpos_profile  # noqa: PLC0415
+                # python-escpos 3.x exposes ``get_profile`` from
+                # ``escpos.capabilities`` (the old ``escpos.profile``
+                # module was removed; importing it silently returned
+                # None, so the configured profile was never applied at
+                # connect time).
+                from escpos.capabilities import get_profile  # noqa: PLC0415
 
-                return escpos_profile.get_profile(self._config.profile)
+                return get_profile(self._config.profile)
             except Exception as e:
                 _LOGGER.debug(
                     "Unknown printer profile '%s': %s",
@@ -278,30 +352,41 @@ class EscposPrinterAdapterBase(
     def get_profile_pixel_width(self, hass: HomeAssistant | None = None) -> int | None:
         """Return the printer profile's max pixel width (cached).
 
-        Falls back to :data:`FALLBACK_PROFILE_WIDTH`, logs a single
-        WARNING per adapter instance, and (when ``hass`` is provided)
-        raises a repairs issue so the miss is visible in the UI. A
-        silent log line is easy to miss; silently miscalibrated images
-        are the resulting #1 support question.
+        Resolved from the configured python-escpos profile object — not
+        from the live connection, which is ``None`` for USB, Bluetooth,
+        and non-keepalive network printers (i.e. nearly every install),
+        so reading it there always missed.
+
+        When a profile *is* configured but exposes no pixel width, falls
+        back to :data:`FALLBACK_PROFILE_WIDTH`, logs a single WARNING per
+        adapter instance, and (when ``hass`` is provided) raises a
+        repairs issue so the miss is visible in the UI — silently
+        miscalibrated images are the resulting #1 support question. The
+        auto/default profile (no profile chosen) has no declared pixel
+        width by design, so it falls back silently without warning.
         """
         if self._profile_width_lookup_done:
             return self._cached_profile_width
         width: int | None = None
-        printer = self._printer
-        if printer is not None:
+        profile_obj = self._get_profile_obj()
+        if profile_obj is not None:
             try:
-                data = printer.profile.profile_data["media"]["width"]["pixels"]
+                data = profile_obj.profile_data["media"]["width"]["pixels"]
                 if isinstance(data, (int, float)):
                     width = int(data)
-            except AttributeError, KeyError, TypeError, ValueError:
+            except (AttributeError, KeyError, TypeError, ValueError):
                 width = None
         self._cached_profile_width = width
         self._profile_width_lookup_done = True
-        if width is None and not self._profile_width_warning_logged:
+        # Only surface the fallback when the user actually picked a
+        # profile that turned out to lack width data; auto/default
+        # (``profile_obj is None``) is an expected, silent fallback.
+        if width is None and profile_obj is not None and not self._profile_width_warning_logged:
             _LOGGER.warning(
-                "Printer profile does not expose media.width.pixels; "
+                "Printer profile '%s' does not expose media.width.pixels; "
                 "falling back to %dpx for image width. Set image_width "
-                "explicitly or check the python-escpos profile data.",
+                "explicitly or pick a profile that declares a pixel width.",
+                self._config.profile,
                 FALLBACK_PROFILE_WIDTH,
             )
             self._profile_width_warning_logged = True
@@ -409,12 +494,14 @@ class EscposPrinterAdapterBase(
 
         async with self._lock:
             printer, owned = await self._acquire_printer(hass)
+            failed = True
             try:
                 try:
                     await _print_text_under_lock(self, hass, printer, **text_kwargs)
                     await _print_prepared_under_lock(hass, printer, prepared)
                     await self._apply_cut_and_feed(hass, printer, cut, feed)
-                except asyncio.CancelledError, Exception:  # pragma: no cover (T-L4)
+                    failed = False
+                except (asyncio.CancelledError, Exception):  # pragma: no cover (T-L4)
                     # S-M3: shield the cleanup so a second cancellation
                     # mid-flush doesn't leave paper half-printed. The
                     # suppress() catches Exception only — CancelledError
@@ -430,10 +517,12 @@ class EscposPrinterAdapterBase(
                     with contextlib.suppress(Exception):
                         await asyncio.shield(
                             asyncio.ensure_future(
-                                self._apply_cut_and_feed(hass, printer, cut or "full", feed or 1)
+                                self._apply_cut_and_feed(
+                                    hass, printer, cleanup_cut(cut), feed or 1
+                                )
                             )
                         )
                     raise
             finally:
-                await self._release_printer(hass, printer, owned=owned)
+                await self._release_printer(hass, printer, owned=owned, failed=failed)
         await self._mark_success()

--- a/custom_components/escpos_printer/printer/bluetooth_adapter.py
+++ b/custom_components/escpos_printer/printer/bluetooth_adapter.py
@@ -116,14 +116,6 @@ class BluetoothPrinterAdapter(EscposPrinterAdapterBase):
         We skip the tick if a print operation currently holds the lock and
         let the next print/tick refresh status.
         """
-        if self._lock.locked():
-            _LOGGER.debug(
-                "Skipping Bluetooth status probe for %s ch=%s — print operation in flight",
-                self._mac_redacted,
-                self._bt_config.rfcomm_channel,
-            )
-            return
-
         def _probe() -> tuple[bool, str | None, int | None, int | None]:
             start = time.perf_counter()
             try:
@@ -141,7 +133,15 @@ class BluetoothPrinterAdapter(EscposPrinterAdapterBase):
                     transport.close()
                 return True, None, latency_ms, None
 
-        ok, err, latency_ms, err_no = await hass.async_add_executor_job(_probe)
+        async with self._probe_lock_or_skip() as acquired:
+            if not acquired:
+                _LOGGER.debug(
+                    "Skipping Bluetooth status probe for %s ch=%s — print operation in flight",
+                    self._mac_redacted,
+                    self._bt_config.rfcomm_channel,
+                )
+                return
+            ok, err, latency_ms, err_no = await hass.async_add_executor_job(_probe)
         now = dt_util.utcnow()
         self._last_check = now
         self._last_latency_ms = latency_ms

--- a/custom_components/escpos_printer/printer/control_operations.py
+++ b/custom_components/escpos_printer/printer/control_operations.py
@@ -36,7 +36,9 @@ class ControlOperationsMixin:
         """Return a printer instance and whether it should be closed by the caller."""
         raise NotImplementedError
 
-    async def _release_printer(self, hass: Any, printer: Any, *, owned: bool) -> None:
+    async def _release_printer(
+        self, hass: Any, printer: Any, *, owned: bool, failed: bool = False
+    ) -> None:
         """Close a printer instance if owned by the caller."""
         raise NotImplementedError
 
@@ -70,10 +72,12 @@ class ControlOperationsMixin:
 
         async with self._lock:
             printer, owned = await self._acquire_printer(hass)
+            failed = True
             try:
                 await hass.async_add_executor_job(_feed_inner, printer)
+                failed = False
             finally:
-                await self._release_printer(hass, printer, owned=owned)
+                await self._release_printer(hass, printer, owned=owned, failed=failed)
 
     async def cut(self, hass: HomeAssistant, *, mode: str) -> None:
         """Cut the paper."""
@@ -83,10 +87,12 @@ class ControlOperationsMixin:
             cut_mode = "FULL"
         async with self._lock:
             printer, owned = await self._acquire_printer(hass)
+            failed = True
             try:
                 await hass.async_add_executor_job(lambda: printer.cut(mode=cut_mode))
+                failed = False
             finally:
-                await self._release_printer(hass, printer, owned=owned)
+                await self._release_printer(hass, printer, owned=owned, failed=failed)
 
     async def beep(self, hass: HomeAssistant, *, times: int = 2, duration: int = 4) -> None:
         """Trigger the printer buzzer."""
@@ -114,7 +120,9 @@ class ControlOperationsMixin:
 
         async with self._lock:
             printer, owned = await self._acquire_printer(hass)
+            failed = True
             try:
                 await hass.async_add_executor_job(_beep_inner, printer)
+                failed = False
             finally:
-                await self._release_printer(hass, printer, owned=owned)
+                await self._release_printer(hass, printer, owned=owned, failed=failed)

--- a/custom_components/escpos_printer/printer/image_operations.py
+++ b/custom_components/escpos_printer/printer/image_operations.py
@@ -35,7 +35,7 @@ from .image_processor import (
     ImageProcessOptions,
     process_image_from_bytes,
 )
-from .mapping_utils import map_align
+from .mapping_utils import cleanup_cut, map_align
 
 if TYPE_CHECKING:
     from homeassistant.core import Context, HomeAssistant
@@ -345,10 +345,12 @@ class ImageOperationsMixin:
         stats = getattr(self, "_image_stats", None)
         async with self._lock:
             printer, owned = await self._acquire_printer(hass)
+            failed = True
             try:
                 try:
                     await _print_prepared_under_lock(hass, printer, prepared)
                     await self._apply_cut_and_feed(hass, printer, cut, feed)
+                    failed = False
                 except (asyncio.CancelledError, Exception) as err:
                     # Best-effort cleanup so a cancelled mid-print doesn't
                     # leave paper hanging mid-image.
@@ -356,10 +358,12 @@ class ImageOperationsMixin:
                         stats.total_failures += 1
                         stats.last_error_class = type(err).__name__
                     with contextlib.suppress(Exception):
-                        await self._apply_cut_and_feed(hass, printer, cut or "full", feed or 1)
+                        await self._apply_cut_and_feed(
+                            hass, printer, cleanup_cut(cut), feed or 1
+                        )
                     raise
             finally:
-                await self._release_printer(hass, printer, owned=owned)
+                await self._release_printer(hass, printer, owned=owned, failed=failed)
         if stats is not None:
             stats.total_prints += 1
             stats.last_error_class = None

--- a/custom_components/escpos_printer/printer/image_processor.py
+++ b/custom_components/escpos_printer/printer/image_processor.py
@@ -21,10 +21,13 @@ import io
 import logging
 
 from PIL import Image, ImageOps
-import PIL.Image
 
 from ..const import DEFAULT_DITHER, DEFAULT_THRESHOLD
-from ..security import MAX_IMAGE_PIXELS, MAX_PROCESSED_HEIGHT
+from ..security import (
+    MAX_IMAGE_PIXELS,
+    MAX_IMAGE_PIXELS_AUTO_RESIZE,
+    MAX_PROCESSED_HEIGHT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,12 +36,13 @@ _LOGGER = logging.getLogger(__name__)
 # override with their actual width (576) via the adapter base.
 FALLBACK_PROFILE_WIDTH = 512
 
-# Set Pillow's process-global pixel cap so DecompressionBombError fires
-# deterministically on attacker-controlled images. This is a process-wide
-# setting; the value here is the maximum across all PIL consumers in the
-# Python process (Pillow checks ``> 2*MAX_IMAGE_PIXELS`` for the hard
-# error and warns at ``> MAX_IMAGE_PIXELS``).
-PIL.Image.MAX_IMAGE_PIXELS = MAX_IMAGE_PIXELS
+# NOTE: we deliberately do NOT set ``PIL.Image.MAX_IMAGE_PIXELS`` — that
+# is a process-global shared with every other Pillow consumer in the HA
+# process (camera processing, the ``image`` platform, …), and lowering it
+# to our cap made *those* integrations throw DecompressionBombError on
+# legitimate large photos. The decompression-bomb guard is instead
+# enforced per-decode in ``process_image_from_bytes`` against the header
+# dimensions, before any full-bitmap allocation.
 
 # Pinned decoder allow-list for ``Image.open`` so we never invoke novelty
 # or vulnerability-prone decoders on attacker-controlled bytes. HEIC /
@@ -198,5 +202,29 @@ def process_image_from_bytes(raw: bytes, opts: ImageProcessOptions) -> Image.Ima
     in :func:`process_image`), so it is safe to close ``src`` afterward.
     """
     with Image.open(io.BytesIO(raw), formats=_DECODER_ALLOWLIST) as src:
+        # Decompression-bomb guard: reject oversized images by their
+        # declared header dimensions *before* ``load()`` allocates the
+        # full bitmap. Scoped to this integration so we don't perturb
+        # Pillow's process-global limit for other HA consumers.
+        #
+        # When ``auto_resize`` is set the caller has opted into decoding a
+        # larger source that we then downscale, so the cap is raised to
+        # ``MAX_IMAGE_PIXELS_AUTO_RESIZE`` (matching the pre-0.7.3 hard
+        # limit). We still bound it — even with auto_resize we ``load()``
+        # the full bitmap before thumbnailing, so an unbounded source
+        # would still be a bomb.
+        cap = MAX_IMAGE_PIXELS_AUTO_RESIZE if opts.auto_resize else MAX_IMAGE_PIXELS
+        width, height = src.size
+        pixels = width * height
+        if pixels > cap:
+            hint = (
+                "reduce the source resolution"
+                if opts.auto_resize
+                else "reduce the source resolution or enable auto_resize"
+            )
+            raise ValueError(
+                f"Image {width}x{height} ({pixels} px) exceeds the maximum of "
+                f"{cap} px; {hint}"
+            )
         src.load()
         return process_image(src, opts)

--- a/custom_components/escpos_printer/printer/mapping_utils.py
+++ b/custom_components/escpos_printer/printer/mapping_utils.py
@@ -56,3 +56,20 @@ def map_cut(mode: str | None) -> str | None:
     if mode_l == "none":
         return None
     return None
+
+
+def cleanup_cut(cut: str | None) -> str:
+    """Return the cut mode to use for best-effort cleanup after a failure.
+
+    The normal default ``cut="none"`` means "don't cut" on a *successful*
+    print, but on a cancelled/failed print we want to sever the
+    half-printed receipt so it doesn't hang into the next job. ``"none"``
+    (or empty/None) therefore falls through to a full cut here; an
+    explicit ``"partial"``/``"full"`` is honoured as-is.
+
+    (Plain ``cut or "full"`` was wrong because ``DEFAULT_CUT == "none"``
+    is truthy, so it was never replaced and ``map_cut("none")`` → no cut.)
+    """
+    if cut and cut.lower() != "none":
+        return cut
+    return "full"

--- a/custom_components/escpos_printer/printer/network_adapter.py
+++ b/custom_components/escpos_printer/printer/network_adapter.py
@@ -51,9 +51,6 @@ class NetworkPrinterAdapter(EscposPrinterAdapterBase):
         until the print completes — strictly better than corrupting an
         active job.
         """
-        if self._lock.locked():
-            return
-
         def _probe() -> tuple[bool, str | None, int | None]:
             start = time.perf_counter()
             try:
@@ -67,7 +64,11 @@ class NetworkPrinterAdapter(EscposPrinterAdapterBase):
                 latency_ms = int((time.perf_counter() - start) * 1000)
                 return False, str(e), latency_ms
 
-        ok, err, latency_ms = await hass.async_add_executor_job(_probe)
+        async with self._probe_lock_or_skip() as acquired:
+            if not acquired:
+                _LOGGER.debug("Skipping network status probe; print in flight")
+                return
+            ok, err, latency_ms = await hass.async_add_executor_job(_probe)
         now = dt_util.utcnow()
         self._last_check = now
         self._last_latency_ms = latency_ms

--- a/custom_components/escpos_printer/printer/print_operations.py
+++ b/custom_components/escpos_printer/printer/print_operations.py
@@ -46,6 +46,7 @@ class PrintOperationsMixin:
         """Print text to the printer."""
         async with self._lock:
             printer, owned = await self._acquire_printer(hass)
+            failed = True
             try:
                 await _print_text_under_lock(
                     self,
@@ -60,8 +61,9 @@ class PrintOperationsMixin:
                     encoding=encoding,
                 )
                 await self._apply_cut_and_feed(hass, printer, cut, feed)
+                failed = False
             finally:
-                await self._release_printer(hass, printer, owned=owned)
+                await self._release_printer(hass, printer, owned=owned, failed=failed)
         await self._mark_success()
 
     async def print_qr(
@@ -104,11 +106,13 @@ class PrintOperationsMixin:
 
         async with self._lock:
             printer, owned = await self._acquire_printer(hass)
+            failed = True
             try:
                 await hass.async_add_executor_job(_do_print, printer)
                 await self._apply_cut_and_feed(hass, printer, cut, feed)
+                failed = False
             finally:
-                await self._release_printer(hass, printer, owned=owned)
+                await self._release_printer(hass, printer, owned=owned, failed=failed)
         await self._mark_success()
 
 
@@ -163,20 +167,21 @@ async def _print_text_under_lock(
             )
 
         if encoding:
+            # ``encoding`` is a per-call codepage override. ``charcode``
+            # both selects the codepage table on the printer *and* points
+            # python-escpos's text encoder at the matching codec, so a
+            # subsequent ``p.text`` encodes correctly. (The old path
+            # called ``p._set_codepage`` — removed in python-escpos 3.x —
+            # so the override was silently a no-op and printed mojibake.)
             try:
-                if hasattr(p, "_set_codepage"):
-                    try:
-                        p._set_codepage(encoding)
-                    except Exception:
-                        _LOGGER.warning("Unsupported encoding/codepage: %s", encoding)
-                text_bytes = text_to_print.encode(encoding, errors="replace")
-                if hasattr(p, "_raw"):
-                    p._raw(text_bytes)
-                else:
-                    p.text(text_to_print)
-            except Exception:
-                p.text(text_to_print)
-        else:
-            p.text(text_to_print)
+                if hasattr(p, "charcode"):
+                    p.charcode(encoding)
+            except Exception as e:
+                _LOGGER.warning(
+                    "Unsupported encoding/codepage override '%s': %s",
+                    encoding,
+                    sanitize_log_message(str(e)),
+                )
+        p.text(text_to_print)
 
     await hass.async_add_executor_job(_do_print, printer)

--- a/custom_components/escpos_printer/printer/usb_adapter.py
+++ b/custom_components/escpos_printer/printer/usb_adapter.py
@@ -118,9 +118,6 @@ class UsbPrinterAdapter(EscposPrinterAdapterBase):
         configurations; the cost of a stale status reading is strictly
         lower than the cost of corrupting an active print.
         """
-        if self._lock.locked():
-            return
-
         def _probe() -> tuple[bool, str | None, int | None]:
             start = time.perf_counter()
             try:
@@ -139,7 +136,11 @@ class UsbPrinterAdapter(EscposPrinterAdapterBase):
                     return True, None, latency_ms
                 return False, "USB device not found", latency_ms
 
-        ok, err, latency_ms = await hass.async_add_executor_job(_probe)
+        async with self._probe_lock_or_skip() as acquired:
+            if not acquired:
+                _LOGGER.debug("Skipping USB status probe; print in flight")
+                return
+            ok, err, latency_ms = await hass.async_add_executor_job(_probe)
         now = dt_util.utcnow()
         self._last_check = now
         self._last_latency_ms = latency_ms

--- a/custom_components/escpos_printer/quality_scale.yaml
+++ b/custom_components/escpos_printer/quality_scale.yaml
@@ -1,6 +1,13 @@
 rules:
   # Bronze
-  action-setup: done
+  action-setup:
+    status: todo
+    comment: >-
+      Services are registered in async_setup_entry (gated on the first
+      config entry) rather than async_setup. Calls still raise
+      ServiceValidationError when no printer entries are loaded (see
+      target_resolution); moving registration to async_setup to fully
+      satisfy this rule is pending.
   appropriate-polling: done
   brands: todo  # PR to home-assistant/brands required before submission
   common-modules: done
@@ -30,7 +37,7 @@ rules:
   parallel-updates: done
   reauthentication-flow:
     status: exempt
-    comment: Local-push integration with no authentication; reauth has nothing to refresh.
+    comment: Local integration with no authentication; reauth has nothing to refresh.
   test-coverage: todo  # currently ~70%; silver target is ≥95%
 
   # Gold
@@ -55,7 +62,7 @@ rules:
   exception-translations: done  # `no_target_found` wired up in strings.json + translations/en.json
   icon-translations: done
   reconfiguration-flow: todo  # only options-flow exists; no async_step_reconfigure. Blocks discovery-update-info.
-  repair-issues: todo
+  repair-issues: done  # profile_width_fallback issue raised in printer/base_adapter.py
   stale-devices:
     status: exempt
     comment: One device per config entry; entry removal handles device cleanup.
@@ -66,5 +73,10 @@ rules:
     comment: Upstream python-escpos is synchronous; calls run via hass.async_add_executor_job with a per-adapter asyncio.Lock and asyncio.timeout boundaries.
   inject-websession:
     status: exempt
-    comment: Transports are TCP sockets / pyusb / RFCOMM. aiohttp is not used.
+    comment: >-
+      Printer transports are TCP sockets / pyusb / RFCOMM. aiohttp is
+      used only for image-URL fetches, where a per-request session is
+      built with a DNS-pinned connector (image_sources._StaticResolver)
+      to defeat DNS rebinding; HA's shared session can't carry that
+      pinning, so it cannot be injected here.
   strict-typing: todo  # mypy strict mode partial; integration imports lack full type coverage

--- a/custom_components/escpos_printer/security.py
+++ b/custom_components/escpos_printer/security.py
@@ -61,10 +61,15 @@ IMAGE_FRAGMENT_MAX = 1024
 IMAGE_CHUNK_DELAY_MIN = 0
 IMAGE_CHUNK_DELAY_MAX = 5000
 
-# Maximum decoded pixel count for a single image. Set process-globally on
-# ``PIL.Image.MAX_IMAGE_PIXELS`` by ``image_processor`` so PIL's bomb
-# protection fires deterministically.
+# Maximum decoded pixel count for a single image. Enforced per-decode
+# against the image header in ``image_processor.process_image_from_bytes``
+# (not via Pillow's process-global ``PIL.Image.MAX_IMAGE_PIXELS``, which is
+# shared with — and was perturbing — other Home Assistant Pillow
+# consumers). ``MAX_IMAGE_PIXELS_AUTO_RESIZE`` is the raised ceiling when
+# the caller opts into ``auto_resize`` (the source is downscaled after
+# decode), still bounded so an unbounded source can't allocate freely.
 MAX_IMAGE_PIXELS = 20_000_000
+MAX_IMAGE_PIXELS_AUTO_RESIZE = 40_000_000
 
 # Post-processing height (rows) and per-print slice count caps. Both
 # protect against paper-waste DoS (legitimate receipts rarely exceed
@@ -200,6 +205,15 @@ def validate_barcode_data(code: str, bc_type: str) -> tuple[str, str]:
 
     if not code.strip():
         raise HomeAssistantError("Barcode data cannot be empty")
+
+    # Reject ESC/GS/C0 control bytes. python-escpos frames barcode data
+    # in a ``GS k`` command (NUL-terminated for the type-A form), so an
+    # embedded NUL/ESC could terminate the barcode early and let the
+    # trailing bytes execute as raw ESC/POS commands (cash-drawer kick,
+    # codepage/config change). Text input is stripped of these bytes;
+    # barcode data must be *exact*, so we reject rather than strip.
+    if _CONTROL_CHAR_RE.search(code):
+        raise HomeAssistantError("Barcode data contains disallowed control characters")
 
     aliases = {
         "UPC-A": "UPCA",
@@ -426,6 +440,19 @@ async def validate_image_url_and_resolve(
     if hostname is None:  # pragma: no cover — validate_image_url enforces it
         raise HomeAssistantError("URL must include a valid hostname")
     addrs = await hass.async_add_executor_job(_resolve_hostname_sync, hostname, parsed.port)
+    # The ``allow_local`` opt-in lifts the port allowlist (see
+    # ``validate_image_url``) so LAN cameras/NVRs on non-standard ports
+    # work. But it should only do so for *private* targets — a public
+    # host on an arbitrary port would turn the HA box into a port-scan
+    # oracle for the internet, which the opt-in never intended. Re-apply
+    # the port allowlist to any resolved *public* address.
+    if allow_local and parsed.port not in VALID_URL_PORTS:
+        public = [a for a in addrs if _is_public_address(a)]
+        if public:
+            raise HomeAssistantError(
+                f"URL port {parsed.port} is only permitted for private/LAN "
+                "targets; this hostname resolves to a public address"
+            )
     bad = [a for a in addrs if not _is_allowed_address(a, allow_local=allow_local)]
     if bad:
         if allow_local:

--- a/custom_components/escpos_printer/services.yaml
+++ b/custom_components/escpos_printer/services.yaml
@@ -180,7 +180,11 @@ print_text:
             - "8"
     encoding:
       name: Encoding
-      description: Character encoding override
+      description: >-
+        Codepage override for this print — a python-escpos codepage name
+        such as CP437, CP850, or CP858 (not a Python codec name). Leave
+        empty to use the printer's configured codepage.
+      example: CP858
       selector:
         text: {}
     cut:
@@ -1569,7 +1573,7 @@ beep:
     times:
       name: Times
       description: Number of beeps
-      default: 1
+      default: 2
       selector:
         number:
           min: 1
@@ -1578,8 +1582,8 @@ beep:
           mode: slider
     duration:
       name: Duration
-      description: Duration of each beep
-      default: 1
+      description: Duration of each beep (in the printer's buzzer time units, ~100 ms each)
+      default: 4
       selector:
         number:
           min: 1
@@ -1681,7 +1685,10 @@ print_message:
         boolean: {}
     encoding:
       name: Encoding
-      description: Character encoding override (ignored when UTF-8 mode is enabled)
+      description: >-
+        Codepage override — a python-escpos codepage name such as CP437 or
+        CP858 (not a Python codec name). Ignored when UTF-8 mode is enabled.
+      example: CP858
       selector:
         text: {}
     image:

--- a/custom_components/escpos_printer/services/_handler_utils.py
+++ b/custom_components/escpos_printer/services/_handler_utils.py
@@ -19,7 +19,11 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import ServiceCall
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import (
+    HomeAssistantError,
+    ServiceValidationError,
+    Unauthorized,
+)
 
 from ..security import sanitize_log_message
 from .target_resolution import _async_get_target_entries, _get_adapter_and_defaults
@@ -51,15 +55,27 @@ async def _for_each_target(
 ) -> None:
     """Run ``body`` once per resolved target with consistent error wrapping.
 
-    Resolves targets via :func:`_async_get_target_entries`, looks up the
-    adapter / defaults / config for each, logs a debug line, then awaits
-    ``body``. ``HomeAssistantError`` (and its subclasses) propagate
-    untouched so the HA framework keeps any ``translation_key`` /
-    ``status`` context. Everything else is logged with a traceback and
-    re-raised through :func:`_wrap_unexpected`.
+    Single target: ``body`` runs directly and its ``HomeAssistantError``
+    (with any ``translation_key`` / ``status`` context) propagates
+    untouched; other exceptions are sanitised via :func:`_wrap_unexpected`.
+
+    Multiple targets (an explicit ``device_id`` list, or a broadcast to
+    every configured printer): each target is attempted even if an
+    earlier one fails, so one offline printer doesn't silently skip the
+    rest. Failures are collected and reported together afterwards, named
+    by printer, with a count of how many succeeded — partial success is
+    no longer hidden behind the first error.
+
+    Authorization (``Unauthorized``) and validation
+    (``ServiceValidationError``) failures are NOT aggregated: they
+    propagate immediately with their status / translation context, so a
+    permission denial on any target fails the whole call (fail-closed)
+    rather than being downgraded into a generic "N of M failed" string.
     """
     target_entries = await _async_get_target_entries(call)
-    for entry in target_entries:
+
+    if len(target_entries) == 1:
+        entry = target_entries[0]
         try:
             adapter, defaults, config = _get_adapter_and_defaults(call.hass, entry.entry_id)
             _LOGGER.debug("Service call: %s for entry %s", service_name, entry.entry_id)
@@ -69,6 +85,35 @@ async def _for_each_target(
         except Exception as err:
             _LOGGER.exception("Service %s failed for entry %s", service_name, entry.entry_id)
             raise _wrap_unexpected(err, service_name) from err
+        return
+
+    failures: list[tuple[str, str]] = []
+    for entry in target_entries:
+        try:
+            adapter, defaults, config = _get_adapter_and_defaults(call.hass, entry.entry_id)
+            _LOGGER.debug("Service call: %s for entry %s", service_name, entry.entry_id)
+            await body(entry, adapter, defaults, config)
+        except (Unauthorized, ServiceValidationError):
+            # Auth/validation failures are not per-printer transport
+            # hiccups — propagate immediately with context intact instead
+            # of aggregating and continuing to other printers.
+            raise
+        except Exception as err:
+            _LOGGER.exception("Service %s failed for entry %s", service_name, entry.entry_id)
+            failures.append(
+                (
+                    sanitize_log_message(entry.title or entry.entry_id),
+                    sanitize_log_message(str(err)),
+                )
+            )
+
+    if failures:
+        succeeded = len(target_entries) - len(failures)
+        detail = "; ".join(f"{name} ({msg})" for name, msg in failures)
+        raise HomeAssistantError(
+            f"Service {service_name} failed for {len(failures)} of "
+            f"{len(target_entries)} printers ({succeeded} succeeded): {detail}"
+        )
 
 
 __all__ = ["_for_each_target", "_wrap_unexpected"]

--- a/custom_components/escpos_printer/services/print_handlers.py
+++ b/custom_components/escpos_printer/services/print_handlers.py
@@ -654,6 +654,7 @@ async def _prepare_text_image_kwargs(
         },
         defaults,
         prefix="image_",
+        hass=call.hass,
     )
     cut = call.data.get(ATTR_CUT) or defaults.get("cut")
     feed = call.data.get(ATTR_FEED)
@@ -713,6 +714,7 @@ async def _dispatch_print_image(call: ServiceCall, *, image_value: str, service_
             {**call.data, ATTR_IMAGE: image_value},
             defaults,
             prefix="",
+            hass=call.hass,
         )
         await adapter.print_image(
             call.hass,
@@ -806,7 +808,9 @@ async def handle_preview_image(call: ServiceCall) -> ServiceResponse:
     # actually print. We accept the slight overhead of resolving image
     # bytes twice (once in prepare_image_for_print, once here for
     # source_kind) in exchange for code reuse.
-    image_kwargs = extract_image_kwargs({**call.data, ATTR_IMAGE: image_value}, defaults, prefix="")
+    image_kwargs = extract_image_kwargs(
+        {**call.data, ATTR_IMAGE: image_value}, defaults, prefix="", hass=call.hass
+    )
     image_kwargs.pop(ATTR_IMAGE, None)
     prepared = await prepare_image_for_print(
         adapter,
@@ -942,7 +946,7 @@ async def handle_print_barcode(call: ServiceCall) -> None:
             align_ct=call.data.get(ATTR_ALIGN_CT, True),
             check=call.data.get(ATTR_CHECK, False),
             force_software=fs,
-            align=defaults.get("align"),
+            align=call.data.get(ATTR_ALIGN) or defaults.get("align"),
             cut=call.data.get(ATTR_CUT) or defaults.get("cut"),
             feed=call.data.get(ATTR_FEED),
         )

--- a/custom_components/escpos_printer/services/schemas.py
+++ b/custom_components/escpos_printer/services/schemas.py
@@ -348,13 +348,20 @@ def _local_path_only(value: Any) -> str:
     return s
 
 
+# The focused services advertise a friendly feed default in services.yaml
+# (a small paper buffer so a one-off print tears off cleanly). Set the
+# same default in the schema so a YAML/script caller that omits ``feed``
+# gets the advertised behaviour instead of 0 — without the schema default
+# voluptuous never injects the key and the handler's
+# ``call.data.get(ATTR_FEED)`` returns None (→ 0 lines). The generic
+# ``print_image`` keeps no default (services.yaml advertises 0).
 PRINT_CAMERA_SNAPSHOT_SCHEMA = vol.Schema(
     {
         vol.Optional("device_id"): _DEVICE_ID,
         vol.Required("camera_entity"): _entity_id_in_domain("camera"),
         **_IMAGE_OPTION_FRAGMENT_CAMERA,
         vol.Optional(ATTR_CUT): _CUT,
-        vol.Optional(ATTR_FEED): _FEED,
+        vol.Optional(ATTR_FEED, default=2): _FEED,
     }
 )
 
@@ -364,7 +371,7 @@ PRINT_IMAGE_ENTITY_SCHEMA = vol.Schema(
         vol.Required("image_entity"): _entity_id_in_domain("image"),
         **_IMAGE_OPTION_FRAGMENT_PLAIN,
         vol.Optional(ATTR_CUT): _CUT,
-        vol.Optional(ATTR_FEED): _FEED,
+        vol.Optional(ATTR_FEED, default=1): _FEED,
     }
 )
 
@@ -374,7 +381,7 @@ PRINT_IMAGE_URL_SCHEMA = vol.Schema(
         vol.Required("url"): vol.All(_url_only, vol.Length(min=1, max=MAX_URL_LENGTH)),
         **_IMAGE_OPTION_FRAGMENT_URL,
         vol.Optional(ATTR_CUT): _CUT,
-        vol.Optional(ATTR_FEED): _FEED,
+        vol.Optional(ATTR_FEED, default=1): _FEED,
     }
 )
 
@@ -386,7 +393,7 @@ PRINT_IMAGE_PATH_SCHEMA = vol.Schema(
         ),
         **_IMAGE_OPTION_FRAGMENT_URL,
         vol.Optional(ATTR_CUT): _CUT,
-        vol.Optional(ATTR_FEED): _FEED,
+        vol.Optional(ATTR_FEED, default=1): _FEED,
     }
 )
 

--- a/custom_components/escpos_printer/services/target_resolution.py
+++ b/custom_components/escpos_printer/services/target_resolution.py
@@ -65,17 +65,36 @@ async def _async_get_target_entries(
     for device_id in device_id_list:
         device = device_registry.async_get(device_id)
         if device is None:
-            _LOGGER.warning("Device %s not found in registry", device_id)
+            _LOGGER.warning("Targeted device %s not found in registry; skipping", device_id)
             continue
 
         # Get config entry IDs from the device
+        matched = False
         for config_entry_id in device.config_entries:
             # Check if this config entry is for our domain
             entry = hass.config_entries.async_get_entry(config_entry_id)
             if entry and entry.domain == DOMAIN:
                 target_entry_ids.add(config_entry_id)
+                matched = True
+        if not matched:
+            _LOGGER.warning(
+                "Targeted device %s is not an ESC/POS printer; skipping", device_id
+            )
 
     # Get the actual config entry objects
+    loaded_entry_ids = {e.entry_id for e in hass.config_entries.async_loaded_entries(DOMAIN)}
+    not_loaded = target_entry_ids - loaded_entry_ids
+    if not_loaded:
+        # An entry that resolved from a targeted device but isn't loaded
+        # (setup failed / disabled) would otherwise be dropped silently,
+        # making a multi-printer call look fully successful.
+        _LOGGER.warning(
+            "Skipping %d targeted ESC/POS printer(s) that are not currently loaded "
+            "(setup failed or entry disabled): %s",
+            len(not_loaded),
+            sorted(not_loaded),
+        )
+
     target_entries: list[ConfigEntry] = [
         loaded_entry
         for loaded_entry in hass.config_entries.async_loaded_entries(DOMAIN)

--- a/custom_components/escpos_printer/strings.json
+++ b/custom_components/escpos_printer/strings.json
@@ -95,15 +95,24 @@
         "description": "Select a paired Bluetooth printer. If your printer isn't listed, pair it on the host first (HA OS: Settings → System → Hardware; otherwise run 'bluetoothctl pair AA:BB:CC:DD:EE:FF' on the host) and try again, or choose Manual MAC entry.",
         "data": {
           "bt_device": "Bluetooth device",
-          "rfcomm_channel": "RFCOMM channel",
           "timeout": "Timeout (seconds)",
           "profile": "Printer profile"
         },
         "data_description": {
           "bt_device": "Select your printer from the list of paired Bluetooth devices.",
-          "rfcomm_channel": "RFCOMM channel (almost always 1 for ESC/POS printers; run 'bluetoothctl info [MAC]' on the host and look for the SerialPort service-record 'Channel:' line to confirm).",
           "timeout": "Connection timeout in seconds.",
           "profile": "Select your printer model or Auto-detect."
+        },
+        "sections": {
+          "advanced_options": {
+            "name": "Advanced options",
+            "data": {
+              "rfcomm_channel": "RFCOMM channel"
+            },
+            "data_description": {
+              "rfcomm_channel": "RFCOMM channel (almost always 1 for ESC/POS printers; run 'bluetoothctl info [MAC]' on the host and look for the SerialPort service-record 'Channel:' line to confirm)."
+            }
+          }
         }
       },
       "bluetooth_manual": {

--- a/custom_components/escpos_printer/strings.json
+++ b/custom_components/escpos_printer/strings.json
@@ -72,8 +72,8 @@
           "profile": "Printer profile"
         },
         "data_description": {
-          "vendor_id": "USB Vendor ID (decimal, e.g., 1208 for Epson).",
-          "product_id": "USB Product ID (decimal).",
+          "vendor_id": "USB Vendor ID. Use the 0x-prefixed hex form shown by lsusb / discovery, e.g. 0x04B8 (recommended). A plain decimal number is also accepted.",
+          "product_id": "USB Product ID. Use the 0x-prefixed hex form, e.g. 0x0E03. A plain decimal number is also accepted.",
           "in_ep": "Leave at default (130) unless your printer doesn't work. This is the USB address for receiving status from the printer.",
           "out_ep": "Leave at default (1) unless your printer doesn't work. This is the USB address for sending data to the printer.",
           "timeout": "Connection timeout in seconds.",
@@ -186,7 +186,7 @@
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to network printer.",
+      "cannot_connect": "Failed to connect to the network printer. Check the IP address and port (most ESC/POS printers listen on 9100), that the printer is powered on and reachable on the same network, and that no firewall is blocking the connection. If the printer sleeps when idle, try printing once to wake it.",
       "cannot_connect_usb": "Failed to connect to USB printer. Check that the printer is connected and permissions are configured correctly.",
       "usb_permission_denied": "Permission denied accessing USB device. On Linux, add udev rules or run with appropriate permissions. On Docker/HAOS, ensure the USB device is passed through to the container.",
       "usb_kernel_driver_active": "A kernel driver is active for this USB device. Stop other printing services or detach/blacklist the driver (e.g., usblp on Linux).",
@@ -289,117 +289,6 @@
       "feed": "Feed Paper",
       "cut": "Cut Paper",
       "beep": "Beep"
-    }
-  },
-  "services": {
-    "print_text": {
-      "name": "Print Text (Raw Encoding)",
-      "description": "Print text to the ESC/POS printer using raw encoding.",
-      "fields": {
-        "text": {"name": "Text", "description": "Text content to print."},
-        "align": {"name": "Alignment", "description": "Horizontal alignment for the text."},
-        "bold": {"name": "Bold", "description": "Render text in bold font."},
-        "underline": {"name": "Underline", "description": "Underline mode for text."},
-        "width": {"name": "Width multiplier", "description": "Text width multiplier (normal/double/triple, or 1-8 in YAML)."},
-        "height": {"name": "Height multiplier", "description": "Text height multiplier (normal/double/triple, or 1-8 in YAML)."},
-        "encoding": {"name": "Encoding", "description": "Character encoding/codepage for text."},
-        "cut": {"name": "Cut", "description": "Cut mode after printing."},
-        "feed": {"name": "Feed lines", "description": "Lines to feed after printing."}
-      }
-    },
-    "print_text_utf8": {
-      "name": "Print Text (UTF-8)",
-      "description": "Print UTF-8 text with automatic transcoding to the printer's codepage. Converts special characters like curly quotes, em-dashes, and accented letters to their closest equivalents.",
-      "fields": {
-        "text": {"name": "Text", "description": "UTF-8 text content to print. Special characters will be automatically converted."},
-        "align": {"name": "Alignment", "description": "Horizontal alignment for the text."},
-        "bold": {"name": "Bold", "description": "Render text in bold font."},
-        "underline": {"name": "Underline", "description": "Underline mode for text."},
-        "width": {"name": "Width multiplier", "description": "Text width multiplier (normal/double/triple, or 1-8 in YAML)."},
-        "height": {"name": "Height multiplier", "description": "Text height multiplier (normal/double/triple, or 1-8 in YAML)."},
-        "cut": {"name": "Cut", "description": "Cut mode after printing."},
-        "feed": {"name": "Feed lines", "description": "Lines to feed after printing."}
-      }
-    },
-    "print_qr": {
-      "name": "Print QR",
-      "description": "Print a QR code.",
-      "fields": {
-        "data": {"name": "Data", "description": "Data content to encode in the QR code."},
-        "size": {"name": "Size", "description": "Module size for the QR code (1-16)."},
-        "ec": {"name": "Error correction", "description": "QR error correction level (L/M/Q/H)."},
-        "align": {"name": "Alignment", "description": "Horizontal alignment for the QR code."},
-        "cut": {"name": "Cut", "description": "Cut mode after printing."},
-        "feed": {"name": "Feed lines", "description": "Lines to feed after printing."}
-      }
-    },
-    "print_image": {
-      "name": "Print image",
-      "description": "Print an image by URL or local path.",
-      "fields": {
-        "image": {"name": "Image", "description": "Path or URL to the image to print."},
-        "high_density": {"name": "High density", "description": "Use high density image mode if supported."},
-        "align": {"name": "Alignment", "description": "Horizontal alignment for the image."},
-        "cut": {"name": "Cut", "description": "Cut mode after printing."},
-        "feed": {"name": "Feed lines", "description": "Lines to feed after printing."}
-      }
-    },
-    "feed": {
-      "name": "Feed",
-      "description": "Feed the paper by a number of lines.",
-      "fields": {
-        "lines": {"name": "Lines", "description": "Number of lines to feed."}
-      }
-    },
-    "cut": {
-      "name": "Cut",
-      "description": "Cut the paper.",
-      "fields": {
-        "mode": {"name": "Mode", "description": "Cut mode (full or partial)."}
-      }
-    },
-    "print_barcode": {
-      "name": "Print barcode",
-      "description": "Print a barcode.",
-      "fields": {
-        "code": {"name": "Code", "description": "Barcode data to print."},
-        "bc": {"name": "Type", "description": "Barcode symbology to use."},
-        "height": {"name": "Height", "description": "Barcode height in dots (1-255)."},
-        "width": {"name": "Width", "description": "Barcode module width (2-6)."},
-        "pos": {"name": "Text position", "description": "Human-readable text position (ABOVE/BELOW/BOTH/OFF)."},
-        "font": {"name": "Font", "description": "Font for human-readable text (A or B)."},
-        "align_ct": {"name": "Center align", "description": "Center the barcode on the line."},
-        "check": {"name": "Validate code", "description": "Enable checksum/validation when supported."},
-        "force_software": {"name": "Force software renderer", "description": "Force software rendering mode to improve compatibility."},
-        "align": {"name": "Alignment", "description": "Horizontal alignment for the barcode."},
-        "cut": {"name": "Cut", "description": "Cut mode after printing."},
-        "feed": {"name": "Feed lines", "description": "Lines to feed after printing."}
-      }
-    },
-    "beep": {
-      "name": "Beep",
-      "description": "Trigger the printer buzzer (if supported).",
-      "fields": {
-        "times": {"name": "Times", "description": "Number of beep cycles."},
-        "duration": {"name": "Duration", "description": "Duration of each beep in units supported by the printer."}
-      }
-    },
-    "print_message": {
-      "name": "Print Formatted Message",
-      "description": "Print a message with full text formatting to an ESC/POS thermal printer.",
-      "fields": {
-        "message": {"name": "Message", "description": "Text content to print."},
-        "title": {"name": "Title", "description": "Optional title printed before the message."},
-        "align": {"name": "Alignment", "description": "Horizontal alignment for the text."},
-        "bold": {"name": "Bold", "description": "Render text in bold font."},
-        "underline": {"name": "Underline", "description": "Underline mode for text."},
-        "width": {"name": "Width multiplier", "description": "Text width multiplier (normal/double/triple, or 1-8 in YAML)."},
-        "height": {"name": "Height multiplier", "description": "Text height multiplier (normal/double/triple, or 1-8 in YAML)."},
-        "utf8": {"name": "UTF-8 mode", "description": "Enable UTF-8 transcoding to automatically convert special characters to printer-compatible encoding."},
-        "encoding": {"name": "Encoding", "description": "Character encoding/codepage for text (ignored when UTF-8 mode is enabled)."},
-        "cut": {"name": "Cut", "description": "Cut mode after printing."},
-        "feed": {"name": "Feed lines", "description": "Lines to feed after printing."}
-      }
     }
   },
   "issues": {

--- a/custom_components/escpos_printer/translations/en.json
+++ b/custom_components/escpos_printer/translations/en.json
@@ -95,15 +95,24 @@
         "description": "Select a paired Bluetooth printer. If your printer isn't listed, pair it on the host first (HA OS: Settings → System → Hardware; otherwise run 'bluetoothctl pair AA:BB:CC:DD:EE:FF' on the host) and try again, or choose Manual MAC entry.",
         "data": {
           "bt_device": "Bluetooth device",
-          "rfcomm_channel": "RFCOMM channel",
           "timeout": "Timeout (seconds)",
           "profile": "Printer profile"
         },
         "data_description": {
           "bt_device": "Select your printer from the list of paired Bluetooth devices.",
-          "rfcomm_channel": "RFCOMM channel (almost always 1 for ESC/POS printers; run 'bluetoothctl info [MAC]' on the host and look for the SerialPort service-record 'Channel:' line to confirm).",
           "timeout": "Connection timeout in seconds.",
           "profile": "Select your printer model or Auto-detect."
+        },
+        "sections": {
+          "advanced_options": {
+            "name": "Advanced options",
+            "data": {
+              "rfcomm_channel": "RFCOMM channel"
+            },
+            "data_description": {
+              "rfcomm_channel": "RFCOMM channel (almost always 1 for ESC/POS printers; run 'bluetoothctl info [MAC]' on the host and look for the SerialPort service-record 'Channel:' line to confirm)."
+            }
+          }
         }
       },
       "bluetooth_manual": {

--- a/custom_components/escpos_printer/translations/en.json
+++ b/custom_components/escpos_printer/translations/en.json
@@ -72,8 +72,8 @@
           "profile": "Printer profile"
         },
         "data_description": {
-          "vendor_id": "USB Vendor ID (decimal, e.g., 1208 for Epson).",
-          "product_id": "USB Product ID (decimal).",
+          "vendor_id": "USB Vendor ID. Use the 0x-prefixed hex form shown by lsusb / discovery, e.g. 0x04B8 (recommended). A plain decimal number is also accepted.",
+          "product_id": "USB Product ID. Use the 0x-prefixed hex form, e.g. 0x0E03. A plain decimal number is also accepted.",
           "in_ep": "Leave at default (130) unless your printer doesn't work. This is the USB address for receiving status from the printer.",
           "out_ep": "Leave at default (1) unless your printer doesn't work. This is the USB address for sending data to the printer.",
           "timeout": "Connection timeout in seconds.",
@@ -186,7 +186,7 @@
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to network printer.",
+      "cannot_connect": "Failed to connect to the network printer. Check the IP address and port (most ESC/POS printers listen on 9100), that the printer is powered on and reachable on the same network, and that no firewall is blocking the connection. If the printer sleeps when idle, try printing once to wake it.",
       "cannot_connect_usb": "Failed to connect to USB printer. Check that the printer is connected and permissions are configured correctly.",
       "usb_permission_denied": "Permission denied accessing USB device. On Linux, add udev rules or run with appropriate permissions. On Docker/HAOS, ensure the USB device is passed through to the container.",
       "usb_kernel_driver_active": "A kernel driver is active for this USB device. Stop other printing services or detach/blacklist the driver (e.g., usblp on Linux).",
@@ -229,6 +229,7 @@
           "line_width": "Characters per line",
           "default_align": "Default alignment",
           "default_cut": "Default cut mode",
+          "reliability_profile": "Image reliability profile",
           "keepalive": "Keep persistent connection",
           "status_interval": "Status check interval (seconds)",
           "allow_local_image_urls": "Allow local image URLs"
@@ -240,6 +241,7 @@
           "line_width": "Number of characters per line (columns).",
           "default_align": "Default text alignment for printing.",
           "default_cut": "Default paper cut mode after printing.",
+          "reliability_profile": "Picks safe defaults for image chunk size, inter-chunk delay, and ESC/POS image command. Service-call options always override these.",
           "keepalive": "Keep the connection open between print jobs (network printers only).",
           "status_interval": "How often to check printer status (0 to disable).",
           "allow_local_image_urls": "Permit print_image_url (and the other image services) to fetch URLs that resolve to private/LAN/loopback addresses and to use non-standard ports (e.g. a local camera, a Frigate proxy on :5000, or your Home Assistant instance on :8123). Off by default. Cloud-metadata/link-local addresses stay blocked even when enabled."
@@ -289,115 +291,10 @@
       "beep": "Beep"
     }
   },
-  "services": {
-    "print_text": {
-      "name": "Print Text (Raw Encoding)",
-      "description": "Print text to the ESC/POS printer using raw encoding.",
-      "fields": {
-        "text": {"name": "Text", "description": "Text content to print."},
-        "align": {"name": "Alignment", "description": "Horizontal alignment for the text."},
-        "bold": {"name": "Bold", "description": "Render text in bold font."},
-        "underline": {"name": "Underline", "description": "Underline mode for text."},
-        "width": {"name": "Width multiplier", "description": "Text width multiplier (normal/double/triple, or 1-8 in YAML)."},
-        "height": {"name": "Height multiplier", "description": "Text height multiplier (normal/double/triple, or 1-8 in YAML)."},
-        "encoding": {"name": "Encoding", "description": "Character encoding/codepage for text."},
-        "cut": {"name": "Cut", "description": "Cut mode after printing."},
-        "feed": {"name": "Feed lines", "description": "Lines to feed after printing."}
-      }
-    },
-    "print_text_utf8": {
-      "name": "Print Text (UTF-8)",
-      "description": "Print UTF-8 text with automatic transcoding to the printer's codepage. Converts special characters like curly quotes, em-dashes, and accented letters to their closest equivalents.",
-      "fields": {
-        "text": {"name": "Text", "description": "UTF-8 text content to print. Special characters will be automatically converted."},
-        "align": {"name": "Alignment", "description": "Horizontal alignment for the text."},
-        "bold": {"name": "Bold", "description": "Render text in bold font."},
-        "underline": {"name": "Underline", "description": "Underline mode for text."},
-        "width": {"name": "Width multiplier", "description": "Text width multiplier (normal/double/triple, or 1-8 in YAML)."},
-        "height": {"name": "Height multiplier", "description": "Text height multiplier (normal/double/triple, or 1-8 in YAML)."},
-        "cut": {"name": "Cut", "description": "Cut mode after printing."},
-        "feed": {"name": "Feed lines", "description": "Lines to feed after printing."}
-      }
-    },
-    "print_qr": {
-      "name": "Print QR",
-      "description": "Print a QR code.",
-      "fields": {
-        "data": {"name": "Data", "description": "Data content to encode in the QR code."},
-        "size": {"name": "Size", "description": "Module size for the QR code (1-16)."},
-        "ec": {"name": "Error correction", "description": "QR error correction level (L/M/Q/H)."},
-        "align": {"name": "Alignment", "description": "Horizontal alignment for the QR code."},
-        "cut": {"name": "Cut", "description": "Cut mode after printing."},
-        "feed": {"name": "Feed lines", "description": "Lines to feed after printing."}
-      }
-    },
-    "print_image": {
-      "name": "Print image",
-      "description": "Print an image by URL or local path.",
-      "fields": {
-        "image": {"name": "Image", "description": "Path or URL to the image to print."},
-        "high_density": {"name": "High density", "description": "Use high density image mode if supported."},
-        "align": {"name": "Alignment", "description": "Horizontal alignment for the image."},
-        "cut": {"name": "Cut", "description": "Cut mode after printing."},
-        "feed": {"name": "Feed lines", "description": "Lines to feed after printing."}
-      }
-    },
-    "feed": {
-      "name": "Feed",
-      "description": "Feed the paper by a number of lines.",
-      "fields": {
-        "lines": {"name": "Lines", "description": "Number of lines to feed."}
-      }
-    },
-    "cut": {
-      "name": "Cut",
-      "description": "Cut the paper.",
-      "fields": {
-        "mode": {"name": "Mode", "description": "Cut mode (full or partial)."}
-      }
-    },
-    "print_barcode": {
-      "name": "Print barcode",
-      "description": "Print a barcode.",
-      "fields": {
-        "code": {"name": "Code", "description": "Barcode data to print."},
-        "bc": {"name": "Type", "description": "Barcode symbology to use."},
-        "height": {"name": "Height", "description": "Barcode height in dots (1-255)."},
-        "width": {"name": "Width", "description": "Barcode module width (2-6)."},
-        "pos": {"name": "Text position", "description": "Human-readable text position (ABOVE/BELOW/BOTH/OFF)."},
-        "font": {"name": "Font", "description": "Font for human-readable text (A or B)."},
-        "align_ct": {"name": "Center align", "description": "Center the barcode on the line."},
-        "check": {"name": "Validate code", "description": "Enable checksum/validation when supported."},
-        "force_software": {"name": "Force software renderer", "description": "Force software rendering mode to improve compatibility."},
-        "align": {"name": "Alignment", "description": "Horizontal alignment for the barcode."},
-        "cut": {"name": "Cut", "description": "Cut mode after printing."},
-        "feed": {"name": "Feed lines", "description": "Lines to feed after printing."}
-      }
-    },
-    "beep": {
-      "name": "Beep",
-      "description": "Trigger the printer buzzer (if supported).",
-      "fields": {
-        "times": {"name": "Times", "description": "Number of beep cycles."},
-        "duration": {"name": "Duration", "description": "Duration of each beep in units supported by the printer."}
-      }
-    },
-    "print_message": {
-      "name": "Print Formatted Message",
-      "description": "Print a message with full text formatting to an ESC/POS thermal printer.",
-      "fields": {
-        "message": {"name": "Message", "description": "Text content to print."},
-        "title": {"name": "Title", "description": "Optional title printed before the message."},
-        "align": {"name": "Alignment", "description": "Horizontal alignment for the text."},
-        "bold": {"name": "Bold", "description": "Render text in bold font."},
-        "underline": {"name": "Underline", "description": "Underline mode for text."},
-        "width": {"name": "Width multiplier", "description": "Text width multiplier (normal/double/triple, or 1-8 in YAML)."},
-        "height": {"name": "Height multiplier", "description": "Text height multiplier (normal/double/triple, or 1-8 in YAML)."},
-        "utf8": {"name": "UTF-8 mode", "description": "Enable UTF-8 transcoding to automatically convert special characters to printer-compatible encoding."},
-        "encoding": {"name": "Encoding", "description": "Character encoding/codepage for text (ignored when UTF-8 mode is enabled)."},
-        "cut": {"name": "Cut", "description": "Cut mode after printing."},
-        "feed": {"name": "Feed lines", "description": "Lines to feed after printing."}
-      }
+  "issues": {
+    "profile_width_fallback": {
+      "title": "Printer profile is missing the pixel width",
+      "description": "The selected printer profile ({profile}) does not expose `media.width.pixels`, so images are being scaled to a generic {fallback}px width. This is usually correct for 58 mm thermals but may print stretched or truncated on 80 mm printers.\n\n**To fix:** open the integration's options, pick the closest matching printer profile, or set `image_width` explicitly in your service calls. If your printer's profile name is correct, the python-escpos profile database may need updating."
     }
   },
   "exceptions": {

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -3,11 +3,11 @@
 ## All connection types
 
 - **One queued operation per printer.** Each adapter holds an `asyncio.Lock`; service calls to the same printer serialize. Concurrent prints to the same device wait their turn.
-- **Images auto-fit to the printer's profile width.** By default, images wider than the printer profile's maximum pixel width are resized down (with aspect ratio preserved). When the profile doesn't expose `media.width.pixels`, the integration falls back to **512 px** and logs a `WARNING` once per adapter — check `home-assistant.log` for `Printer profile does not expose media.width.pixels`. Set `image_width` on `print_image` to override. Images are never upscaled. See the [Images guide](images.md).
+- **Images auto-fit to the printer's profile width.** By default, images wider than the printer profile's maximum pixel width are resized down (with aspect ratio preserved). When you've selected a profile that doesn't expose `media.width.pixels`, the integration falls back to **512 px**, logs a `WARNING` once per adapter (check `home-assistant.log` for `does not expose media.width.pixels`), and raises a Repairs issue. The auto/default profile (no profile chosen) also uses the 512 px fallback, but silently — it has no declared width by design. Set `image_width` on `print_image` to override, or pick a profile that declares a pixel width. Images are never upscaled. See the [Images guide](images.md).
 - **Image files are capped at 10 MB** (both for HTTP download and for decoded base64 data URIs).
-- **Image processing caps.** Decoded images cannot exceed 20 M pixels (`Image.MAX_IMAGE_PIXELS`), 8192 rows of processed height, or 64 slices per print. These guard against decompression bombs and paper-DoS via tall ribbons.
+- **Image processing caps.** Decoded images cannot exceed 20 M pixels (40 M with `auto_resize`, since the source is downscaled after decode) — enforced per-decode against the image header, scoped to this integration — 8192 rows of processed height, or 64 slices per print. These guard against decompression bombs and paper-DoS via tall ribbons.
 - **Buffer overruns on tall images.** Chunked transmission (`fragment_height`, `chunk_delay_ms`) mitigates this; tune both per printer if you still see freezes or character dumps. Default `chunk_delay_ms` is 0 on Network / USB and 50 on Bluetooth.
-- **No print preview.** Output is unbuffered ESC/POS — what you send is what prints.
+- **Output is unbuffered ESC/POS** — once a print service runs, the bytes go straight to the printer. To iterate on layout without wasting paper, use the `preview_image`, `preview_box`, and `preview_table` services, which render to a PNG/TXT file instead of printing.
 - **Print quality** depends on the printer's hardware density setting and paper. Not adjustable from the integration.
 
 ## Security posture (image pipeline)

--- a/docs/services.md
+++ b/docs/services.md
@@ -14,9 +14,9 @@ Print raw text using the configured codepage. No transcoding.
 | underline | string | `none`, `single`, `double` |
 | width | string\|int | `normal`, `double`, `triple`, or 1–8 |
 | height | string\|int | `normal`, `double`, `triple`, or 1–8 |
-| encoding | string | Override codepage |
+| encoding | string | Codepage override — a python-escpos codepage name such as `CP437`/`CP858` (not a Python codec name) |
 | cut | string | `none`, `partial`, `full` |
-| feed | int | Lines to feed (0–10) |
+| feed | int | Lines to feed (0–50) |
 
 ## escpos_printer.print_text_utf8
 
@@ -52,11 +52,11 @@ Entity service for the notify platform. Targets a notify entity and supports all
 | ec | string | Error correction: `L`, `M`, `Q`, `H` |
 | align | string | `left`, `center`, `right` |
 | cut | string | `none`, `partial`, `full` |
-| feed | int | Lines to feed (0–10) |
+| feed | int | Lines to feed (0–50) |
 
 ## escpos_printer.print_barcode
 
-Supported types: `EAN13`, `EAN8`, `UPC-A`, `UPC-E`, `CODE39`, `CODE93`, `CODE128`, `ITF`, `CODABAR`.
+Supported types: `EAN13`, `EAN8`, `UPC-A`, `UPC-E`, `CODE39`, `CODE93`, `CODE128`, `ITF`, `ITF14`, `CODABAR`, `JAN`, `JAN13`, `JAN8`.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -70,7 +70,7 @@ Supported types: `EAN13`, `EAN8`, `UPC-A`, `UPC-E`, `CODE39`, `CODE93`, `CODE128
 | check | boolean | Validate checksum |
 | force_software | string | Rendering mode |
 | cut | string | `none`, `partial`, `full` |
-| feed | int | Lines to feed (0–10) |
+| feed | int | Lines to feed (0–50) |
 
 ## Image services
 
@@ -221,7 +221,7 @@ Response shape: `{path, width, line_count, codepage}`.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| lines | int | Lines to feed 1–10 (required) |
+| lines | int | Lines to feed 1–50 (required) |
 
 ## escpos_printer.cut
 
@@ -237,3 +237,17 @@ If the printer supports it.
 |-----------|------|-------------|
 | times | int | Number of beeps (default 2) |
 | duration | int | Beep duration (default 4) |
+
+## escpos_printer.calibration_print
+
+Prints a test sheet of dither/threshold swatches so you can pick the
+image settings that look best on your paper. Use it after setup to
+choose a `dither` mode and `threshold` for `print_image`.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| device_id | string\|list | Target printer(s); omit to broadcast to all |
+| cut | string | `none`, `partial`, `full` (default `full`) |
+| feed | int | Lines to feed after printing (default 2) |
+
+The test sheet width is taken from the printer profile (falling back to 384 px); it is not configurable.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -164,7 +164,7 @@ sudo rfcomm connect 0 AA:BB:CC:DD:EE:FF 1  # manual RFCOMM probe
 
 ## Image issues
 
-- **"Image too large"** — resize under 512px wide.
+- **"Image too large"** — the source file exceeds the 10 MB cap (40 MB with `auto_resize: true`), or the decoded image exceeds 20 M pixels. Re-export at lower resolution/quality, or set `auto_resize: true`. Width is fitted to the printer automatically and is not the cause of this error.
 - **Image doesn't print** — use PNG or JPEG; for URLs verify reachable from HA host; for local files use absolute paths starting with `/config/`.
 - **Image prints solid black** — image is too dark or has alpha issues. Use white background, increase contrast, convert to 1-bit B&W.
 

--- a/docs/usb.md
+++ b/docs/usb.md
@@ -29,8 +29,8 @@ If your printer isn't auto-discovered:
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| Vendor ID | USB Vendor ID (hex, e.g. 04B8) | From discovery |
-| Product ID | USB Product ID (hex, e.g. 0E03) | From discovery |
+| Vendor ID | USB Vendor ID — use the `0x`-prefixed hex form, e.g. `0x04B8` (a plain decimal number is also accepted) | From discovery |
+| Product ID | USB Product ID — use the `0x`-prefixed hex form, e.g. `0x0E03` (a plain decimal number is also accepted) | From discovery |
 | Input Endpoint | USB IN endpoint | 0x82 |
 | Output Endpoint | USB OUT endpoint | 0x01 |
 | Timeout | Connect timeout (seconds) | 4.0 |

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,5 @@
 {
   "name": "ESC/POS Thermal Printer",
-  "filename": "",
   "render_readme": true,
-  "country": ["US"],
   "homeassistant": "2026.3.0"
 }

--- a/info.md
+++ b/info.md
@@ -8,7 +8,7 @@ Native Home Assistant control for ESC/POS thermal receipt printers connected via
 - **Status binary sensor** — reachability check works for network, USB, and Bluetooth
 - **Battery sensor** — reports battery level for portable BT printers that expose `org.bluez.Battery1`
 - **Auto-discovery** — USB printers matched against known thermal-printer vendor IDs
-- **Local push** — no cloud, no account
+- **Fully local** — no cloud, no account
 
 ## Setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-escpos-thermal-printer"
-version = "0.7.2"
+version = "0.7.3"
 description = "Network thermal printer integration for Home Assistant using ESC/POS protocol"
 readme = "README.md"
 requires-python = ">=3.14.2"

--- a/tests/test_adapter_lifecycle.py
+++ b/tests/test_adapter_lifecycle.py
@@ -168,11 +168,14 @@ async def test_wrap_text_zero_width_no_wrap(hass):  # type: ignore[no-untyped-de
 
 
 async def test_get_profile_pixel_width_handles_broken_profile_data(hass):  # type: ignore[no-untyped-def]
-    """A printer whose profile_data is missing the media/width keys must not raise.
+    """A configured profile missing the media/width keys must not raise.
 
     Exercises the AttributeError/KeyError/TypeError/ValueError guard in
-    get_profile_pixel_width: a connected printer with a malformed profile
-    falls back to None rather than crashing the image pipeline.
+    get_profile_pixel_width: a profile object with malformed profile_data
+    falls back to None rather than crashing the image pipeline. The width
+    is read from the configured profile object (``_get_profile_obj``),
+    not the live connection — the connection is None for USB/Bluetooth
+    and non-keepalive network printers.
     """
     entry = await _setup_entry(hass)
     adapter = entry.runtime_data.adapter
@@ -181,12 +184,40 @@ async def test_get_profile_pixel_width_handles_broken_profile_data(hass):  # typ
         # Real dict so ["media"] raises KeyError (not a Mock that auto-vivifies).
         profile_data: dict = {}
 
-    class _Printer:
-        profile = _BrokenProfile()
-
-    adapter._printer = _Printer()  # type: ignore[attr-defined]
+    # Class is callable with no args → returns a fresh instance, matching
+    # the _get_profile_obj() contract.
+    adapter._get_profile_obj = _BrokenProfile  # type: ignore[attr-defined,method-assign]
     # No hass passed → skips the repair-issue path; just exercises the guard.
     assert adapter.get_profile_pixel_width() is None
+
+
+async def test_get_profile_pixel_width_reads_configured_profile(hass):  # type: ignore[no-untyped-def]
+    """A profile that declares media.width.pixels is read without a connection."""
+    entry = await _setup_entry(hass)
+    adapter = entry.runtime_data.adapter
+
+    class _Profile:
+        profile_data = {"media": {"width": {"pixels": 576}}}
+
+    adapter._get_profile_obj = _Profile  # type: ignore[attr-defined,method-assign]
+    # self._printer is None (no keepalive), proving the width comes from
+    # the profile object, not the connection.
+    assert adapter._printer is None  # type: ignore[attr-defined]
+    assert adapter.get_profile_pixel_width() == 576
+
+
+async def test_get_profile_pixel_width_auto_profile_silent_fallback(hass, caplog):  # type: ignore[no-untyped-def]
+    """The auto/default profile (no profile chosen) falls back silently."""
+    entry = await _setup_entry(hass)
+    adapter = entry.runtime_data.adapter
+
+    # Auto profile → _get_profile_obj() returns None → fallback with no
+    # warning and no repair issue (it's expected, not a misconfiguration).
+    adapter._get_profile_obj = lambda: None  # type: ignore[attr-defined,method-assign]
+    assert adapter.get_profile_pixel_width(hass) is None
+    assert not any(
+        "does not expose media.width.pixels" in rec.message for rec in caplog.records
+    )
 
 
 async def test_get_connection_info(hass):  # type: ignore[no-untyped-def]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -293,3 +293,55 @@ async def test_config_flow_custom_line_width(hass):  # type: ignore[no-untyped-d
 
         assert result5["type"] == "create_entry"
         assert result5["data"][CONF_LINE_WIDTH] == 80
+
+
+async def test_config_flow_custom_codepage_and_custom_line_width(hass):  # type: ignore[no-untyped-def]
+    """Choosing BOTH custom codepage and custom width must chain, not drop the width.
+
+    Regression: the codepage step overwrote the custom-width sentinel with
+    DEFAULT_LINE_WIDTH, so the width prompt was skipped and the entry was
+    silently created with the default width.
+    """
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.settings_steps.is_valid_codepage_for_profile",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK}
+        )
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"], {CONF_HOST: "1.2.3.4", CONF_PORT: 9100}
+        )
+        # Select BOTH custom codepage AND custom line width.
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
+            {
+                CONF_CODEPAGE: "__custom__",
+                CONF_LINE_WIDTH: "__custom__",
+                CONF_DEFAULT_ALIGN: "left",
+                CONF_DEFAULT_CUT: "none",
+            },
+        )
+        assert result4["step_id"] == "custom_codepage"
+
+        # After the custom codepage, the flow must chain to custom width
+        # (not create the entry with the default width).
+        result5 = await hass.config_entries.flow.async_configure(
+            result4["flow_id"], {"custom_codepage": "CP932"}
+        )
+        assert result5["type"] == "form"
+        assert result5["step_id"] == "custom_line_width"
+
+        result6 = await hass.config_entries.flow.async_configure(
+            result5["flow_id"], {"custom_line_width": 80}
+        )
+        assert result6["type"] == "create_entry"
+        assert result6["data"][CONF_CODEPAGE] == "CP932"
+        assert result6["data"][CONF_LINE_WIDTH] == 80

--- a/tests/test_config_flow_bluetooth.py
+++ b/tests/test_config_flow_bluetooth.py
@@ -10,6 +10,9 @@ from custom_components.escpos_printer._config_flow.bluetooth_helpers import (
     _can_connect_bluetooth,
     _classify_bt_error,
 )
+from custom_components.escpos_printer._config_flow.bluetooth_steps import (
+    SECTION_BT_ADVANCED,
+)
 from custom_components.escpos_printer.config_flow import EscposConfigFlow
 from custom_components.escpos_printer.const import (
     CONF_BT_MAC,
@@ -397,14 +400,13 @@ class TestBluetoothImagingFilter:
 
 
 class TestBluetoothChannelHidden:
-    """The RFCOMM channel field is hidden by default (almost always 1)."""
+    """The RFCOMM channel is tucked into a collapsed Advanced section."""
 
     @pytest.mark.asyncio
-    async def test_channel_field_hidden_by_default(self, hass, mock_paired_devices):
+    async def test_channel_field_in_collapsed_section(self, hass, mock_paired_devices):
         flow = EscposConfigFlow()
         flow.hass = hass
-        # `show_advanced_options` reads from flow.context; default is False.
-        flow.context = {"source": "user", "show_advanced_options": False}
+        flow.context = {"source": "user"}
         flow._user_data = {CONF_CONNECTION_TYPE: CONNECTION_TYPE_BLUETOOTH}
         flow._paired_bt_devices = mock_paired_devices
 
@@ -415,26 +417,43 @@ class TestBluetoothChannelHidden:
         ):
             result = await flow.async_step_bluetooth_select()
 
-        schema_keys = {str(k) for k in result["data_schema"].schema}
-        assert "rfcomm_channel" not in schema_keys
+        schema = result["data_schema"].schema
+        top_level_keys = {str(k) for k in schema}
+        assert "rfcomm_channel" not in top_level_keys
+        assert SECTION_BT_ADVANCED in top_level_keys
+
+        advanced = next(v for k, v in schema.items() if str(k) == SECTION_BT_ADVANCED)
+        assert advanced.options["collapsed"] is True
+        assert "rfcomm_channel" in {str(k) for k in advanced.schema.schema}
 
     @pytest.mark.asyncio
-    async def test_channel_field_visible_with_advanced_options(self, hass, mock_paired_devices):
+    async def test_channel_from_advanced_section_reaches_probe(self, hass, mock_paired_devices):
+        """A channel submitted inside the section is used for the connect test."""
         flow = EscposConfigFlow()
         flow.hass = hass
-        flow.context = {"source": "user", "show_advanced_options": True}
         flow._user_data = {CONF_CONNECTION_TYPE: CONNECTION_TYPE_BLUETOOTH}
         flow._paired_bt_devices = mock_paired_devices
 
-        with patch(
-            "custom_components.escpos_printer._config_flow.bluetooth_steps."
-            "_list_paired_bluetooth_devices",
-            return_value=mock_paired_devices,
+        with (
+            patch(
+                "custom_components.escpos_printer._config_flow.bluetooth_steps."
+                "_can_connect_bluetooth",
+                return_value=(True, None, None),
+            ) as mock_connect,
+            patch.object(flow, "async_set_unique_id", return_value=None),
+            patch.object(flow, "_abort_if_unique_id_configured"),
+            patch.object(flow, "async_step_codepage", return_value={"type": "form"}),
         ):
-            result = await flow.async_step_bluetooth_select()
+            await flow.async_step_bluetooth_select(
+                {
+                    "bt_device": "AA:BB:CC:DD:EE:FF",
+                    "timeout": 4.0,
+                    "profile": "",
+                    SECTION_BT_ADVANCED: {CONF_RFCOMM_CHANNEL: 3},
+                }
+            )
 
-        schema_keys = {str(k) for k in result["data_schema"].schema}
-        assert "rfcomm_channel" in schema_keys
+        mock_connect.assert_called_once_with("AA:BB:CC:DD:EE:FF", 3, 4.0)
 
 
 class TestBluetoothChannelRetry:
@@ -444,7 +463,7 @@ class TestBluetoothChannelRetry:
     async def test_channel_refused_routes_to_retry_step(self, hass, mock_paired_devices):
         flow = EscposConfigFlow()
         flow.hass = hass
-        flow.context = {"source": "user", "show_advanced_options": False}
+        flow.context = {"source": "user"}
         flow._user_data = {CONF_CONNECTION_TYPE: CONNECTION_TYPE_BLUETOOTH}
         flow._paired_bt_devices = mock_paired_devices
 

--- a/tests/test_config_flow_options_and_duplicate.py
+++ b/tests/test_config_flow_options_and_duplicate.py
@@ -38,18 +38,23 @@ async def test_options_flow_update(hass):  # type: ignore[no-untyped-def]
     result = await hass.config_entries.options.async_init(entry.entry_id)
     assert result["type"] == "form"
 
-    # Submit options
-    result2 = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        {
-            CONF_TIMEOUT: 5.5,
-            CONF_CODEPAGE: "CP437",
-            CONF_DEFAULT_ALIGN: "center",
-            CONF_DEFAULT_CUT: "partial",
-            CONF_KEEPALIVE: True,
-            CONF_STATUS_INTERVAL: 30,
-        },
-    )
+    # Submit options. Saving schedules an automatic entry reload
+    # (OptionsFlowWithReload); with keepalive enabled the real setup would
+    # open a TCP connection to the printer, which the HA test harness
+    # rejects — patch the setup so the reload stays hermetic.
+    with patch("custom_components.escpos_printer.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_TIMEOUT: 5.5,
+                CONF_CODEPAGE: "CP437",
+                CONF_DEFAULT_ALIGN: "center",
+                CONF_DEFAULT_CUT: "partial",
+                CONF_KEEPALIVE: True,
+                CONF_STATUS_INTERVAL: 30,
+            },
+        )
+        await hass.async_block_till_done()
     assert result2["type"] == "create_entry"
     assert result2["data"][CONF_TIMEOUT] == 5.5
     assert result2["data"][CONF_DEFAULT_ALIGN] == "center"

--- a/tests/test_config_flow_options_and_duplicate.py
+++ b/tests/test_config_flow_options_and_duplicate.py
@@ -83,13 +83,18 @@ async def test_options_flow_allow_local_image_urls_roundtrips(hass):  # type: ig
     }
     assert schema_defaults.get(CONF_ALLOW_LOCAL_IMAGE_URLS) is False
 
-    result2 = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        {
-            CONF_TIMEOUT: 4.0,
-            CONF_ALLOW_LOCAL_IMAGE_URLS: True,
-        },
-    )
+    # Saving schedules an automatic entry reload (OptionsFlowWithReload);
+    # patch the setup so the reload can't leave a half-finished real setup
+    # (and its delayed Store writes) lingering past the end of the test.
+    with patch("custom_components.escpos_printer.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_TIMEOUT: 4.0,
+                CONF_ALLOW_LOCAL_IMAGE_URLS: True,
+            },
+        )
+        await hass.async_block_till_done()
     assert result2["type"] == "create_entry"
     assert result2["data"][CONF_ALLOW_LOCAL_IMAGE_URLS] is True
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -6,11 +6,14 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.escpos_printer.const import (
+    CONF_BT_MAC,
     CONF_CONNECTION_TYPE,
     CONF_IN_EP,
     CONF_OUT_EP,
     CONF_PRODUCT_ID,
+    CONF_RFCOMM_CHANNEL,
     CONF_VENDOR_ID,
+    CONNECTION_TYPE_BLUETOOTH,
     CONNECTION_TYPE_NETWORK,
     CONNECTION_TYPE_USB,
     DOMAIN,
@@ -35,7 +38,10 @@ async def test_diagnostics_network_entry(hass):  # type: ignore[no-untyped-def]
 
     diag = await async_get_config_entry_diagnostics(hass, entry)
 
-    assert diag["entry"]["title"] == "1.2.3.4:9100"
+    # Title is redacted: the default network title embeds host:port (and
+    # the BT title embeds the MAC), so it must not leak in a diagnostics
+    # download.
+    assert diag["entry"]["title"] == "**REDACTED**"
     # Host is redacted
     assert diag["entry"]["data"][CONF_HOST] == "**REDACTED**"
     assert diag["entry"]["data"][CONF_PORT] == 9100
@@ -81,6 +87,37 @@ async def test_diagnostics_usb_entry(hass):  # type: ignore[no-untyped-def]
     assert diag["runtime"]["product_id"] == "0x0E03"
 
 
+async def test_diagnostics_bluetooth_entry_redacts_mac(hass):  # type: ignore[no-untyped-def]
+    """A Bluetooth entry must be labelled bluetooth and have its MAC + title redacted.
+
+    Regression: the BT branch was missing (entries were mislabelled
+    ``network`` with a null host), and the MAC leaked via both the
+    ``bt_mac`` field and the entry title.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Bluetooth Printer AA:BB:CC:DD:EE:FF",
+        data={
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_BLUETOOTH,
+            CONF_BT_MAC: "AA:BB:CC:DD:EE:FF",
+            CONF_RFCOMM_CHANNEL: 1,
+        },
+        unique_id="bt:AA:BB:CC:DD:EE:FF",
+    )
+    # NOT calling async_setup (BT setup needs RFCOMM/D-Bus); the entry_data
+    # branch + redaction are exercised from the static data.
+    entry.add_to_hass(hass)
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    entry_data = diag["entry"]["data"]
+    assert entry_data[CONF_CONNECTION_TYPE] == CONNECTION_TYPE_BLUETOOTH
+    # MAC and title (which embeds the MAC) are redacted; channel is kept.
+    assert entry_data[CONF_BT_MAC] == "**REDACTED**"
+    assert diag["entry"]["title"] == "**REDACTED**"
+    assert entry_data[CONF_RFCOMM_CHANNEL] == 1
+
+
 async def test_diagnostics_without_runtime_data(hass):  # type: ignore[no-untyped-def]
     """Diagnostics must work even when runtime_data hasn't been set (e.g. setup failed)."""
     entry = MockConfigEntry(
@@ -94,8 +131,9 @@ async def test_diagnostics_without_runtime_data(hass):  # type: ignore[no-untype
 
     diag = await async_get_config_entry_diagnostics(hass, entry)
 
-    # Entry section is still populated from the static data
-    assert diag["entry"]["title"] == "1.2.3.4:9100"
+    # Entry section is still populated from the static data; the title
+    # (which embeds host:port) is redacted.
+    assert diag["entry"]["title"] == "**REDACTED**"
     assert diag["entry"]["data"][CONF_PORT] == 9100
     # Runtime section is empty because no adapter exists
     assert diag["runtime"] == {}

--- a/tests/test_manifest_usb_vids.py
+++ b/tests/test_manifest_usb_vids.py
@@ -1,0 +1,33 @@
+"""Guard: manifest.json USB discovery VIDs must cover THERMAL_PRINTER_VIDS.
+
+HA's USB discovery (manifest ``usb:`` matchers) and the config-flow
+auto-discovery (``const.THERMAL_PRINTER_VIDS``) must agree on which
+vendor IDs are thermal printers. They are maintained as two separate
+lists; this test fails if the manifest is missing any VID the code
+treats as a thermal printer (the two drifted once — 0x0FE6 was in
+const.py but not the manifest).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from custom_components.escpos_printer.const import THERMAL_PRINTER_VIDS
+
+_MANIFEST = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components"
+    / "escpos_printer"
+    / "manifest.json"
+)
+
+
+def test_manifest_usb_vids_cover_thermal_vids() -> None:
+    manifest = json.loads(_MANIFEST.read_text(encoding="utf-8"))
+    manifest_vids = {int(entry["vid"], 16) for entry in manifest.get("usb", [])}
+    missing = {f"0x{v:04X}" for v in THERMAL_PRINTER_VIDS if v not in manifest_vids}
+    assert not missing, (
+        f"manifest.json usb matchers are missing VIDs present in "
+        f"THERMAL_PRINTER_VIDS: {sorted(missing)}"
+    )

--- a/tests/test_optional_services_and_errors.py
+++ b/tests/test_optional_services_and_errors.py
@@ -64,8 +64,10 @@ async def test_print_image_url_download_error(hass, caplog):  # type: ignore[no-
 async def test_encoding_codepage_warning(hass, caplog):  # type: ignore[no-untyped-def]
     await _setup_entry(hass)
     fake = MagicMock()
-    # Cause _set_codepage to raise
-    fake._set_codepage.side_effect = RuntimeError("bad codepage")
+    # The per-call ``encoding`` override is applied via ``charcode`` (the
+    # python-escpos 3.x API). An unknown codepage raises and must warn —
+    # but the text must still print.
+    fake.charcode.side_effect = KeyError("XYZ")
     with patch("escpos.printer.Network", return_value=fake):
         await hass.services.async_call(
             DOMAIN,
@@ -73,7 +75,9 @@ async def test_encoding_codepage_warning(hass, caplog):  # type: ignore[no-untyp
             {"text": "Hello", "encoding": "XYZ"},
             blocking=True,
         )
+    fake.charcode.assert_any_call("XYZ")
     assert any("Unsupported encoding/codepage" in rec.message for rec in caplog.records)
+    fake.text.assert_called()
 
 
 async def test_print_barcode_service_calls_escpos(hass):  # type: ignore[no-untyped-def]

--- a/tests/test_options_flow_custom.py
+++ b/tests/test_options_flow_custom.py
@@ -120,10 +120,15 @@ async def test_options_flow_custom_line_width_valid(hass):  # type: ignore[no-un
     )
     assert result["step_id"] == "custom_line_width"
 
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={"custom_line_width": 64},
-    )
+    # Saving schedules an automatic entry reload (OptionsFlowWithReload);
+    # patch the setup so the reload can't leave a half-finished real setup
+    # (and its delayed Store writes) lingering past the end of the test.
+    with patch("custom_components.escpos_printer.async_setup_entry", return_value=True):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"custom_line_width": 64},
+        )
+        await hass.async_block_till_done()
     assert result["type"] == "create_entry"
     assert result["data"][CONF_LINE_WIDTH] == 64
 

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -1,0 +1,331 @@
+"""Regression tests for the full-codebase review fix batch.
+
+Each test pins a specific defect surfaced in the full-codebase review so
+it cannot silently regress:
+
+- C3: ``fallback_image`` template is rendered (was a dead Template object).
+- H1: a keepalive connection is invalidated after a failed operation.
+- H3: the decompression-bomb guard is enforced per-decode (no process-global).
+- M-ssrf: ``allow_local`` only lifts the port allowlist for private targets.
+- M-cancel: cleanup cut severs paper even when the default cut is "none".
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.template import Template
+import pytest
+
+from custom_components.escpos_printer.const import ATTR_FALLBACK_IMAGE, ATTR_IMAGE
+from custom_components.escpos_printer.image_sources import extract_image_kwargs
+from custom_components.escpos_printer.printer import (
+    NetworkPrinterConfig,
+    create_printer_adapter,
+)
+from custom_components.escpos_printer.printer.mapping_utils import cleanup_cut
+
+
+def _network_adapter():  # type: ignore[no-untyped-def]
+    return create_printer_adapter(
+        NetworkPrinterConfig(host="1.2.3.4", port=9100, timeout=4.0)
+    )
+
+
+# ---------------------------------------------------------------------------
+# C3: fallback_image must be rendered to a string, not left a Template object.
+# ---------------------------------------------------------------------------
+
+
+async def test_fallback_image_template_is_rendered(hass):  # type: ignore[no-untyped-def]
+    data = {
+        ATTR_IMAGE: "camera.front",
+        ATTR_FALLBACK_IMAGE: Template("http://host/fallback.png", hass),
+    }
+    out = extract_image_kwargs(data, {}, prefix="", hass=hass)
+    assert out[ATTR_FALLBACK_IMAGE] == "http://host/fallback.png"
+    assert isinstance(out[ATTR_FALLBACK_IMAGE], str)
+
+
+async def test_fallback_image_jinja_is_evaluated(hass):  # type: ignore[no-untyped-def]
+    data = {
+        ATTR_IMAGE: "camera.front",
+        ATTR_FALLBACK_IMAGE: Template("http://host/{{ 1 + 1 }}.png", hass),
+    }
+    out = extract_image_kwargs(data, {}, prefix="", hass=hass)
+    assert out[ATTR_FALLBACK_IMAGE] == "http://host/2.png"
+
+
+# ---------------------------------------------------------------------------
+# H1: a failed keepalive operation must drop the (possibly dead) connection.
+# ---------------------------------------------------------------------------
+
+
+async def test_release_printer_invalidates_keepalive_on_failure(hass):  # type: ignore[no-untyped-def]
+    adapter = _network_adapter()
+    adapter._keepalive = True
+    fake = MagicMock()
+    adapter._printer = fake
+
+    await adapter._release_printer(hass, fake, owned=False, failed=True)
+
+    assert adapter._printer is None
+    fake.close.assert_called_once()
+
+
+async def test_release_printer_keeps_keepalive_on_success(hass):  # type: ignore[no-untyped-def]
+    adapter = _network_adapter()
+    adapter._keepalive = True
+    fake = MagicMock()
+    adapter._printer = fake
+
+    await adapter._release_printer(hass, fake, owned=False, failed=False)
+
+    assert adapter._printer is fake
+    fake.close.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# H3: decompression-bomb guard is per-decode (does not touch PIL's global).
+# ---------------------------------------------------------------------------
+
+
+def test_image_processor_rejects_oversized_image():
+    import io
+
+    from PIL import Image
+    import PIL.Image
+
+    from custom_components.escpos_printer.printer.image_processor import (
+        ImageProcessOptions,
+        process_image_from_bytes,
+    )
+
+    original_global = PIL.Image.MAX_IMAGE_PIXELS
+    # 5000x5000 = 25M px: above our 20M cap but below Pillow's ~89M default,
+    # so our explicit per-decode guard — not Pillow's global — must reject
+    # it. A solid image compresses to a few KB so the fixture is cheap.
+    buf = io.BytesIO()
+    Image.new("L", (5000, 5000), color=255).save(buf, format="PNG")
+    with pytest.raises(ValueError, match="exceeds the maximum"):
+        process_image_from_bytes(buf.getvalue(), ImageProcessOptions(width=100))
+    # The integration must not have mutated Pillow's process-global limit.
+    assert original_global == PIL.Image.MAX_IMAGE_PIXELS
+
+
+# ---------------------------------------------------------------------------
+# M-ssrf: allow_local only lifts the port allowlist for private targets.
+# ---------------------------------------------------------------------------
+
+
+async def test_allow_local_rejects_public_nonstandard_port(hass):  # type: ignore[no-untyped-def]
+    from custom_components.escpos_printer import security
+
+    with patch.object(security, "_resolve_hostname_sync", return_value=["93.184.216.34"]):
+        with pytest.raises(HomeAssistantError, match="private/LAN"):
+            await security.validate_image_url_and_resolve(
+                hass, "http://example.com:8080/x.png", allow_local=True
+            )
+
+
+async def test_allow_local_permits_private_nonstandard_port(hass):  # type: ignore[no-untyped-def]
+    from custom_components.escpos_printer import security
+
+    with patch.object(security, "_resolve_hostname_sync", return_value=["192.168.1.50"]):
+        _url, addrs = await security.validate_image_url_and_resolve(
+            hass, "http://printer.local:8080/x.png", allow_local=True
+        )
+    assert addrs == ["192.168.1.50"]
+
+
+# ---------------------------------------------------------------------------
+# M-cancel: cleanup cut severs paper even when the default cut is "none".
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_cut_forces_full_for_none():
+    assert cleanup_cut("none") == "full"
+    assert cleanup_cut(None) == "full"
+    assert cleanup_cut("") == "full"
+
+
+def test_cleanup_cut_honours_explicit_mode():
+    assert cleanup_cut("partial") == "partial"
+    assert cleanup_cut("full") == "full"
+
+
+# ---------------------------------------------------------------------------
+# C2: an options change reloads the entry so it takes effect immediately.
+# The options flow extends OptionsFlowWithReload, which HA guarantees to
+# reload the entry on a (changed) options save.
+# ---------------------------------------------------------------------------
+
+
+def test_options_flow_uses_reload_base():
+    from homeassistant import config_entries
+
+    from custom_components.escpos_printer._config_flow.options_flow import (
+        EscposOptionsFlowHandler,
+    )
+
+    assert issubclass(EscposOptionsFlowHandler, config_entries.OptionsFlowWithReload)
+
+
+# ---------------------------------------------------------------------------
+# H6: a printer that's unreachable at setup raises ConfigEntryNotReady
+# (retry-with-backoff) instead of hard-failing the entry.
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_entry_raises_config_entry_not_ready(hass):  # type: ignore[no-untyped-def]
+    from homeassistant.const import CONF_HOST, CONF_PORT
+    from homeassistant.exceptions import ConfigEntryNotReady
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.escpos_printer import async_setup_entry
+    from custom_components.escpos_printer.const import CONF_KEEPALIVE, DOMAIN
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: 9100},
+        # keepalive forces an eager connect at start() — the only blocking
+        # work that can fail and should trigger ConfigEntryNotReady.
+        options={CONF_KEEPALIVE: True},
+    )
+    entry.add_to_hass(hass)
+
+    with patch("escpos.printer.Network", side_effect=OSError("connection refused")):
+        with pytest.raises(ConfigEntryNotReady):
+            await async_setup_entry(hass, entry)
+
+
+# ---------------------------------------------------------------------------
+# H9: a multi-target call attempts every printer and aggregates failures.
+# ---------------------------------------------------------------------------
+
+
+async def test_for_each_target_aggregates_partial_failure(hass):  # type: ignore[no-untyped-def]
+    from custom_components.escpos_printer.services import _handler_utils as hu
+
+    e1 = MagicMock(entry_id="e1", title="Printer A")
+    e2 = MagicMock(entry_id="e2", title="Printer B")
+    call = MagicMock()
+    call.hass = hass
+
+    attempted: list[str] = []
+
+    async def _body(entry, _adapter, _defaults, _config):  # type: ignore[no-untyped-def]
+        attempted.append(entry.entry_id)
+        if entry.entry_id == "e1":
+            raise HomeAssistantError("printer offline")
+
+    with (
+        patch.object(hu, "_async_get_target_entries", AsyncMock(return_value=[e1, e2])),
+        patch.object(
+            hu, "_get_adapter_and_defaults", return_value=(MagicMock(), {}, MagicMock())
+        ),
+    ):
+        with pytest.raises(HomeAssistantError, match="Printer A"):
+            await hu._for_each_target(call, "print_text", _body)
+
+    # The second target is still attempted even though the first failed.
+    assert attempted == ["e1", "e2"]
+
+
+async def test_for_each_target_single_target_propagates_exact_error(hass):  # type: ignore[no-untyped-def]
+    from homeassistant.exceptions import ServiceValidationError
+
+    from custom_components.escpos_printer.services import _handler_utils as hu
+
+    e1 = MagicMock(entry_id="e1", title="Printer A")
+    call = MagicMock()
+    call.hass = hass
+
+    async def _body(_entry, _adapter, _defaults, _config):  # type: ignore[no-untyped-def]
+        raise ServiceValidationError("bad value")
+
+    with (
+        patch.object(hu, "_async_get_target_entries", AsyncMock(return_value=[e1])),
+        patch.object(
+            hu, "_get_adapter_and_defaults", return_value=(MagicMock(), {}, MagicMock())
+        ),
+    ):
+        # Single-target: the original ServiceValidationError (with its
+        # translation/status context) must propagate untouched.
+        with pytest.raises(ServiceValidationError):
+            await hu._for_each_target(call, "print_text", _body)
+
+
+async def test_for_each_target_reraises_unauthorized_in_multi(hass):  # type: ignore[no-untyped-def]
+    """A permission denial on a broadcast must propagate as Unauthorized.
+
+    (Review S-M3: the aggregate `except Exception` must not downgrade an
+    auth failure into a generic "N of M failed" string.)
+    """
+    from homeassistant.exceptions import Unauthorized
+
+    from custom_components.escpos_printer.services import _handler_utils as hu
+
+    e1 = MagicMock(entry_id="e1", title="Printer A")
+    e2 = MagicMock(entry_id="e2", title="Printer B")
+    call = MagicMock()
+    call.hass = hass
+
+    async def _body(entry, _adapter, _defaults, _config):  # type: ignore[no-untyped-def]
+        if entry.entry_id == "e1":
+            raise Unauthorized
+
+    with (
+        patch.object(hu, "_async_get_target_entries", AsyncMock(return_value=[e1, e2])),
+        patch.object(
+            hu, "_get_adapter_and_defaults", return_value=(MagicMock(), {}, MagicMock())
+        ),
+    ):
+        with pytest.raises(Unauthorized):
+            await hu._for_each_target(call, "print_image", _body)
+
+
+# ---------------------------------------------------------------------------
+# auto_resize: the per-decode cap is raised (but still bounded) when the
+# caller opts into downscaling. (Review: bomb-guard regression.)
+# ---------------------------------------------------------------------------
+
+
+def test_auto_resize_permits_above_base_cap():
+    import io
+
+    from PIL import Image
+
+    from custom_components.escpos_printer.printer.image_processor import (
+        ImageProcessOptions,
+        process_image_from_bytes,
+    )
+
+    buf = io.BytesIO()
+    Image.new("L", (5000, 5000), color=255).save(buf, format="PNG")  # 25M px
+    # 25M > the 20M base cap, but auto_resize raises the ceiling to 40M and
+    # downscales — so it must succeed, not raise.
+    out = process_image_from_bytes(
+        buf.getvalue(), ImageProcessOptions(width=384, auto_resize=True)
+    )
+    assert out.width <= 384
+
+
+def test_auto_resize_still_bounded():
+    import io
+
+    from PIL import Image
+
+    from custom_components.escpos_printer.printer.image_processor import (
+        ImageProcessOptions,
+        process_image_from_bytes,
+    )
+
+    buf = io.BytesIO()
+    Image.new("L", (7000, 7000), color=255).save(buf, format="PNG")  # 49M px
+    # Even with auto_resize the ceiling (40M) is enforced before load().
+    with pytest.raises(ValueError, match="exceeds the maximum"):
+        process_image_from_bytes(
+            buf.getvalue(), ImageProcessOptions(width=384, auto_resize=True)
+        )

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -88,6 +88,17 @@ class TestBarcodeDataValidation:
         with pytest.raises(HomeAssistantError, match="exceeds maximum"):
             validate_barcode_data("x" * (MAX_BARCODE_LENGTH + 1), "CODE128")
 
+    @pytest.mark.parametrize(
+        "payload",
+        ["12345\x00\x1bp", "ab\x1dcd", "foo\x00bar", "x\x1bX", "\x10dle"],
+    )
+    def test_validate_barcode_data_rejects_control_bytes(self, payload):  # type: ignore[no-untyped-def]
+        # ESC/GS/NUL/C0 bytes could terminate the GS k barcode frame early
+        # and inject raw ESC/POS commands (cash-drawer kick, codepage
+        # change). They must be rejected, not stripped.
+        with pytest.raises(HomeAssistantError, match="control characters"):
+            validate_barcode_data(payload, "CODE128")
+
 
 # ---------------------------------------------------------------------------
 # URL validation (legacy + Phase 3 T-C1 hardening).

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "ha-escpos-thermal-printer"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "dbus-fast" },


### PR DESCRIPTION
## Summary

Fixes the Critical/High/Medium findings from a full-codebase review, plus a follow-up multi-dimensional review of the fixes themselves. No new features — bug fixes, security hardening, and metadata/doc accuracy. Bumps the version to **0.7.3**.

All printer I/O, locking, and HA conventions are preserved. **873 unit + 67 integration tests pass; ruff and mypy clean; version + requirements sync green.**

## Critical / High

- **Configured profile was never applied + image width wrong on nearly every install.** `escpos.profile` was removed upstream (moved to `escpos.capabilities`); the swallowed `ImportError` dropped the profile at connect time, and width was read from the never-populated live connection. Now read from the configured profile object; the auto/default profile falls back to 512px silently, a named profile lacking width warns + files a Repairs issue.
- **Options changes apply without a restart** (`OptionsFlowWithReload`); codepage/profile can be reset to "auto".
- **`fallback_image` works** (was a dead `Template` object the resolver rejected).
- **Keepalive connection is dropped after a failed op** — one transient error no longer bricks printing until reload.
- **`print_text` `encoding` override** uses `charcode` (was the removed `_set_codepage` → mojibake); it's a python-escpos codepage name, now documented.
- **`ConfigEntryNotReady`** retry/backoff when the printer is off at boot.
- **Multi-printer calls attempt every target** and report an aggregate failure; `Unauthorized`/`ServiceValidationError` fail closed.
- **Pillow's process-global decompression-bomb cap is no longer lowered** (enforced per-decode; 40 M ceiling under `auto_resize`) — stops perturbing other HA Pillow consumers.
- **notify `print_message` enforces the caller's entity ACL** (context captured before any `await`, closing a TOCTOU).
- **Barcode data with ESC/GS/NUL/C0 bytes is rejected** (ESC/POS command injection).
- **"Allow local image URLs" no longer opens a public-port scan oracle** (non-standard ports only for private targets).

## Medium

Config-flow custom-codepage+width chain; network unique-id normalization + port range; barcode `align` honored; per-service `feed` defaults; `beep` UI defaults (2/4); diagnostics Bluetooth branch + MAC/host/title redaction; status-probe TOCTOU; `stop()` closes on the executor under the lock; cancel-cleanup cut; `iot_class` → `local_polling`; USB VID drift fixed + sync test; doc/CHANGELOG/translation accuracy (incl. removing the stale `services` translation block so services.yaml is authoritative, `country` removed from hacs.json, feed ranges, blueprints 8→13, calibration_print).

## Architecture / Best practices

`cleanup_cut` relocated to `mapping_utils.py` (cut-policy's proper home); `_shared_print_config` DRYs the three per-transport config blocks; the `failed`-flag is threaded through the `_PrinterHost` Protocol; options flow modernized to `OptionsFlowWithReload`.

## Tests

New `tests/test_review_fixes.py` and `tests/test_manifest_usb_vids.py`, plus targeted additions for barcode control-byte rejection, Bluetooth diagnostics redaction, multi-target `Unauthorized` re-raise, the `auto_resize` ceiling, the custom-codepage+width chain, and `ConfigEntryNotReady`.

See `CHANGELOG.md` `[0.7.3]` for the full user-facing list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)