### PR TITLE
Fix 0.7.3 profile KeyError breaking all prints + image-URL fetch identity (0.7.4)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-config-flow.yml
+++ b/.github/ISSUE_TEMPLATE/bug-config-flow.yml
@@ -69,5 +69,5 @@ body:
     id: logs
     attributes:
       label: Relevant log lines
-      description: Enable debug logging (`logger.logs.custom_components.escpos_printer: debug`), reproduce, paste here.
+      description: "Enable debug logging (`logger.logs.custom_components.escpos_printer: debug`), reproduce, paste here."
       render: text

--- a/.github/ISSUE_TEMPLATE/bug-transport.yml
+++ b/.github/ISSUE_TEMPLATE/bug-transport.yml
@@ -65,7 +65,7 @@ body:
     id: logs
     attributes:
       label: Relevant log lines
-      description: Enable debug logging via configuration.yaml (`logger.logs.custom_components.escpos_printer: debug`), reproduce, and paste the matching log block here.
+      description: "Enable debug logging via configuration.yaml (`logger.logs.custom_components.escpos_printer: debug`), reproduce, and paste the matching log block here."
       render: text
 
   - type: textarea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-06-12
+
+### Fixed
+
+- **0.7.3 broke every print on entries with a configured printer
+  profile** (`Service … failed: <escpos.capabilities.TMT20IIProfile
+  object at 0x…>`). The 0.7.3 profile fix passed the *resolved profile
+  object* into the python-escpos printer constructors, but
+  `Escpos.__init__` re-runs that kwarg through `get_profile()`, which
+  only accepts a profile *name* — the object fell through to a dict
+  lookup keyed by the object itself and every connect raised `KeyError`.
+  The adapters now hand over the validated profile name; an unknown
+  profile still degrades to the library default with a debug log. The
+  test-suite escpos fakes now mirror the real constructor's profile
+  round-trip so this class of bug can't slip through again.
+- **URL image fetches identify as Home Assistant again.** The
+  SSRF-hardened per-request fetch session sent aiohttp's default
+  `Python/3.x aiohttp/…` User-Agent, which CDN/WAF bot rules
+  (WordPress/Photon, Cloudflare) often answer with an HTML block page
+  served as 200 — surfacing as `cannot identify image file`. The session
+  now sends HA's own User-Agent (as the pooled clients did pre-0.7) plus
+  an Accept header biased toward the decodable image formats.
+- **Undecodable image bytes now produce an actionable error.** Instead
+  of Pillow's bare `cannot identify image file <_io.BytesIO …>`, the
+  error reports the declared content type, payload size, and the leading
+  bytes — and calls out the likely HTML-error/bot-block page when the
+  body looks like HTML.
+
 ## [0.7.3] - 2026-06-12
 
 ### Fixed

--- a/custom_components/escpos_printer/image_sources.py
+++ b/custom_components/escpos_printer/image_sources.py
@@ -30,6 +30,7 @@ import aiohttp
 from homeassistant.auth.permissions.const import POLICY_READ
 from homeassistant.core import Context
 from homeassistant.exceptions import HomeAssistantError, Unauthorized
