### PR TITLE
Serial reliability fixes + v0.8.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   ESP32 via ESPHome `serial_proxy`). Recommended values: chunk size 128,
   delay 10 ms. Both are validated in the options flow (0–4096 bytes,
   0–1000 ms) to prevent runaway `time.sleep()` calls under the print
-  lock.
+  lock. Because serial writes are coalesced and only sent to the wire at
+  flush time, the payload is now flushed with error propagation before the
+  connection closes — a failed write (unplugged adapter, dropped proxy)
+  surfaces as a failed print instead of silently reporting success.
 - **Serial printer status sensor.** The binary sensor checks device-path
   ports via `os.stat` + `S_ISCHR` (non-invasive, no open required) and
   URL-based ports via a brief open/close probe — consistent with the
-  Bluetooth reachability model.
+  Bluetooth reachability model. The probe runs under the operation lock,
+  so it never opens a second connection to a URL proxy while a print is in
+  flight.
 - **Serial port redaction in diagnostics.** The serial port path or URL
   is included in the diagnostics download but redacted by
   `async_redact_data` (same treatment as network host and Bluetooth MAC).

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,12 @@
+# Contributors
+
+Thanks to everyone who has contributed to the ESC/POS Thermal Printer
+integration for Home Assistant.
+
+## Maintainer
+
+- **Nathan Byrd** ([@cognitivegears](https://github.com/cognitivegears)) — author and maintainer
+
+## Contributors
+
+- **Mark Johnson** ([@megageek](https://github.com/megageek)) — serial (UART/RS-232) printer support ([#103](https://github.com/cognitivegears/ha-escpos-thermal-printer/pull/103))

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ See [`blueprints/README.md`](blueprints/README.md) for import instructions, per-
 | [Limitations](docs/limitations.md) | Known limitations |
 | [Troubleshooting](docs/troubleshooting.md) | Common issues and solutions |
 | [Contributing](CONTRIBUTING.md) | Contributing, testing, and local development |
+| [Contributors](CONTRIBUTORS.md) | People who have contributed to this project |
 
 ## Getting Help
 

--- a/custom_components/escpos_printer/diagnostics.py
+++ b/custom_components/escpos_printer/diagnostics.py
@@ -26,7 +26,12 @@ from .const import (
     CONNECTION_TYPE_SERIAL,
     CONNECTION_TYPE_USB,
 )
-from .printer import BluetoothPrinterConfig, NetworkPrinterConfig, SerialPrinterConfig, UsbPrinterConfig
+from .printer import (
+    BluetoothPrinterConfig,
+    NetworkPrinterConfig,
+    SerialPrinterConfig,
+    UsbPrinterConfig,
+)
 
 if TYPE_CHECKING:
     from . import EscposConfigEntry

--- a/custom_components/escpos_printer/manifest.json
+++ b/custom_components/escpos_printer/manifest.json
@@ -117,5 +117,5 @@
       "description": "*pos*"
     }
   ],
-  "version": "0.7.4"
+  "version": "0.8.0"
 }

--- a/custom_components/escpos_printer/printer/_escpos_serial.py
+++ b/custom_components/escpos_printer/printer/_escpos_serial.py
@@ -42,6 +42,17 @@ def _get_serial_escpos_cls() -> type[Any]:
                 raise OSError("Serial transport already closed")
             self._transport.write(msg)
 
+        def flush(self) -> None:
+            """Flush buffered bytes to the wire, raising on write failure.
+
+            python-escpos itself never calls this; the serial adapter calls
+            it on the success path (before the best-effort ``close``) so a
+            failed write is reported instead of silently swallowed.
+            """
+            if self._transport is None:
+                raise OSError("Serial transport already closed")
+            self._transport.flush()
+
         def _read(self) -> bytes:
             # ESC/POS serial connections are write-only in practice.
             # Returning empty keeps python-escpos paths that opportunistically

--- a/custom_components/escpos_printer/printer/serial_adapter.py
+++ b/custom_components/escpos_printer/printer/serial_adapter.py
@@ -104,72 +104,97 @@ class SerialPrinterAdapter(EscposPrinterAdapterBase):
         assert last_exc is not None  # pragma: no cover
         raise last_exc
 
+    async def _release_printer(
+        self, hass: HomeAssistant, printer: Any, *, owned: bool, failed: bool = False
+    ) -> None:
+        """Flush coalesced output (errors propagate) before the base close.
+
+        The serial transport buffers every ``_raw()`` micro-write and only
+        sends the payload to the wire when the connection is flushed/closed.
+        The base ``_release_printer`` closes best-effort (suppressing
+        exceptions), so without this a write that fails at flush time —
+        device unplugged, ESPHome proxy reset, socket dropped mid-flush —
+        would be swallowed and the operation reported as success. On the
+        success path (``owned`` reconnect-per-op, ``not failed``) we flush
+        explicitly here: a failed write raises out of the operation's
+        ``finally``, skipping ``_mark_success`` so the caller sees the
+        error. The connection is still closed afterwards either way.
+        """
+        flush_exc: Exception | None = None
+        if owned and not failed and printer is not None:
+
+            def _flush() -> None:
+                printer.flush()
+
+            try:
+                await hass.async_add_executor_job(_flush)
+            except Exception as exc:  # surfaced after the close below
+                flush_exc = exc
+                failed = True
+
+        await super()._release_printer(hass, printer, owned=owned, failed=failed)
+        if flush_exc is not None:
+            raise flush_exc
+
     async def _status_check(self, hass: HomeAssistant) -> None:
         """Check serial printer reachability.
 
         For filesystem paths we do a non-invasive character-device check
-        (``os.path.exists`` + ``stat.S_ISCHR``).  For URL-based connections
-        (ESPHome proxy, RFC2217, socket) we attempt a brief open/close, since
-        there is no device-file to inspect.
+        (``os.stat`` + ``stat.S_ISCHR``). For URL-based connections (ESPHome
+        proxy, RFC2217, socket) we attempt a brief open/close, since there is
+        no device-file to inspect.
 
-        Skips the check when a print operation currently holds the lock.
+        The probe runs under the operation lock via ``_probe_lock_or_skip``
+        so it cannot race a print onto the same transport: a bare
+        ``if self._lock.locked(): return`` was TOCTOU — a print could acquire
+        the lock between the check and the probe, leaving a status open/close
+        to a URL proxy (ESPHome/socket/RFC2217) running concurrently with the
+        active job. When a print already holds the lock, this tick is skipped.
         """
-        if self._lock.locked():
-            _LOGGER.debug(
-                "Skipping serial status probe for %s — print operation in flight",
-                sanitize_log_message(self._serial_config.serial_port),
-            )
-            return
-
         port = self._serial_config.serial_port
 
-        if _is_url(port):
-            await self._status_check_url(hass, port)
-        else:
-            await self._status_check_path(hass, port)
-
-    async def _status_check_path(self, hass: HomeAssistant, port: str) -> None:
-        """Non-invasive status check for filesystem serial ports."""
-
-        def _probe() -> tuple[bool, str | None, int | None, int | None]:
-            start = time.perf_counter()
-            try:
-                st = os.stat(port)
-            except OSError as exc:
-                latency_ms = int((time.perf_counter() - start) * 1000)
-                return False, str(exc), latency_ms, getattr(exc, "errno", None)
-            else:
-                latency_ms = int((time.perf_counter() - start) * 1000)
-                if not stat.S_ISCHR(st.st_mode):
-                    return False, f"{port} is not a character device", latency_ms, None
-                return True, None, latency_ms, None
-
-        ok, err, latency_ms, err_no = await hass.async_add_executor_job(_probe)
-        self._record_status(ok, err, latency_ms, err_no)
-
-    async def _status_check_url(self, hass: HomeAssistant, port: str) -> None:
-        """Status check for URL-based serial connections via a brief open/close probe."""
-
-        def _probe() -> tuple[bool, str | None, int | None, int | None]:
-            start = time.perf_counter()
-            probe_timeout = min(self._serial_config.timeout, 3.0)
-            try:
-                transport = serial_transport.open_serial_transport(
-                    port,
-                    self._serial_config.baudrate,
-                    probe_timeout,
+        async with self._probe_lock_or_skip() as acquired:
+            if not acquired:
+                _LOGGER.debug(
+                    "Skipping serial status probe for %s — print operation in flight",
+                    sanitize_log_message(port),
                 )
-            except OSError as exc:
-                latency_ms = int((time.perf_counter() - start) * 1000)
-                return False, str(exc), latency_ms, getattr(exc, "errno", None)
-            else:
-                latency_ms = int((time.perf_counter() - start) * 1000)
-                with contextlib.suppress(Exception):
-                    transport.close()
-                return True, None, latency_ms, None
+                return
+            probe = self._probe_url if _is_url(port) else self._probe_path
+            ok, err, latency_ms, err_no = await hass.async_add_executor_job(probe, port)
 
-        ok, err, latency_ms, err_no = await hass.async_add_executor_job(_probe)
         self._record_status(ok, err, latency_ms, err_no)
+
+    def _probe_path(self, port: str) -> tuple[bool, str | None, int | None, int | None]:
+        """Non-invasive reachability probe for filesystem serial ports."""
+        start = time.perf_counter()
+        try:
+            st = os.stat(port)
+        except OSError as exc:
+            latency_ms = int((time.perf_counter() - start) * 1000)
+            return False, str(exc), latency_ms, getattr(exc, "errno", None)
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        if not stat.S_ISCHR(st.st_mode):
+            return False, f"{port} is not a character device", latency_ms, None
+        return True, None, latency_ms, None
+
+    def _probe_url(self, port: str) -> tuple[bool, str | None, int | None, int | None]:
+        """Reachability probe for URL serial ports via a brief open/close."""
+        start = time.perf_counter()
+        probe_timeout = min(self._serial_config.timeout, 3.0)
+        try:
+            transport = serial_transport.open_serial_transport(
+                port,
+                self._serial_config.baudrate,
+                probe_timeout,
+            )
+        except OSError as exc:
+            latency_ms = int((time.perf_counter() - start) * 1000)
+            return False, str(exc), latency_ms, getattr(exc, "errno", None)
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        with contextlib.suppress(Exception):
+            transport.close()
+        return True, None, latency_ms, None
 
     def _record_status(
         self,

--- a/custom_components/escpos_printer/printer/serial_transport.py
+++ b/custom_components/escpos_printer/printer/serial_transport.py
@@ -22,6 +22,9 @@ class SerialTransport(Protocol):
     def write(self, data: bytes) -> None:
         """Write bytes to the underlying transport."""
 
+    def flush(self) -> None:
+        """Write any buffered bytes to the wire, raising on failure."""
+
     def close(self) -> None:
         """Close the underlying transport."""
 
@@ -73,7 +76,22 @@ class _SerialTransportImpl:
             if self._write_chunk_delay_s > 0 and i + self._write_chunk_size < len(data):
                 time.sleep(self._write_chunk_delay_s)
 
+    def flush(self) -> None:
+        """Write the buffered payload to the wire, propagating errors.
+
+        Unlike :meth:`close`, this does **not** suppress write failures —
+        the adapter calls it on the success path so a failed write surfaces
+        and the print operation is reported as failed instead of silently
+        "succeeding". Idempotent: ``_flush`` clears the buffer, so a later
+        ``close()`` flush is a no-op.
+        """
+        self._flush()
+
     def close(self) -> None:
+        # Best-effort flush for paths that did not call flush() first (the
+        # error path): a write failure here is intentionally suppressed so
+        # close() never raises during cleanup. The success path flushes via
+        # flush() above, where errors do propagate.
         with contextlib.suppress(Exception):
             self._flush()
         with contextlib.suppress(Exception):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-escpos-thermal-printer"
-version = "0.7.4"
+version = "0.8.0"
 description = "Network thermal printer integration for Home Assistant using ESC/POS protocol"
 readme = "README.md"
 requires-python = ">=3.14.2"

--- a/tests/test_serial_adapter.py
+++ b/tests/test_serial_adapter.py
@@ -406,3 +406,56 @@ class TestSerialTransportImpl:
         transport.write(b"data")
         transport.close()
         port.close.assert_called_once()
+
+    def test_flush_writes_buffer_to_port(self):
+        transport, port = self._make_transport()
+        transport.write(b"hello")
+        transport.flush()
+        port.write.assert_called_once_with(b"hello")
+
+    def test_flush_propagates_write_error(self):
+        # Unlike close(), flush() must NOT suppress: the adapter relies on the
+        # error surfacing so a failed write is reported instead of silently
+        # "succeeding".
+        transport, port = self._make_transport()
+        port.write.side_effect = OSError("port gone")
+        transport.write(b"data")
+        with pytest.raises(OSError, match="port gone"):
+            transport.flush()
+
+    def test_flush_then_close_writes_once(self):
+        # flush() clears the buffer, so the close() best-effort flush is a no-op.
+        transport, port = self._make_transport()
+        transport.write(b"hello")
+        transport.flush()
+        transport.close()
+        port.write.assert_called_once_with(b"hello")
+
+
+class TestSerialReleasePrinterFlush:
+    """Deferred-write fix: _release_printer flushes with error propagation."""
+
+    @pytest.mark.asyncio
+    async def test_release_flushes_on_success(self, hass, serial_adapter):
+        printer = MagicMock()
+        await serial_adapter._release_printer(hass, printer, owned=True, failed=False)
+        printer.flush.assert_called_once()
+        printer.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_release_surfaces_flush_error_and_still_closes(self, hass, serial_adapter):
+        printer = MagicMock()
+        printer.flush.side_effect = OSError("port gone")
+        with pytest.raises(OSError, match="port gone"):
+            await serial_adapter._release_printer(hass, printer, owned=True, failed=False)
+        # Connection is still closed even though the flush failed.
+        printer.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_release_skips_flush_when_op_already_failed(self, hass, serial_adapter):
+        # On the failure path the buffered partial payload is only sent
+        # best-effort via the (suppressed) close — no explicit flush.
+        printer = MagicMock()
+        await serial_adapter._release_printer(hass, printer, owned=True, failed=True)
+        printer.flush.assert_not_called()
+        printer.close.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -1124,7 +1124,7 @@ wheels = [
 
 [[package]]
 name = "ha-escpos-thermal-printer"
-version = "0.7.4"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "dbus-fast" },


### PR DESCRIPTION
Follow-up to the serial support merged in #103. Fixes two reliability issues found in a post-merge review, adds contributor credit, and bumps the version for the upcoming 0.8.0 release.

## Serial reliability fixes
- **Silent write failure** — the serial transport coalesces every `_raw()` write and only sends the payload to the wire at flush time, which previously happened inside the best-effort (exception-suppressing) `close()`. A failed write (unplugged adapter, dropped ESPHome proxy, socket reset mid-flush) was swallowed and the print still reported success. Added a non-suppressed `flush()` to the transport + `_SerialEscpos`, and override `_release_printer()` to flush on the success path so a failed write surfaces as a failed print. The connection is still closed afterwards.
- **Status-probe TOCTOU** — `_status_check` used the old `if self._lock.locked(): return` pattern; network/USB/Bluetooth all use the race-safe `_probe_lock_or_skip()`. Routed the serial probe through the same helper so it can't open a second URL-proxy connection mid-print.
- +6 tests covering flush propagation and release/probe behavior.

## Other
- **CONTRIBUTORS.md** added (credits @megageek for the serial work in #103) and linked from the README.
- **diagnostics.py** — ruff `I001` import-sort autofix. This was pre-existing on `main` after the #103 merge (formatting only). Note: the same one-line fix also appears in the dependency-updates PR; whichever merges second will already have it (identical change, no conflict).
- **Version bump to 0.8.0** — `manifest.json`, `pyproject.toml`, and the `uv.lock` self-version. CHANGELOG `[Unreleased]` is left undated; it becomes `[0.8.0] - <date>` when the release is cut.

## Verification
`ruff check .` clean · `mypy` clean · full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yGmxUiFwoGVePnngo6kHP