+from homeassistant.helpers.aiohttp_client import SERVER_SOFTWARE
 from homeassistant.helpers.template import Template
 
 from .const import (
@@ -78,6 +79,21 @@ _MAX_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024
 # cap, which is the real DoS axis.
 _MAX_BYTES_AUTO_RESIZE = MAX_IMAGE_SIZE_MB * 1024 * 1024 * 4
 _MAX_REDIRECTS = 5
+
+# Sent on every URL fetch. The bare per-request ``ClientSession`` (S-H1
+# pinning) otherwise advertises aiohttp's default ``Python/3.x aiohttp/…``
+# User-Agent, which CDN/WAF bot rules (WordPress/Photon, Cloudflare)
+# routinely answer with an HTML block page served as 200 — surfacing
+# downstream as "cannot identify image file". Pre-0.7.x fetches went
+# through HA's pooled clients and sent HA's own UA, so this restores the
+# identity that worked. The Accept header biases content negotiation
+# toward formats in the image-processor decoder allowlist (notably it
+# does not advertise AVIF, whose decode support depends on the optional
+# ``pillow-heif``).
+_FETCH_HEADERS: dict[str, str] = {
+    "User-Agent": SERVER_SOFTWARE,
+    "Accept": "image/jpeg,image/png,image/gif,image/webp,image/*;q=0.9,*/*;q=0.5",
+}
 
 # Public sentinel strings returned in the optional content-type hint slot
 # so callers / tests can rely on stable identifiers regardless of the
@@ -223,7 +239,7 @@ async def _resolve_camera(
     _LOGGER.debug("Fetching camera snapshot: %s", entity_id)
     try:
         image = await async_get_image(hass, entity_id, timeout=_ENTITY_FETCH_TIMEOUT_SECONDS)
-    except (HomeAssistantError, Unauthorized):
+    except HomeAssistantError, Unauthorized:
         raise
     except Exception as exc:
         raise HomeAssistantError(
@@ -253,7 +269,7 @@ async def _resolve_image_entity(
     _LOGGER.debug("Fetching image entity: %s", entity_id)
     try:
         image = await async_get_image(hass, entity_id, timeout=_ENTITY_FETCH_TIMEOUT_SECONDS)
-    except (HomeAssistantError, Unauthorized):
+    except HomeAssistantError, Unauthorized:
         raise
     except Exception as exc:
         raise HomeAssistantError(
@@ -282,7 +298,7 @@ def _check_content_length(headers: Mapping[str, str], max_bytes: int) -> None:
         return
     try:
         size = int(raw)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return
     if size > max_bytes:
         raise HomeAssistantError(
@@ -372,7 +388,7 @@ def _build_pinned_session(hostname: str, addresses: list[str]) -> aiohttp.Client
     """
     resolver = _StaticResolver(hostname, addresses)
     connector = aiohttp.TCPConnector(resolver=resolver, force_close=True)
-    return aiohttp.ClientSession(connector=connector)
+    return aiohttp.ClientSession(connector=connector, headers=_FETCH_HEADERS)
 
 
 async def _resolve_http_aiohttp(

--- a/custom_components/escpos_printer/manifest.json
+++ b/custom_components/escpos_printer/manifest.json
@@ -116,5 +116,5 @@
       "description": "*pos*"
     }
   ],
-  "version": "0.7.3"
+  "version": "0.7.4"
 }

--- a/custom_components/escpos_printer/printer/base_adapter.py
+++ b/custom_components/escpos_printer/printer/base_adapter.py
@@ -349,6 +349,24 @@ class EscposPrinterAdapterBase(
                 )
         return None
 
+    def _profile_for_constructor(self) -> str | None:
+        """Profile kwarg for python-escpos printer constructors.
+
+        Must be the profile *name*, not the resolved object:
+        ``Escpos.__init__`` runs the kwarg through
+        ``capabilities.get_profile()``, whose isinstance fast-path only
+        accepts instances of the library's *default* profile class. A
+        specific profile instance (e.g. ``TMT20IIProfile``) falls through
+        to a dict lookup keyed by the object itself, so every connect
+        dies with ``KeyError: <...TMT20IIProfile object...>``. Validating
+        via :meth:`_get_profile_obj` first keeps the old behaviour for
+        unknown profiles — degrade to the library default with a debug
+        log instead of raising at connect time.
+        """
+        if self._get_profile_obj() is not None:
+            return self._config.profile
+        return None
+
     def get_profile_pixel_width(self, hass: HomeAssistant | None = None) -> int | None:
         """Return the printer profile's max pixel width (cached).
 
@@ -374,7 +392,7 @@ class EscposPrinterAdapterBase(
                 data = profile_obj.profile_data["media"]["width"]["pixels"]
                 if isinstance(data, (int, float)):
                     width = int(data)
-            except (AttributeError, KeyError, TypeError, ValueError):
+            except AttributeError, KeyError, TypeError, ValueError:
                 width = None
         self._cached_profile_width = width
         self._profile_width_lookup_done = True
@@ -501,7 +519,7 @@ class EscposPrinterAdapterBase(
                     await _print_prepared_under_lock(hass, printer, prepared)
                     await self._apply_cut_and_feed(hass, printer, cut, feed)
                     failed = False
-                except (asyncio.CancelledError, Exception):  # pragma: no cover (T-L4)
+                except asyncio.CancelledError, Exception:  # pragma: no cover (T-L4)
                     # S-M3: shield the cleanup so a second cancellation
                     # mid-flush doesn't leave paper half-printed. The
                     # suppress() catches Exception only — CancelledError
@@ -517,9 +535,7 @@ class EscposPrinterAdapterBase(
                     with contextlib.suppress(Exception):
                         await asyncio.shield(
                             asyncio.ensure_future(
-                                self._apply_cut_and_feed(
-                                    hass, printer, cleanup_cut(cut), feed or 1
-                                )
+                                self._apply_cut_and_feed(hass, printer, cleanup_cut(cut), feed or 1)
                             )
                         )
                     raise

--- a/custom_components/escpos_printer/printer/bluetooth_adapter.py
+++ b/custom_components/escpos_printer/printer/bluetooth_adapter.py
@@ -59,7 +59,7 @@ class BluetoothPrinterAdapter(EscposPrinterAdapterBase):
 
     def _connect(self) -> Any:
         """Open an RFCOMM transport and wrap it in a python-escpos printer."""
-        profile_obj = self._get_profile_obj()
+        profile_name = self._profile_for_constructor()
         last_exc: Exception | None = None
         for attempt in range(self._CONNECT_RETRIES + 1):
             try:
@@ -94,7 +94,7 @@ class BluetoothPrinterAdapter(EscposPrinterAdapterBase):
                 time.sleep(self._CONNECT_RETRY_DELAY_S)
                 continue
             else:
-                return make_bluetooth_escpos(transport, profile_obj)
+                return make_bluetooth_escpos(transport, profile_name)
         # Loop only exits via return or re-raise above. This line is
         # defensive: if a future refactor changes a `raise` to `break`,
         # the assert fails loudly instead of silently passing `None` to
@@ -116,6 +116,7 @@ class BluetoothPrinterAdapter(EscposPrinterAdapterBase):
         We skip the tick if a print operation currently holds the lock and
         let the next print/tick refresh status.
         """
+
         def _probe() -> tuple[bool, str | None, int | None, int | None]:
             start = time.perf_counter()
             try:

--- a/custom_components/escpos_printer/printer/image_operations.py
+++ b/custom_components/escpos_printer/printer/image_operations.py
@@ -14,6 +14,7 @@ import logging
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from homeassistant.exceptions import HomeAssistantError
+from PIL import UnidentifiedImageError
 
 from ..const import (
     DEFAULT_CUT,
@@ -31,6 +32,7 @@ from ..security import (
 )
 from ._host import _PrinterHost
 from .image_processor import (
+    _DECODER_ALLOWLIST,
     FALLBACK_PROFILE_WIDTH,
     ImageProcessOptions,
     process_image_from_bytes,
@@ -133,7 +135,7 @@ async def prepare_image_for_print(
     )
     allow_local = bool(getattr(host, "allow_local_image_urls", False))
     try:
-        raw, _content_type = await _resolve_with_retry(
+        raw, content_type = await _resolve_with_retry(
             hass,
             image,
             context=context,
@@ -141,7 +143,7 @@ async def prepare_image_for_print(
             fallback=fallback_image,
             allow_local=allow_local,
         )
-        img_obj = await _process_bytes(hass, raw, process_opts)
+        img_obj = await _process_bytes(hass, raw, process_opts, content_type=content_type)
         raw_len = len(raw)
         del raw
 
@@ -358,9 +360,7 @@ class ImageOperationsMixin:
                         stats.total_failures += 1
                         stats.last_error_class = type(err).__name__
                     with contextlib.suppress(Exception):
-                        await self._apply_cut_and_feed(
-                            hass, printer, cleanup_cut(cut), feed or 1
-                        )
+                        await self._apply_cut_and_feed(hass, printer, cleanup_cut(cut), feed or 1)
                     raise
             finally:
                 await self._release_printer(hass, printer, owned=owned, failed=failed)
@@ -375,11 +375,43 @@ class ImageOperationsMixin:
 # ---------------------------------------------------------------------------
 
 
-async def _process_bytes(hass: HomeAssistant, raw: bytes, opts: ImageProcessOptions) -> Image.Image:
+def _describe_undecodable(raw: bytes, content_type: str | None) -> str:
+    """Build an actionable error for bytes PIL could not identify.
+
+    Pillow's own ``UnidentifiedImageError`` text ("cannot identify image
+    file <_io.BytesIO …>") tells the user nothing about *what* came back.
+    The usual culprit for a URL source is a CDN/WAF answering with an
+    HTML error or block page served as 200, so surface the declared
+    content type and a bounded sniff of the leading bytes.
+    """
+    sniff = bytes(raw[:16])
+    looks_html = sniff.lstrip()[:1] == b"<"
+    detail = f"content-type {content_type!r}, {len(raw)} bytes, starts with {sniff!r}"
+    hint = (
+        " — the server appears to have returned an HTML page (error/bot-block) instead of the image"
+        if looks_html or (content_type or "").lower().startswith("text/")
+        else ""
+    )
+    return (
+        f"Source did not return a decodable image ({detail}){hint}. "
+        f"Supported formats: {', '.join(_DECODER_ALLOWLIST)}."
+    )
+
+
+async def _process_bytes(
+    hass: HomeAssistant,
+    raw: bytes,
+    opts: ImageProcessOptions,
+    *,
+    content_type: str | None = None,
+) -> Image.Image:
     """Run ``process_image_from_bytes`` on an executor thread."""
 
     def _go() -> Image.Image:
-        return process_image_from_bytes(raw, opts)
+        try:
+            return process_image_from_bytes(raw, opts)
+        except UnidentifiedImageError as exc:
+            raise HomeAssistantError(_describe_undecodable(raw, content_type)) from exc
 
     return await hass.async_add_executor_job(_go)
 

--- a/custom_components/escpos_printer/printer/network_adapter.py
+++ b/custom_components/escpos_printer/printer/network_adapter.py
@@ -33,12 +33,11 @@ class NetworkPrinterAdapter(EscposPrinterAdapterBase):
     def _connect(self) -> Any:
         """Create and return a network printer connection."""
         network_class = _get_network_printer()
-        profile_obj = self._get_profile_obj()
         return network_class(
             self._network_config.host,
             port=self._network_config.port,
             timeout=self._network_config.timeout,
-            profile=profile_obj,
+            profile=self._profile_for_constructor(),
         )
 
     async def _status_check(self, hass: HomeAssistant) -> None:
@@ -51,6 +50,7 @@ class NetworkPrinterAdapter(EscposPrinterAdapterBase):
         until the print completes — strictly better than corrupting an
         active job.
         """
+
         def _probe() -> tuple[bool, str | None, int | None]:
             start = time.perf_counter()
             try:

--- a/custom_components/escpos_printer/printer/usb_adapter.py
+++ b/custom_components/escpos_printer/printer/usb_adapter.py
@@ -37,7 +37,7 @@ class UsbPrinterAdapter(EscposPrinterAdapterBase):
     def _connect(self) -> Any:
         """Create and return a USB printer connection."""
         usb_class = _get_usb_printer()
-        profile_obj = self._get_profile_obj()
+        profile_name = self._profile_for_constructor()
 
         def _is_retryable(exc: Exception) -> bool:
             try:
@@ -79,7 +79,7 @@ class UsbPrinterAdapter(EscposPrinterAdapterBase):
                     timeout=int(self._usb_config.timeout * 1000),  # USB timeout in milliseconds
                     in_ep=self._usb_config.in_ep,
                     out_ep=self._usb_config.out_ep,
-                    profile=profile_obj,
+                    profile=profile_name,
                 )
             except Exception as exc:
                 last_exc = exc
@@ -118,6 +118,7 @@ class UsbPrinterAdapter(EscposPrinterAdapterBase):
         configurations; the cost of a stale status reading is strictly
         lower than the cost of corrupting an active print.
         """
+
         def _probe() -> tuple[bool, str | None, int | None]:
             start = time.perf_counter()
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-escpos-thermal-printer"
-version = "0.7.3"
+version = "0.7.4"
 description = "Network thermal printer integration for Home Assistant using ESC/POS protocol"
 readme = "README.md"
 requires-python = ">=3.14.2"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,15 @@ def fake_escpos_module(request: Any, monkeypatch: pytest.MonkeyPatch) -> Generat
     if request.node.get_closest_marker("integration"):
         yield
         return
+    # Import the REAL capabilities module before installing the fake
+    # package: profile resolution must behave exactly like production
+    # (``Escpos.__init__`` round-trips the profile kwarg through
+    # ``get_profile()``, which only accepts a *name* — passing the
+    # resolved profile object broke every connect in 0.7.3, and the
+    # all-fake escpos hid it by making ``_get_profile_obj`` silently
+    # return None in unit tests).
+    import escpos.capabilities as real_capabilities
+
     escpos = types.ModuleType("escpos")
     printer = types.ModuleType("escpos.printer")
     escpos_pkg = types.ModuleType("escpos.escpos")
@@ -73,8 +82,10 @@ def fake_escpos_module(request: Any, monkeypatch: pytest.MonkeyPatch) -> Generat
             pass
 
     class _FakeNetwork(_FakeEscposCommon):
-        def __init__(self, *_: Any, **__: Any) -> None:
-            pass
+        def __init__(self, *_: Any, profile: Any = None, **__: Any) -> None:
+            # Mirror real Escpos.__init__: the profile kwarg must be a
+            # name (or default-class instance) acceptable to get_profile.
+            self.profile = real_capabilities.get_profile(profile)
 
     class _FakeUsb(_FakeEscposCommon):
         def __init__(
@@ -92,17 +103,20 @@ def fake_escpos_module(request: Any, monkeypatch: pytest.MonkeyPatch) -> Generat
             self.timeout = timeout
             self.in_ep = in_ep
             self.out_ep = out_ep
-            self.profile = profile
+            self.profile = real_capabilities.get_profile(profile)
 
     class _FakeEscposBase(_FakeEscposCommon):
         def __init__(self, profile: Any = None, **__: Any) -> None:
-            self.profile = profile
+            self.profile = real_capabilities.get_profile(profile)
 
     printer.Network = _FakeNetwork  # type: ignore[attr-defined]
     printer.Usb = _FakeUsb  # type: ignore[attr-defined]
     escpos.printer = printer  # type: ignore[attr-defined]
     escpos_pkg.Escpos = _FakeEscposBase  # type: ignore[attr-defined]
     escpos.escpos = escpos_pkg  # type: ignore[attr-defined]
+    # Keep the real capabilities reachable through the fake package so
+    # ``from escpos.capabilities import get_profile`` works in unit tests.
+    escpos.capabilities = real_capabilities  # type: ignore[attr-defined]
 
     # Use monkeypatch.setitem so each test's stub is automatically reverted at
     # teardown. Previously this used sys.modules.setdefault which never cleaned
@@ -111,6 +125,7 @@ def fake_escpos_module(request: Any, monkeypatch: pytest.MonkeyPatch) -> Generat
     monkeypatch.setitem(sys.modules, "escpos", escpos)
     monkeypatch.setitem(sys.modules, "escpos.printer", printer)
     monkeypatch.setitem(sys.modules, "escpos.escpos", escpos_pkg)
+    monkeypatch.setitem(sys.modules, "escpos.capabilities", real_capabilities)
 
     # The Bluetooth subclass is cached at module scope; invalidate it so the
     # next make_bluetooth_escpos call resolves the (just-installed) fake base.

--- a/tests/test_adapter_profile_roundtrip.py
+++ b/tests/test_adapter_profile_roundtrip.py
@@ -1,0 +1,92 @@
+"""Regression tests: the profile kwarg must survive python-escpos's round-trip.
+
+0.7.3 passed the *resolved profile object* into the printer constructors.
+``Escpos.__init__`` re-runs that kwarg through
+``escpos.capabilities.get_profile()``, whose isinstance fast-path only
+accepts instances of the library's *default* profile class — a specific
+profile instance (``TMT20IIProfile``, …) fell through to a dict lookup
+keyed by the object itself, so every connect raised
+``KeyError: <…TMT20IIProfile object…>`` and all printing broke for any
+entry with a configured profile.
+
+The conftest escpos fakes now mirror that round-trip (their ``__init__``
+calls the real ``get_profile()``), so these connects exercise the same
+contract the real library enforces, without any I/O.
+"""
+
+from custom_components.escpos_printer.printer.bluetooth_adapter import (
+    BluetoothPrinterAdapter,
+)
+from custom_components.escpos_printer.printer.config import (
+    BluetoothPrinterConfig,
+    NetworkPrinterConfig,
+    UsbPrinterConfig,
+)
+from custom_components.escpos_printer.printer.network_adapter import (
+    NetworkPrinterAdapter,
+)
+from custom_components.escpos_printer.printer.usb_adapter import UsbPrinterAdapter
+
+
+def _network_config(profile: str) -> NetworkPrinterConfig:
+    return NetworkPrinterConfig(
+        host="192.0.2.1", port=9100, timeout=1.0, codepage="", profile=profile, line_width=48
+    )
+
+
+def test_network_connect_profile_roundtrips() -> None:
+    adapter = NetworkPrinterAdapter(_network_config("TM-T20II"))
+    printer = adapter._connect()
+    assert type(printer.profile).__name__ == "TMT20IIProfile"
+    assert printer.profile.profile_data["media"]["width"]["pixels"] == 576
+
+
+def test_usb_connect_profile_roundtrips() -> None:
+    adapter = UsbPrinterAdapter(
+        UsbPrinterConfig(
+            vendor_id=0x04B8,
+            product_id=0x0E28,
+            in_ep=0x82,
+            out_ep=0x01,
+            timeout=1.0,
+            codepage="",
+            profile="TM-T20II",
+            line_width=48,
+        )
+    )
+    printer = adapter._connect()
+    assert type(printer.profile).__name__ == "TMT20IIProfile"
+
+
+def test_bluetooth_connect_profile_roundtrips() -> None:
+    adapter = BluetoothPrinterAdapter(
+        BluetoothPrinterConfig(
+            mac="AA:BB:CC:DD:EE:FF",
+            rfcomm_channel=1,
+            timeout=1.0,
+            codepage="",
+            profile="TM-T20II",
+            line_width=48,
+        )
+    )
+    printer = adapter._connect()
+    assert type(printer.profile).__name__ == "TMT20IIProfile"
+
+
+def test_profile_for_constructor_returns_name() -> None:
+    adapter = NetworkPrinterAdapter(_network_config("TM-T20II"))
+    assert adapter._profile_for_constructor() == "TM-T20II"
+
+
+def test_profile_for_constructor_unknown_degrades_to_none() -> None:
+    """Unknown profile keeps the old degrade-to-library-default behaviour."""
+    adapter = NetworkPrinterAdapter(_network_config("definitely_not_a_real_profile"))
+    assert adapter._profile_for_constructor() is None
+    # And the connect itself must not raise — it falls back to the default.
+    printer = adapter._connect()
+    assert printer.profile is not None
+
+
+def test_profile_for_constructor_empty_is_none() -> None:
+    adapter = NetworkPrinterAdapter(_network_config(""))
+    assert adapter._profile_for_constructor() is None

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -255,10 +255,10 @@ class TestGetProfileLineWidths:
         assert result == sorted(result)
 
     def test_default_profile_has_widths(self):
-        """Default fallback profile should have line widths."""
+        """The escpos 'default' profile exposes its real font column counts."""
         result = get_profile_line_widths("default")
         assert len(result) > 0
-        assert 48 in result  # Default fallback has Font A with 48 columns
+        assert 42 in result  # escpos default profile: Font A = 42 columns
 
 
 class TestGetAllLineWidths:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -125,12 +125,14 @@ async def test_config_flow_with_profile_selection(hass):  # type: ignore[no-unty
         assert result3["type"] == "form"
         assert result3["step_id"] == "codepage"
 
-        # Complete with defaults
+        # Complete with defaults. The real escpos "default" profile offers
+        # 42/56-column fonts (the old 48 came from the test-only fallback
+        # capability table that the fake escpos module used to force).
         result4 = await hass.config_entries.flow.async_configure(
             result3["flow_id"],
             {
                 CONF_CODEPAGE: "CP437",
-                CONF_LINE_WIDTH: 48,
+                CONF_LINE_WIDTH: 42,
                 CONF_DEFAULT_ALIGN: "center",
                 CONF_DEFAULT_CUT: "partial",
             },
@@ -139,7 +141,7 @@ async def test_config_flow_with_profile_selection(hass):  # type: ignore[no-unty
         assert result4["type"] == "create_entry"
         assert result4["data"][CONF_PROFILE] == "default"
         assert result4["data"][CONF_CODEPAGE] == "CP437"
-        assert result4["data"][CONF_LINE_WIDTH] == 48
+        assert result4["data"][CONF_LINE_WIDTH] == 42
         assert result4["data"][CONF_DEFAULT_ALIGN] == "center"
         assert result4["data"][CONF_DEFAULT_CUT] == "partial"
 
@@ -184,12 +186,13 @@ async def test_config_flow_custom_profile(hass):  # type: ignore[no-untyped-def]
         assert result4["type"] == "form"
         assert result4["step_id"] == "codepage"
 
-        # Complete the flow
+        # Complete the flow. TM-T88V is a real escpos profile with
+        # 42/56-column fonts, so the schema no longer offers 48.
         result5 = await hass.config_entries.flow.async_configure(
             result4["flow_id"],
             {
                 CONF_CODEPAGE: "",
-                CONF_LINE_WIDTH: DEFAULT_LINE_WIDTH,
+                CONF_LINE_WIDTH: 42,
                 CONF_DEFAULT_ALIGN: "left",
                 CONF_DEFAULT_CUT: "none",
             },

--- a/tests/test_image_decode_errors.py
+++ b/tests/test_image_decode_errors.py
@@ -1,0 +1,54 @@
+"""Decode-failure diagnostics: undecodable bytes must produce an actionable error.
+
+A CDN/WAF answering a URL fetch with an HTML error/block page served as
+200 used to surface as Pillow's bare ``cannot identify image file
+<_io.BytesIO …>`` — useless for diagnosing what actually came back. The
+``_process_bytes`` wrapper now reports the declared content type, the
+size, and a bounded sniff of the leading bytes.
+"""
+
+import io
+
+from homeassistant.exceptions import HomeAssistantError
+from PIL import Image
+import pytest
+
+from custom_components.escpos_printer.printer.image_operations import (
+    _describe_undecodable,
+    _process_bytes,
+)
+from custom_components.escpos_printer.printer.image_processor import ImageProcessOptions
+
+_HTML_BODY = b"<!DOCTYPE html><html><head><title>Access denied</title></head></html>"
+
+
+async def test_html_body_raises_actionable_error(hass):  # type: ignore[no-untyped-def]
+    with pytest.raises(HomeAssistantError) as excinfo:
+        await _process_bytes(hass, _HTML_BODY, ImageProcessOptions(), content_type="text/html")
+    msg = str(excinfo.value)
+    assert "text/html" in msg
+    assert "HTML page" in msg
+    assert "<!DOCTYPE htm" in msg  # bounded sniff of the body
+
+
+async def test_unknown_binary_lists_supported_formats(hass):  # type: ignore[no-untyped-def]
+    with pytest.raises(HomeAssistantError) as excinfo:
+        await _process_bytes(
+            hass, b"\x00\x01\x02\x03 not an image", ImageProcessOptions(), content_type=None
+        )
+    msg = str(excinfo.value)
+    assert "JPEG" in msg
+    assert "PNG" in msg
+    assert "HTML page" not in msg
+
+
+async def test_valid_image_still_decodes(hass):  # type: ignore[no-untyped-def]
+    buf = io.BytesIO()
+    Image.new("L", (40, 20), 128).save(buf, format="PNG")
+    img = await _process_bytes(hass, buf.getvalue(), ImageProcessOptions(), content_type=None)
+    assert img.size == (40, 20)
+
+
+def test_describe_undecodable_html_sniff_without_content_type() -> None:
+    msg = _describe_undecodable(_HTML_BODY, None)
+    assert "HTML page" in msg

--- a/tests/test_image_sources_pinned_session.py
+++ b/tests/test_image_sources_pinned_session.py
@@ -150,6 +150,23 @@ async def test_build_pinned_session_returns_session_with_pinned_resolver() -> No
         await session.close()
 
 
+@pytest.mark.asyncio
+async def test_build_pinned_session_sends_identifying_headers() -> None:
+    # The bare per-request session must not fall back to aiohttp's default
+    # ``Python/3.x aiohttp/…`` User-Agent — CDN/WAF bot rules answer that
+    # with HTML block pages served as 200, which then die in the image
+    # decoder. HA's own UA (as sent by the pooled clients pre-0.7.x) plus
+    # an image-biased Accept header restore the identity that worked.
+    session = _build_pinned_session("example.com", ["192.0.2.1"])
+    try:
+        assert "HomeAssistant" in session.headers["User-Agent"]
+        assert session.headers["Accept"].startswith("image/")
+        # AVIF decode support is optional (pillow-heif); don't invite it.
+        assert "avif" not in session.headers["Accept"].lower()
+    finally:
+        await session.close()
+
+
 def test_check_size_below_max_returns_silently() -> None:
     # 1 byte is well under any plausible cap.
     _check_size(1, auto_resize=False)

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "ha-escpos-thermal-printer"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "dbus-fast" },


### PR DESCRIPTION
## Summary

Fixes the two `print_image_url` failures reported against 0.7.3 (both regressions from the 0.7.3 review-fix release), bumps to **0.7.4**.

### 1. `Service print_image_url failed: <escpos.capabilities.TMT20IIProfile object at 0x…>` — every print broken with a configured profile

The 0.7.3 profile fix passed the **resolved profile object** into the python-escpos printer constructors. `Escpos.__init__` re-runs that kwarg through `get_profile()`, whose `isinstance` fast-path only accepts the library's *default* profile class — a specific profile instance (`TMT20IIProfile`, …) fell through to a dict lookup keyed by the object and raised `KeyError` at **every connect**, on all three transports.

- Adapters now pass the validated profile **name** via `_profile_for_constructor()`; unknown profiles still degrade to the library default with a debug log (pre-0.7.3 behaviour).
- Why tests missed it: the unit-test escpos fakes stubbed the whole package without `escpos.capabilities`, so profile resolution silently no-oped, and the fake constructors skipped the round-trip. The fakes now expose the **real** capabilities module and mirror the real constructor's `get_profile()` round-trip, plus per-transport regression tests (`tests/test_adapter_profile_roundtrip.py`).
- Fallout: three tests had encoded the fake's fallback capability table (line width 48); they now assert the real escpos data (default/TM-T88V profiles offer 42/56 columns) — which is what production users have always seen.

### 2. `cannot identify image file <_io.BytesIO …>` on URLs that printed fine pre-0.7

The SSRF-hardened per-request fetch session sent aiohttp's default `Python/3.x aiohttp/…` User-Agent. CDN/WAF bot rules (WordPress/Photon, Cloudflare) commonly answer that UA with an HTML block page **served as 200**, which then dies in the image decoder. Pre-0.7 fetches went through HA's pooled clients and sent HA's own UA.

- The pinned session now sends HA's `User-Agent` (`HomeAssistant/<version> …`) plus an `Accept` header biased toward the decodable formats (deliberately not advertising AVIF, whose decode support depends on optional `pillow-heif`).
- Undecodable bytes now raise an actionable error — declared content type, payload size, leading-bytes sniff, and an explicit hint when the body looks like an HTML error/block page — instead of Pillow's bare message, so any remaining environment-specific case is diagnosable from the HA log.

### Also

- Quoted two GitHub issue-template `description:` values whose inline `: ` made the YAML unparseable (pre-existing; the templates were broken on GitHub).

### Note for a follow-up PR (not included here)

`pre-commit run --all-files` reveals the repo has formatting drift against the pinned ruff hooks (~26 files: line-reflow + PEP 758 except-paren removal under the py314 target). It was originally part of this branch but tripped the per-patch coverage gate (reflowed lines on pre-existing uncovered error paths count as changed lines), so it's left for a dedicated maintenance PR.

## Testing

- Full suite (884 tests incl. 10 new) green on pinned HA 2026.3.4 **and** HA 2026.6.2 (the canary leg's resolved version); ruff, mypy, pre-commit all clean; per-patch coverage 100%.
- Reproduced the original `KeyError: <TMT20IIProfile object>` against real python-escpos 3.1 via `NetworkPrinterAdapter._connect()`, confirmed fixed (profile resolves to `TMT20IIProfile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
