### PR TITLE
Network printer identification (GS I) and DHCP discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   with my model" action is gone. Enter the model (optional), Save or
   Discard — the personalized GitHub share link now appears on the
   final confirmation screen after saving (and still in a notification).
+- Calibration test pages feed two extra blank lines after each test, so
+  the results clear the tear bar without a manual feed.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   generic `default` profile) now shows a tip on the success screen
   pointing at the calibration wizard (Configure → Calibrate printer).
 - Network printers are identified at setup via ESC/POS `GS I` queries: the
-  device page shows the real manufacturer/model (e.g. EPSON TM-T20II), and
-  the calibration share link prefills the model name. Printers that don't
-  answer (most clones) behave exactly as before.
+  device page shows the real manufacturer/model (e.g. EPSON TM-T20II), the
+  calibration share link prefills the model name, and the detected
+  manufacturer/model are included in diagnostics downloads. Printers that
+  don't answer (most clones) behave exactly as before.
 - DHCP discovery for network thermal printers: Home Assistant now offers to
   set up Epson TM-series (`tm-*`) and Rongta (`rongta_*`) printers it sees
   join the network. Candidates are probed on port 9100 first, so matches
-  that aren't printers are ignored silently. Discovered setups preselect
+  that aren't printers are ignored silently; `tm-*` hostnames additionally
+  require a real `GS I` answer, since port 9100 is also Prometheus
+  node_exporter's default. Discovered setups preselect
   the matching printer profile when one is known.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   device page shows the real manufacturer/model (e.g. EPSON TM-T20II), the
   calibration share link prefills the model name, and the detected
   manufacturer/model are included in diagnostics downloads. Printers that
-  don't answer (most clones) behave exactly as before.
+  don't answer (most clones) behave exactly as before. Existing network
+  printer entries pick up the detected model the next time they are
+  reconfigured.
 - DHCP discovery for network thermal printers: Home Assistant now offers to
   set up Epson TM-series (`tm-*`) and Rongta (`rongta_*`) printers it sees
   join the network. Candidates are probed on port 9100 first, so matches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Adding a printer without a real profile ("Generic (no profile)" or the
   generic `default` profile) now shows a tip on the success screen
   pointing at the calibration wizard (Configure → Calibrate printer).
+- Network printers are identified at setup via ESC/POS `GS I` queries: the
+  device page shows the real manufacturer/model (e.g. EPSON TM-T20II), and
+  the calibration share link prefills the model name. Printers that don't
+  answer (most clones) behave exactly as before.
+- DHCP discovery for network thermal printers: Home Assistant now offers to
+  set up Epson TM-series (`tm-*`) and Rongta (`rongta_*`) printers it sees
+  join the network. Candidates are probed on port 9100 first, so matches
+  that aren't printers are ignored silently. Discovered setups preselect
+  the matching printer profile when one is known.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ This integration is in the HACS default store. No custom repository needed.
 **Note:** USB printers may be auto-discovered when connected. Check your Home
 Assistant notifications.
 
+### Automatic discovery
+
+Epson TM-series and Rongta network printers announce recognizable DHCP
+hostnames; Home Assistant will offer to set them up automatically when they
+appear on your network (Settings → Devices & Services → Discovered). Other
+brands and printers with hostname broadcasting disabled can always be added
+manually by IP address. During setup, the integration asks the printer to
+identify itself (ESC/POS `GS I`); Epson printers answer with their real
+model name, which fills the device page and suggests the matching profile.
+Printers that don't answer are configured exactly as before.
+
 ## Basic Examples
 
 ### Print a Message

--- a/README.md
+++ b/README.md
@@ -79,14 +79,22 @@ Assistant notifications.
 
 ### Automatic discovery
 
-Epson TM-series and Rongta network printers announce recognizable DHCP
-hostnames; Home Assistant will offer to set them up automatically when they
-appear on your network (Settings → Devices & Services → Discovered). Other
-brands and printers with hostname broadcasting disabled can always be added
-manually by IP address. During setup, the integration asks the printer to
-identify itself (ESC/POS `GS I`); Epson printers answer with their real
-model name, which fills the device page and suggests the matching profile.
-Printers that don't answer are configured exactly as before.
+Every network printer setup or reconfigure asks the printer to identify
+itself (ESC/POS `GS I`); Epson printers typically answer with their real
+model name, which fills in the device page. Printers that don't answer are
+configured exactly as before.
+
+Epson TM-series and Rongta network printers additionally announce
+recognizable DHCP hostnames; Home Assistant will offer to set them up
+automatically when they appear on your network (Settings → Devices &
+Services → Discovered), with the host prefilled and the matching profile
+preselected. Manual setup still runs the `GS I` query, but the profile
+dropdown is already on the same form when you submit it, so there's no
+discovered result yet to preselect a profile from — you pick the profile
+yourself, same as before.
+
+**Upgrading?** Printers configured before this feature pick up their
+detected model the next time you run **Reconfigure** on the entry.
 
 ## Basic Examples
 

--- a/custom_components/escpos_printer/_config_flow/calibration_steps.py
+++ b/custom_components/escpos_printer/_config_flow/calibration_steps.py
@@ -26,6 +26,7 @@ import voluptuous as vol
 from ..capabilities import get_profile_codepages
 from ..const import (
     CONF_CODEPAGE,
+    CONF_DETECTED_MODEL,
     CONF_IMPL,
     CONF_LINE_WIDTH,
     CONF_PROFILE,
@@ -566,7 +567,10 @@ class CalibrationFlowMixin:
 
         schema = vol.Schema(
             {
-                vol.Optional("model", default=""): str,
+                vol.Optional(
+                    "model",
+                    default=self.config_entry.data.get(CONF_DETECTED_MODEL, ""),
+                ): str,
                 vol.Required("action", default="save"): vol.In(_SUMMARY_ACTION_CHOICES),
             }
         )

--- a/custom_components/escpos_printer/_config_flow/calibration_steps.py
+++ b/custom_components/escpos_printer/_config_flow/calibration_steps.py
@@ -174,7 +174,7 @@ class CalibrationFlowMixin:
                 self.hass, text=f"= {title} =\n{instruction}\n", cut="none", feed=0
             )
 
-    async def _print_step_trailer(self, adapter: Any, feed: int = 3) -> None:
+    async def _print_step_trailer(self, adapter: Any, feed: int = 5) -> None:
         """Blank feed after a step's page so steps separate on the roll."""
         with contextlib.suppress(Exception):
             await adapter.print_text(self.hass, text="", cut="none", feed=feed)
@@ -288,7 +288,7 @@ class CalibrationFlowMixin:
                 feed=1,
                 auto_resize=False,
             )
-        await self._print_step_trailer(adapter, feed=2)
+        await self._print_step_trailer(adapter, feed=4)
 
     async def async_step_calibrate_width(
         self, user_input: dict[str, Any] | None = None
@@ -349,7 +349,7 @@ class CalibrationFlowMixin:
                     feed=0,
                 )
                 await adapter.print_text(
-                    self.hass, text=build_ruler(96), cut="none", feed=3, wrap=False
+                    self.hass, text=build_ruler(96), cut="none", feed=5, wrap=False
                 )
             except Exception as err:
                 _LOGGER.warning("Calibration ruler step failed: %s", sanitize_log_message(str(err)))

--- a/custom_components/escpos_printer/_config_flow/discovery_steps.py
+++ b/custom_components/escpos_printer/_config_flow/discovery_steps.py
@@ -1,0 +1,63 @@
+"""DHCP discovery step mixin.
+
+Evidence-only hostname matchers live in manifest.json ("tm-*", "rongta_*").
+A match is confirmed by a TCP probe of port 9100 before the user ever sees
+a discovery card, so matcher false positives abort silently. The existing
+network form is the confirmation UI — discovery just prefills it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+
+from ..const import DEFAULT_PORT, DEFAULT_TIMEOUT
+from .network_helpers import _can_connect, query_printer_id
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DiscoveryFlowMixin:
+    """Mixin providing the DHCP discovery entry point.
+
+    Expects from the composed flow class:
+    - hass, async_set_unique_id(), _abort_if_unique_id_configured(),
+      async_abort(), async_step_network()
+    - _detected: dict[str, str] (main_flow.__init__)
+    - _discovery_host: str | None (main_flow.__init__)
+    """
+
+    hass: Any
+    _detected: dict[str, str]
+    _discovery_host: str | None
+
+    async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> ConfigFlowResult:
+        """Handle a DHCP-discovered printer candidate."""
+        host = discovery_info.ip
+        await self.async_set_unique_id(f"{host.lower()}:{DEFAULT_PORT}")  # type: ignore[attr-defined]
+        self._abort_if_unique_id_configured()  # type: ignore[attr-defined]
+
+        if not await self.hass.async_add_executor_job(
+            _can_connect, host, DEFAULT_PORT, DEFAULT_TIMEOUT
+        ):
+            _LOGGER.debug(
+                "DHCP match %s (%s) not listening on %s; ignoring",
+                discovery_info.hostname,
+                host,
+                DEFAULT_PORT,
+            )
+            return self.async_abort(reason="cannot_connect")  # type: ignore[attr-defined,no-any-return]
+
+        self._detected = (
+            await self.hass.async_add_executor_job(
+                query_printer_id, host, DEFAULT_PORT, DEFAULT_TIMEOUT
+            )
+            or {}
+        )
+        self._discovery_host = host
+        name = self._detected.get("model") or discovery_info.hostname
+        self.context["title_placeholders"] = {"name": f"{name} ({host})"}  # type: ignore[attr-defined]
+        return await self.async_step_network()  # type: ignore[attr-defined,no-any-return]

--- a/custom_components/escpos_printer/_config_flow/discovery_steps.py
+++ b/custom_components/escpos_printer/_config_flow/discovery_steps.py
@@ -28,11 +28,13 @@ class DiscoveryFlowMixin:
       async_abort(), async_step_network()
     - _detected: dict[str, str] (main_flow.__init__)
     - _discovery_host: str | None (main_flow.__init__)
+    - _discovery_port: int | None (main_flow.__init__)
     """
 
     hass: Any
     _detected: dict[str, str]
     _discovery_host: str | None
+    _discovery_port: int | None
 
     async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> ConfigFlowResult:
         """Handle a DHCP-discovered printer candidate."""
@@ -51,13 +53,29 @@ class DiscoveryFlowMixin:
             )
             return self.async_abort(reason="cannot_connect")  # type: ignore[attr-defined,no-any-return]
 
-        self._detected = (
+        detected = (
             await self.hass.async_add_executor_job(
                 query_printer_id, host, DEFAULT_PORT, DEFAULT_TIMEOUT
             )
             or {}
         )
+
+        # "tm-*" also matches Prometheus node_exporter's default port 9100,
+        # so a port-probe alone is not brand-exclusive evidence for it -- a
+        # positive GS I identification is required before showing a card.
+        # "rongta_*" is a brand-exclusive hostname prefix, so the port probe
+        # above is sufficient evidence on its own.
+        if discovery_info.hostname.lower().startswith("tm-") and not detected:
+            _LOGGER.debug(
+                "DHCP match %s (%s) did not answer GS I identification; ignoring",
+                discovery_info.hostname,
+                host,
+            )
+            return self.async_abort(reason="cannot_connect")  # type: ignore[attr-defined,no-any-return]
+
+        self._detected = detected
         self._discovery_host = host
-        name = self._detected.get("model") or discovery_info.hostname
+        self._discovery_port = DEFAULT_PORT
+        name = detected.get("model") or discovery_info.hostname
         self.context["title_placeholders"] = {"name": f"{name} ({host})"}  # type: ignore[attr-defined]
         return await self.async_step_network()  # type: ignore[attr-defined,no-any-return]

--- a/custom_components/escpos_printer/_config_flow/main_flow.py
+++ b/custom_components/escpos_printer/_config_flow/main_flow.py
@@ -19,6 +19,7 @@ from ..const import (
     DOMAIN,
 )
 from .bluetooth_steps import BluetoothFlowMixin
+from .discovery_steps import DiscoveryFlowMixin
 from .import_steps import ImportFlowMixin
 from .network_steps import NetworkFlowMixin
 from .serial_steps import SerialFlowMixin
@@ -30,6 +31,7 @@ _LOGGER = logging.getLogger(__name__)
 
 class EscposConfigFlow(
     NetworkFlowMixin,
+    DiscoveryFlowMixin,
     UsbFlowMixin,
     BluetoothFlowMixin,
     SerialFlowMixin,
@@ -47,6 +49,7 @@ class EscposConfigFlow(
         """Initialize config flow."""
         self._user_data: dict[str, Any] = {}
         self._detected: dict[str, str] = {}
+        self._discovery_host: str | None = None
         self._discovered_printers: list[dict[str, Any]] = []
         self._all_usb_devices: list[dict[str, Any]] = []
         self._paired_bt_devices: list[dict[str, Any]] = []

--- a/custom_components/escpos_printer/_config_flow/main_flow.py
+++ b/custom_components/escpos_printer/_config_flow/main_flow.py
@@ -46,6 +46,7 @@ class EscposConfigFlow(
     def __init__(self) -> None:
         """Initialize config flow."""
         self._user_data: dict[str, Any] = {}
+        self._detected: dict[str, str] = {}
         self._discovered_printers: list[dict[str, Any]] = []
         self._all_usb_devices: list[dict[str, Any]] = []
         self._paired_bt_devices: list[dict[str, Any]] = []

--- a/custom_components/escpos_printer/_config_flow/main_flow.py
+++ b/custom_components/escpos_printer/_config_flow/main_flow.py
@@ -50,6 +50,7 @@ class EscposConfigFlow(
         self._user_data: dict[str, Any] = {}
         self._detected: dict[str, str] = {}
         self._discovery_host: str | None = None
+        self._discovery_port: int | None = None
         self._discovered_printers: list[dict[str, Any]] = []
         self._all_usb_devices: list[dict[str, Any]] = []
         self._paired_bt_devices: list[dict[str, Any]] = []

--- a/custom_components/escpos_printer/_config_flow/network_helpers.py
+++ b/custom_components/escpos_printer/_config_flow/network_helpers.py
@@ -44,3 +44,55 @@ def _can_connect(host: str, port: int, timeout: float) -> bool:
             return True
     except OSError:
         return False
+
+
+# --- GS I (Transmit Printer ID) query -------------------------------------
+#
+# Epson network printers answer GS I 66/67 with the maker/model name framed
+# as 0x5F <ascii> 0x00. Clones typically ignore the command entirely; the
+# short read timeout turns that silence into a clean None. The commands are
+# read-only: nothing is printed and no printer state changes.
+
+_GS_I_MAKER = b"\x1d\x49\x42"  # GS I 66 -> maker name ("EPSON")
+_GS_I_MODEL = b"\x1d\x49\x43"  # GS I 67 -> model name ("TM-T20II")
+_ID_HEADER = 0x5F
+_ID_MAX_LEN = 80
+_ID_READ_TIMEOUT = 2.0
+
+
+def _read_id_reply(sock: socket.socket) -> str | None:
+    """Read one 0x5F...0x00 framed reply; None on timeout/garbage/empty."""
+    data = bytearray()
+    try:
+        while len(data) < _ID_MAX_LEN:
+            chunk = sock.recv(1)
+            if not chunk or chunk == b"\x00":
+                break
+            data += chunk
+    except OSError:
+        pass  # timeout mid-reply: fall through and parse what we have
+    if not data or data[0] != _ID_HEADER:
+        return None
+    text = data[1:].decode("ascii", errors="ignore").strip()
+    return text or None
+
+
+def query_printer_id(host: str, port: int, timeout: float) -> dict[str, str] | None:
+    """Best-effort printer identification via GS I over raw TCP.
+
+    Returns {"manufacturer": ..., "model": ...} (either key may be
+    absent), or None when nothing was identified. Never raises.
+    """
+    result: dict[str, str] = {}
+    try:
+        with socket.create_connection((host, port), timeout=timeout) as sock:
+            sock.settimeout(_ID_READ_TIMEOUT)
+            for key, command in (("manufacturer", _GS_I_MAKER), ("model", _GS_I_MODEL)):
+                sock.sendall(command)
+                value = _read_id_reply(sock)
+                if value is None:
+                    break  # no answer: don't wait out a second timeout
+                result[key] = value
+    except OSError:
+        _LOGGER.debug("GS I query failed for %s:%s", host, port)
+    return result or None

--- a/custom_components/escpos_printer/_config_flow/network_helpers.py
+++ b/custom_components/escpos_printer/_config_flow/network_helpers.py
@@ -58,6 +58,11 @@ _GS_I_MODEL = b"\x1d\x49\x43"  # GS I 67 -> model name ("TM-T20II")
 _ID_HEADER = 0x5F
 _ID_MAX_LEN = 80
 _ID_READ_TIMEOUT = 2.0
+# Each recv() below resets the read timeout, so an unbounded drain would let
+# a misbehaving/malicious device drip-feed one byte at a time and hold the
+# connection (and an HA executor thread) open indefinitely. Cap total bytes
+# drained; if the cap is hit the stream is abandoned as unrecoverable.
+_ID_DRAIN_MAX = 4096
 
 
 def _read_id_reply(sock: socket.socket) -> str | None:
@@ -73,11 +78,14 @@ def _read_id_reply(sock: socket.socket) -> str | None:
             # Hit the length cap without a NUL terminator: bytes from this
             # oversized reply are still queued on the socket and would
             # desync the framing of the NEXT reply. Drain them (discarding)
-            # until NUL/timeout/closed so the stream resyncs.
-            while True:
+            # until NUL/timeout/closed so the stream resyncs -- bounded by
+            # _ID_DRAIN_MAX so a drip-fed stream can't hang this forever.
+            drained = 0
+            while drained < _ID_DRAIN_MAX:
                 chunk = sock.recv(1)
                 if not chunk or chunk == b"\x00":
                     break
+                drained += 1
     except OSError:
         pass  # timeout mid-reply: fall through and parse what we have
     if not data or data[0] != _ID_HEADER:

--- a/custom_components/escpos_printer/_config_flow/network_helpers.py
+++ b/custom_components/escpos_printer/_config_flow/network_helpers.py
@@ -69,11 +69,24 @@ def _read_id_reply(sock: socket.socket) -> str | None:
             if not chunk or chunk == b"\x00":
                 break
             data += chunk
+        else:
+            # Hit the length cap without a NUL terminator: bytes from this
+            # oversized reply are still queued on the socket and would
+            # desync the framing of the NEXT reply. Drain them (discarding)
+            # until NUL/timeout/closed so the stream resyncs.
+            while True:
+                chunk = sock.recv(1)
+                if not chunk or chunk == b"\x00":
+                    break
     except OSError:
         pass  # timeout mid-reply: fall through and parse what we have
     if not data or data[0] != _ID_HEADER:
         return None
-    text = data[1:].decode("ascii", errors="ignore").strip()
+    text = data[1:].decode("ascii", errors="ignore")
+    # Drop C0 control/escape bytes an untrusted peer could stuff into the
+    # reply; leading/trailing whitespace is stripped last so filtering
+    # doesn't leave it exposed at the ends.
+    text = "".join(c for c in text if c.isprintable()).strip()
     return text or None
 
 

--- a/custom_components/escpos_printer/_config_flow/network_steps.py
+++ b/custom_components/escpos_printer/_config_flow/network_steps.py
@@ -17,13 +17,15 @@ from ..capabilities import (
 )
 from ..const import (
     CONF_CONNECTION_TYPE,
+    CONF_DETECTED_MANUFACTURER,
+    CONF_DETECTED_MODEL,
     CONF_PROFILE,
     CONF_TIMEOUT,
     CONNECTION_TYPE_NETWORK,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
 )
-from .network_helpers import _can_connect
+from .network_helpers import _can_connect, query_printer_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,6 +47,7 @@ class NetworkFlowMixin:
     # These attributes are expected from the main flow class
     hass: Any
     _user_data: dict[str, Any]
+    _detected: dict[str, str]
 
     async def async_step_network(
         self, user_input: dict[str, Any] | None = None
@@ -78,6 +81,14 @@ class NetworkFlowMixin:
             if ok:
                 _LOGGER.debug("Connection test succeeded for %s:%s", host, port)
 
+                # Best-effort GS I identification. Reuse a discovery-time
+                # result (e.g. DHCP discovery step) instead of querying
+                # again when one is already available.
+                detected = self._detected or (
+                    await self.hass.async_add_executor_job(query_printer_id, host, port, timeout)
+                    or {}
+                )
+
                 # Store data and determine next step
                 profile = user_input.get(CONF_PROFILE, PROFILE_AUTO)
                 self._user_data = {
@@ -87,6 +98,10 @@ class NetworkFlowMixin:
                     CONF_TIMEOUT: timeout,
                     CONF_PROFILE: profile,
                 }
+                if detected.get("manufacturer"):
+                    self._user_data[CONF_DETECTED_MANUFACTURER] = detected["manufacturer"]
+                if detected.get("model"):
+                    self._user_data[CONF_DETECTED_MODEL] = detected["model"]
 
                 # If custom profile selected, go to custom profile step
                 if profile == PROFILE_CUSTOM:
@@ -152,6 +167,11 @@ class NetworkFlowMixin:
                 _can_connect, host, port, timeout
             )
             if ok:
+                detected = (
+                    await self.hass.async_add_executor_job(query_printer_id, host, port, timeout)
+                    or {}
+                )
+
                 # Only follow the address to a new auto-generated title
                 # when the entry still carries the original auto-generated
                 # one -- a user's manual rename must never be clobbered.
@@ -168,6 +188,16 @@ class NetworkFlowMixin:
                         CONF_HOST: host,
                         CONF_PORT: port,
                         CONF_TIMEOUT: timeout,
+                        **(
+                            {CONF_DETECTED_MANUFACTURER: detected["manufacturer"]}
+                            if detected.get("manufacturer")
+                            else {}
+                        ),
+                        **(
+                            {CONF_DETECTED_MODEL: detected["model"]}
+                            if detected.get("model")
+                            else {}
+                        ),
                     },
                 )
             errors["base"] = "cannot_connect"

--- a/custom_components/escpos_printer/_config_flow/network_steps.py
+++ b/custom_components/escpos_printer/_config_flow/network_steps.py
@@ -15,6 +15,7 @@ from ..capabilities import (
     PROFILE_CUSTOM,
     get_profile_choices_dict,
 )
+from ..capabilities.suggestions import suggest_profile
 from ..const import (
     CONF_CONNECTION_TYPE,
     CONF_DETECTED_MANUFACTURER,
@@ -48,6 +49,7 @@ class NetworkFlowMixin:
     hass: Any
     _user_data: dict[str, Any]
     _detected: dict[str, str]
+    _discovery_host: str | None
 
     async def async_step_network(
         self, user_input: dict[str, Any] | None = None
@@ -116,6 +118,18 @@ class NetworkFlowMixin:
         # Build profile choices dynamically
         profile_choices = await self.hass.async_add_executor_job(get_profile_choices_dict)
 
+        # Discovery flows ran the GS I query before this form is shown, so
+        # the detected model can preselect the profile dropdown (preselect
+        # only -- the user always confirms). Manual flows query on submit.
+        default_profile = PROFILE_AUTO
+        detected_model = self._detected.get("model") if self._discovery_host else None
+        if detected_model:
+            suggestion = await self.hass.async_add_executor_job(
+                suggest_profile, detected_model, None, None
+            )
+            if suggestion and suggestion in profile_choices:
+                default_profile = suggestion
+
         data_schema = vol.Schema(
             {
                 vol.Required(CONF_HOST): str,
@@ -123,9 +137,13 @@ class NetworkFlowMixin:
                     vol.Coerce(int), vol.Range(min=1, max=65535)
                 ),
                 vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.Coerce(float),
-                vol.Optional(CONF_PROFILE, default=PROFILE_AUTO): vol.In(profile_choices),
+                vol.Optional(CONF_PROFILE, default=default_profile): vol.In(profile_choices),
             }
         )
+        if self._discovery_host:
+            data_schema = self.add_suggested_values_to_schema(  # type: ignore[attr-defined]
+                data_schema, {CONF_HOST: self._discovery_host}
+            )
 
         return self.async_show_form(step_id="network", data_schema=data_schema, errors=errors)  # type: ignore[attr-defined,no-any-return]
 

--- a/custom_components/escpos_printer/_config_flow/network_steps.py
+++ b/custom_components/escpos_printer/_config_flow/network_steps.py
@@ -180,25 +180,29 @@ class NetworkFlowMixin:
                 old_port = reconfigure_entry.data.get(CONF_PORT, DEFAULT_PORT)
                 if reconfigure_entry.title == f"{old_host}:{old_port}":
                     title = f"{host}:{port}"
+                # A fresh GS I query result REPLACES prior detected state
+                # (present -> overwrite, absent -> key removed) since
+                # reconfigure may point the entry at a different printer.
+                # data_updates can only add/override keys, never delete
+                # them, so build the full replacement dict instead.
+                new_data = {
+                    **reconfigure_entry.data,
+                    CONF_HOST: host,
+                    CONF_PORT: port,
+                    CONF_TIMEOUT: timeout,
+                }
+                new_data.pop(CONF_DETECTED_MANUFACTURER, None)
+                new_data.pop(CONF_DETECTED_MODEL, None)
+                if detected.get("manufacturer"):
+                    new_data[CONF_DETECTED_MANUFACTURER] = detected["manufacturer"]
+                if detected.get("model"):
+                    new_data[CONF_DETECTED_MODEL] = detected["model"]
+
                 return self.async_update_reload_and_abort(  # type: ignore[attr-defined,no-any-return]
                     reconfigure_entry,
                     unique_id=new_unique_id,
                     title=title,
-                    data_updates={
-                        CONF_HOST: host,
-                        CONF_PORT: port,
-                        CONF_TIMEOUT: timeout,
-                        **(
-                            {CONF_DETECTED_MANUFACTURER: detected["manufacturer"]}
-                            if detected.get("manufacturer")
-                            else {}
-                        ),
-                        **(
-                            {CONF_DETECTED_MODEL: detected["model"]}
-                            if detected.get("model")
-                            else {}
-                        ),
-                    },
+                    data=new_data,
                 )
             errors["base"] = "cannot_connect"
 

--- a/custom_components/escpos_printer/_config_flow/network_steps.py
+++ b/custom_components/escpos_printer/_config_flow/network_steps.py
@@ -84,11 +84,20 @@ class NetworkFlowMixin:
                 _LOGGER.debug("Connection test succeeded for %s:%s", host, port)
 
                 # Best-effort GS I identification. Reuse a discovery-time
-                # result (e.g. DHCP discovery step) instead of querying
-                # again when one is already available.
-                detected = self._detected or (
-                    await self.hass.async_add_executor_job(query_printer_id, host, port, timeout)
-                    or {}
+                # result (e.g. DHCP discovery step) only when the submitted
+                # host still matches the discovered one -- the host field is
+                # just a suggested value, and if the user points it at a
+                # different printer the discovery-time result must not be
+                # attributed to it.
+                detected = (
+                    self._detected
+                    if self._detected and host == self._discovery_host
+                    else (
+                        await self.hass.async_add_executor_job(
+                            query_printer_id, host, port, timeout
+                        )
+                        or {}
+                    )
                 )
 
                 # Store data and determine next step
@@ -141,8 +150,12 @@ class NetworkFlowMixin:
             }
         )
         if self._discovery_host:
+            # Prefer the host the user just typed (on error redisplay) over
+            # the original discovery suggestion, so a typo fix isn't
+            # clobbered back to the discovered address.
+            suggested_host = (user_input or {}).get(CONF_HOST) or self._discovery_host
             data_schema = self.add_suggested_values_to_schema(  # type: ignore[attr-defined]
-                data_schema, {CONF_HOST: self._discovery_host}
+                data_schema, {CONF_HOST: suggested_host}
             )
 
         return self.async_show_form(step_id="network", data_schema=data_schema, errors=errors)  # type: ignore[attr-defined,no-any-return]

--- a/custom_components/escpos_printer/_config_flow/network_steps.py
+++ b/custom_components/escpos_printer/_config_flow/network_steps.py
@@ -50,6 +50,7 @@ class NetworkFlowMixin:
     _user_data: dict[str, Any]
     _detected: dict[str, str]
     _discovery_host: str | None
+    _discovery_port: int | None
 
     async def async_step_network(
         self, user_input: dict[str, Any] | None = None
@@ -85,13 +86,17 @@ class NetworkFlowMixin:
 
                 # Best-effort GS I identification. Reuse a discovery-time
                 # result (e.g. DHCP discovery step) only when the submitted
-                # host still matches the discovered one -- the host field is
-                # just a suggested value, and if the user points it at a
-                # different printer the discovery-time result must not be
-                # attributed to it.
+                # host AND port still match the discovered ones -- the host
+                # field is just a suggested value, and if the user points it
+                # at a different printer (or a different port on the same
+                # host) the discovery-time result must not be attributed to
+                # it. DHCP always probes DEFAULT_PORT, so an edited port
+                # alone is enough to misattribute identity.
                 detected = (
                     self._detected
-                    if self._detected and host == self._discovery_host
+                    if self._detected
+                    and host == self._discovery_host
+                    and port == self._discovery_port
                     else (
                         await self.hass.async_add_executor_job(
                             query_printer_id, host, port, timeout
@@ -130,8 +135,14 @@ class NetworkFlowMixin:
         # Discovery flows ran the GS I query before this form is shown, so
         # the detected model can preselect the profile dropdown (preselect
         # only -- the user always confirms). Manual flows query on submit.
+        # Only preselect while the form's suggested host still equals the
+        # discovery host: once the user edits the host on an error
+        # redisplay, the detected model no longer describes that address.
         default_profile = PROFILE_AUTO
-        detected_model = self._detected.get("model") if self._discovery_host else None
+        suggested_host_matches_discovery = self._discovery_host and (
+            (user_input or {}).get(CONF_HOST, self._discovery_host) == self._discovery_host
+        )
+        detected_model = self._detected.get("model") if suggested_host_matches_discovery else None
         if detected_model:
             suggestion = await self.hass.async_add_executor_job(
                 suggest_profile, detected_model, None, None
@@ -149,11 +160,12 @@ class NetworkFlowMixin:
                 vol.Optional(CONF_PROFILE, default=default_profile): vol.In(profile_choices),
             }
         )
-        if self._discovery_host:
-            # Prefer the host the user just typed (on error redisplay) over
-            # the original discovery suggestion, so a typo fix isn't
-            # clobbered back to the discovered address.
-            suggested_host = (user_input or {}).get(CONF_HOST) or self._discovery_host
+        # Prefer the host the user just typed (on error redisplay) over the
+        # original discovery suggestion, so a typo fix isn't clobbered back
+        # to the discovered address. This also preserves a manually typed
+        # host across an error redisplay on non-discovery flows.
+        suggested_host = (user_input or {}).get(CONF_HOST) or self._discovery_host
+        if suggested_host:
             data_schema = self.add_suggested_values_to_schema(  # type: ignore[attr-defined]
                 data_schema, {CONF_HOST: suggested_host}
             )
@@ -215,19 +227,29 @@ class NetworkFlowMixin:
                 # (present -> overwrite, absent -> key removed) since
                 # reconfigure may point the entry at a different printer.
                 # data_updates can only add/override keys, never delete
-                # them, so build the full replacement dict instead.
+                # them, so build the full replacement dict instead. But
+                # only clear the existing keys when the query actually
+                # answered or the address changed -- reconfiguring just the
+                # timeout while the printer is transiently busy (query
+                # returns None) must not silently destroy a good prior
+                # detection for the SAME address.
+                addr_changed = (host.lower(), port) != (
+                    str(reconfigure_entry.data.get(CONF_HOST, "")).lower(),
+                    reconfigure_entry.data.get(CONF_PORT, DEFAULT_PORT),
+                )
                 new_data = {
                     **reconfigure_entry.data,
                     CONF_HOST: host,
                     CONF_PORT: port,
                     CONF_TIMEOUT: timeout,
                 }
-                new_data.pop(CONF_DETECTED_MANUFACTURER, None)
-                new_data.pop(CONF_DETECTED_MODEL, None)
-                if detected.get("manufacturer"):
-                    new_data[CONF_DETECTED_MANUFACTURER] = detected["manufacturer"]
-                if detected.get("model"):
-                    new_data[CONF_DETECTED_MODEL] = detected["model"]
+                if detected or addr_changed:
+                    new_data.pop(CONF_DETECTED_MANUFACTURER, None)
+                    new_data.pop(CONF_DETECTED_MODEL, None)
+                    if detected.get("manufacturer"):
+                        new_data[CONF_DETECTED_MANUFACTURER] = detected["manufacturer"]
+                    if detected.get("model"):
+                        new_data[CONF_DETECTED_MODEL] = detected["model"]
 
                 return self.async_update_reload_and_abort(  # type: ignore[attr-defined,no-any-return]
                     reconfigure_entry,

--- a/custom_components/escpos_printer/const.py
+++ b/custom_components/escpos_printer/const.py
@@ -21,6 +21,11 @@ CONF_WIDTH_PIXELS = "width_pixels"  # per-entry image width override (overrides 
 # SSRF proxy; cloud-metadata / link-local ranges stay blocked even when on.
 CONF_ALLOW_LOCAL_IMAGE_URLS = "allow_local_image_urls"
 
+# Best-effort GS I identification captured during config flow (network
+# printers only). Absent when the printer didn't answer.
+CONF_DETECTED_MANUFACTURER = "detected_manufacturer"
+CONF_DETECTED_MODEL = "detected_model"
+
 # Connection type configuration
 CONF_CONNECTION_TYPE = "connection_type"
 CONNECTION_TYPE_NETWORK = "network"

--- a/custom_components/escpos_printer/device.py
+++ b/custom_components/escpos_printer/device.py
@@ -12,6 +12,8 @@ from homeassistant.helpers.entity import DeviceInfo
 
 from .const import (
     CONF_CONNECTION_TYPE,
+    CONF_DETECTED_MANUFACTURER,
+    CONF_DETECTED_MODEL,
     CONNECTION_TYPE_BLUETOOTH,
     CONNECTION_TYPE_NETWORK,
     CONNECTION_TYPE_SERIAL,
@@ -57,12 +59,15 @@ def _usb_serial_number(entry: ConfigEntry) -> str | None:
 def build_device_info(entry: ConfigEntry) -> DeviceInfo:
     """Build the DeviceInfo shared by every entity on a config entry."""
     connection_type = entry.data.get(CONF_CONNECTION_TYPE, CONNECTION_TYPE_NETWORK)
-    model = _MODEL_BY_CONNECTION_TYPE.get(connection_type, "Network Printer")
+    model = entry.data.get(CONF_DETECTED_MODEL) or _MODEL_BY_CONNECTION_TYPE.get(
+        connection_type, "Network Printer"
+    )
+    manufacturer = entry.data.get(CONF_DETECTED_MANUFACTURER) or "ESC/POS"
 
     info = DeviceInfo(
         identifiers={(DOMAIN, entry.entry_id)},
         name=f"ESC/POS Printer {entry.title}",
-        manufacturer="ESC/POS",
+        manufacturer=manufacturer,
         model=model,
     )
     if connection_type == CONNECTION_TYPE_USB:

--- a/custom_components/escpos_printer/diagnostics.py
+++ b/custom_components/escpos_printer/diagnostics.py
@@ -11,6 +11,8 @@ from .const import (
     CONF_BT_MAC,
     CONF_CODEPAGE,
     CONF_CONNECTION_TYPE,
+    CONF_DETECTED_MANUFACTURER,
+    CONF_DETECTED_MODEL,
     CONF_IMPL,
     CONF_IN_EP,
     CONF_LINE_WIDTH,
@@ -159,6 +161,8 @@ async def async_get_config_entry_diagnostics(
             CONF_LINE_WIDTH: data.get(CONF_LINE_WIDTH),
             CONF_WIDTH_PIXELS: data.get(CONF_WIDTH_PIXELS),
             CONF_IMPL: data.get(CONF_IMPL),
+            CONF_DETECTED_MANUFACTURER: data.get(CONF_DETECTED_MANUFACTURER),
+            CONF_DETECTED_MODEL: data.get(CONF_DETECTED_MODEL),
         }
 
     payload = {

--- a/custom_components/escpos_printer/manifest.json
+++ b/custom_components/escpos_printer/manifest.json
@@ -5,6 +5,10 @@
     "@cognitivegears"
   ],
   "config_flow": true,
+  "dhcp": [
+    { "hostname": "tm-*" },
+    { "hostname": "rongta_*" }
+  ],
   "documentation": "https://github.com/cognitivegears/ha-escpos-thermal-printer#readme",
   "integration_type": "service",
   "iot_class": "local_polling",

--- a/custom_components/escpos_printer/strings.json
+++ b/custom_components/escpos_printer/strings.json
@@ -1,6 +1,7 @@
 {
   "title": "ESC/POS Thermal Printer",
   "config": {
+    "flow_title": "{name}",
     "step": {
       "user": {
         "title": "Connection Type",
@@ -316,6 +317,7 @@
     "abort": {
       "already_configured": "This printer is already configured.",
       "already_in_progress": "Configuration flow is already in progress.",
+      "cannot_connect": "The discovered device is not accepting printer connections.",
       "invalid_discovery_info": "Invalid USB discovery information.",
       "invalid_usb_device": "Invalid USB device configuration. Vendor ID and Product ID are required.",
       "unique_id_mismatch": "This connection detail belongs to a different printer than the one being reconfigured. Remove and re-add the integration if you want to switch to a different physical printer.",

--- a/custom_components/escpos_printer/translations/en.json
+++ b/custom_components/escpos_printer/translations/en.json
@@ -1,6 +1,7 @@
 {
   "title": "ESC/POS Thermal Printer",
   "config": {
+    "flow_title": "{name}",
     "step": {
       "user": {
         "title": "Connection Type",
@@ -316,6 +317,7 @@
     "abort": {
       "already_configured": "This printer is already configured.",
       "already_in_progress": "Configuration flow is already in progress.",
+      "cannot_connect": "The discovered device is not accepting printer connections.",
       "invalid_discovery_info": "Invalid USB discovery information.",
       "invalid_usb_device": "Invalid USB device configuration. Vendor ID and Product ID are required.",
       "unique_id_mismatch": "This connection detail belongs to a different printer than the one being reconfigured. Remove and re-add the integration if you want to switch to a different physical printer.",

--- a/docs/calibration.md
+++ b/docs/calibration.md
@@ -100,11 +100,10 @@ skips straight to the summary.
 
 ### 5. Summary — save or discard
 
-The final step lists everything measured so far and builds a **share
-link**: a prefilled GitHub issue containing your measured results and a
-draft `escpos-printer-db` profile entry. Enter your printer's model name
-and choose **Update share link with my model** to personalize it, or
-leave it as-is.
+The final step lists everything measured so far and offers an optional
+**model** field, prefilled with the detected model when the printer
+answered the setup/reconfigure identity query (ESC/POS `GS I`) — clear
+or edit it if you'd rather not include it.
 
 Choose one:
 
@@ -114,11 +113,13 @@ Choose one:
 - **Discard (save nothing)** — closes the wizard without changing
   anything.
 
-Saving closes the wizard, which takes the on-screen share link with it. If
-at least one setting was measured, a persistent notification carrying the
-same link is posted so you can still find it afterwards. A run where every
-step was skipped or left unmeasured saves nothing and posts no
-notification.
+Saving builds the **share link** — a prefilled GitHub issue containing
+your measured results, the model (if entered), and a draft
+`escpos-printer-db` profile entry — and shows it on the post-save
+confirmation screen. If at least one setting was measured, a persistent
+notification carrying the same link is posted so you can still find it
+afterwards. A run where every step was skipped or left unmeasured saves
+nothing and posts no notification.
 
 ### Contributing your results
 

--- a/docs/network.md
+++ b/docs/network.md
@@ -23,6 +23,31 @@ Alternatively, check your router's DHCP client list.
 
 **Tip**: assign a static IP (or DHCP reservation). If the printer's address does change, update it in place via **Settings → Devices & services → ESC/POS Thermal Printer → your printer → Reconfigure**; your entities and automations survive intact (no need to delete and re-add).
 
+## Automatic discovery
+
+Home Assistant listens for DHCP announcements matching known thermal-printer
+hostname patterns: `tm-*` for Epson TM-series (the vendor's own device
+naming convention) and `rongta_*` for Rongta. A candidate is probed on
+port 9100 before it's offered; `tm-*` matches additionally have to answer
+an ESC/POS `GS I` identity query, since port 9100 is also the default for
+Prometheus `node_exporter` and other non-printer services. Anything that
+doesn't pass these checks is ignored silently, no notification, no partial
+setup screen.
+
+A discovered printer shows up under **Settings → Devices & Services →
+Discovered**; accepting it prefills the host and preselects the matching
+printer profile.
+
+Separately from discovery, every network setup and reconfigure queries the
+printer directly with `GS I`. Printers that answer (mostly genuine Epson
+hardware) get their real manufacturer/model shown on the device page and
+prefilled into the calibration wizard's share-link model field. Printers
+that don't answer (most clones) behave exactly as before. Reconfigure
+re-runs the query: if the printer's address didn't change and it simply
+fails to answer this time, the previously detected identity is kept; if
+the address changed, or a fresh answer comes back, the stored identity is
+replaced (or cleared, if the new address doesn't answer either).
+
 ## Paper status sensor
 
 Network printers get a `sensor.<printer>_paper_status` entity reporting `ok`, `low`, or `out`, backed by the ESC/POS real-time paper-sensor query (`DLE EOT 4`). It polls on Home Assistant's standard entity cadence and automatically skips a poll while a print is in flight. If the printer doesn't answer the query (not all firmwares implement it) or is unreachable, the sensor shows unavailable. See [automations.md](automations.md) for a paper-low notification example.

--- a/docs/superpowers/plans/2026-08-10-network-printer-identification.md
+++ b/docs/superpowers/plans/2026-08-10-network-printer-identification.md
@@ -1,0 +1,1003 @@
+# Network Printer Identification & DHCP Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Identify network printers via ESC/POS `GS I` transmit-printer-ID queries (device card, profile hint, calibrate prefill) and auto-discover them via DHCP hostname matchers (`tm-*`, `rongta_*`).
+
+**Architecture:** A raw-socket `query_printer_id()` helper in `_config_flow/network_helpers.py` (same style as the existing `_can_connect`) runs during the network config-flow step; results persist as `detected_manufacturer`/`detected_model` in `entry.data` and are consumed by `device.py`, the profile-dropdown default (discovery flows only), and the calibration summary's model field. A new `DiscoveryFlowMixin` (`_config_flow/discovery_steps.py`) handles `async_step_dhcp`: probe port 9100, query the ID, hand off to the existing network form with host prefilled.
+
+**Tech Stack:** Python 3.14, Home Assistant custom integration, voluptuous, pytest + pytest-homeassistant-custom-component. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-08-10-network-printer-identification-design.md`
+
+## Global Constraints
+
+- No new runtime dependencies; `manifest.json` `requirements` unchanged.
+- All printer I/O runs on executor threads via `hass.async_add_executor_job()` — never block the event loop with sockets.
+- `query_printer_id` must never raise and never change printer state (transmit-ID commands are read-only).
+- DHCP matchers are evidence-only: exactly `{"hostname": "tm-*"}` and `{"hostname": "rongta_*"}`. Do not add more.
+- Discovery false positives must abort **silently** (no user-visible card) when port 9100 is closed.
+- Profile suggestion preselects a dropdown default only — never auto-commits a profile.
+- PEP 758 (`except A, B:`) is valid in this repo (Python ≥ 3.14.2 floor); do not "fix" it.
+- Every user-visible change gets a CHANGELOG entry under `## [Unreleased]`.
+- `strings.json` and `translations/en.json` must stay mirrored for every key touched.
+- Verification commands: `uv run pytest -q` (all unit tests), `uv run ruff check .`, `uv run mypy custom_components/`.
+- Commit messages end with:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+
+---
+
+### Task 1: `query_printer_id` helper
+
+**Files:**
+- Modify: `custom_components/escpos_printer/_config_flow/network_helpers.py`
+- Test: `tests/test_network_helpers_query.py` (new)
+
+**Interfaces:**
+- Consumes: nothing new (stdlib `socket`, existing module).
+- Produces: `query_printer_id(host: str, port: int, timeout: float) -> dict[str, str] | None` — keys `"manufacturer"` and/or `"model"` (non-empty strings, either may be absent), or `None` if nothing was identified. Also module-private `_read_id_reply(sock) -> str | None` (unit-tested directly).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_network_helpers_query.py`:
+
+```python
+"""Tests for the GS I printer-ID query helper."""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import MagicMock, patch
+
+from custom_components.escpos_printer._config_flow.network_helpers import (
+    _read_id_reply,
+    query_printer_id,
+)
+
+
+class FakeSocket:
+    """recv() feeds back a canned byte stream one byte at a time."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._buf = list(payload)
+        self.sent: list[bytes] = []
+
+    def recv(self, _n: int) -> bytes:
+        if not self._buf:
+            raise socket.timeout("timed out")
+        return bytes([self._buf.pop(0)])
+
+    def sendall(self, data: bytes) -> None:
+        self.sent.append(data)
+
+    def settimeout(self, _t: float) -> None:
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def test_read_id_reply_happy_path():
+    assert _read_id_reply(FakeSocket(b"\x5fTM-T20II\x00")) == "TM-T20II"
+
+
+def test_read_id_reply_no_data_times_out():
+    assert _read_id_reply(FakeSocket(b"")) is None
+
+
+def test_read_id_reply_missing_header_is_garbage():
+    assert _read_id_reply(FakeSocket(b"TM-T20II\x00")) is None
+
+
+def test_read_id_reply_missing_nul_hits_length_cap():
+    # 200 printable bytes, no terminator: reply is capped, then rejected
+    # only if the header is absent; with header it returns the capped text.
+    assert _read_id_reply(FakeSocket(b"\x5f" + b"A" * 200)) == "A" * 79
+
+
+def test_read_id_reply_empty_string_reply():
+    assert _read_id_reply(FakeSocket(b"\x5f\x00")) is None
+
+
+def test_read_id_reply_strips_nonascii():
+    assert _read_id_reply(FakeSocket(b"\x5fTM\xff-T20\x00")) == "TM-T20"
+
+
+def test_query_printer_id_both_replies():
+    payload = b"\x5fEPSON\x00\x5fTM-T20II\x00"
+    fake = FakeSocket(payload)
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_helpers.socket.create_connection",
+        return_value=fake,
+    ):
+        result = query_printer_id("192.168.10.157", 9100, 4.0)
+    assert result == {"manufacturer": "EPSON", "model": "TM-T20II"}
+    assert fake.sent == [b"\x1d\x49\x42", b"\x1d\x49\x43"]
+
+
+def test_query_printer_id_silent_clone_returns_none():
+    # Clone never answers: first read times out -> None, no exception.
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_helpers.socket.create_connection",
+        return_value=FakeSocket(b""),
+    ):
+        assert query_printer_id("192.168.10.157", 9100, 4.0) is None
+
+
+def test_query_printer_id_maker_only():
+    # Maker answers, model read times out -> partial dict survives.
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_helpers.socket.create_connection",
+        return_value=FakeSocket(b"\x5fEPSON\x00"),
+    ):
+        assert query_printer_id("192.168.10.157", 9100, 4.0) == {"manufacturer": "EPSON"}
+
+
+def test_query_printer_id_connection_refused_returns_none():
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_helpers.socket.create_connection",
+        side_effect=ConnectionRefusedError,
+    ):
+        assert query_printer_id("192.168.10.157", 9100, 4.0) is None
+
+
+def test_query_printer_id_never_raises_on_weird_oserror():
+    sock = MagicMock()
+    sock.__enter__ = MagicMock(return_value=sock)
+    sock.__exit__ = MagicMock(return_value=False)
+    sock.sendall.side_effect = OSError("broken pipe")
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_helpers.socket.create_connection",
+        return_value=sock,
+    ):
+        assert query_printer_id("192.168.10.157", 9100, 4.0) is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_network_helpers_query.py -v`
+Expected: FAIL — `ImportError: cannot import name '_read_id_reply'`
+
+- [ ] **Step 3: Implement the helper**
+
+Append to `custom_components/escpos_printer/_config_flow/network_helpers.py` (after `_can_connect`):
+
+```python
+# --- GS I (Transmit Printer ID) query -------------------------------------
+#
+# Epson network printers answer GS I 66/67 with the maker/model name framed
+# as 0x5F <ascii> 0x00. Clones typically ignore the command entirely; the
+# short read timeout turns that silence into a clean None. The commands are
+# read-only: nothing is printed and no printer state changes.
+
+_GS_I_MAKER = b"\x1d\x49\x42"  # GS I 66 -> maker name ("EPSON")
+_GS_I_MODEL = b"\x1d\x49\x43"  # GS I 67 -> model name ("TM-T20II")
+_ID_HEADER = 0x5F
+_ID_MAX_LEN = 80
+_ID_READ_TIMEOUT = 2.0
+
+
+def _read_id_reply(sock: socket.socket) -> str | None:
+    """Read one 0x5F...0x00 framed reply; None on timeout/garbage/empty."""
+    data = bytearray()
+    try:
+        while len(data) < _ID_MAX_LEN:
+            chunk = sock.recv(1)
+            if not chunk or chunk == b"\x00":
+                break
+            data += chunk
+    except OSError:
+        pass  # timeout mid-reply: fall through and parse what we have
+    if not data or data[0] != _ID_HEADER:
+        return None
+    text = data[1:].decode("ascii", errors="ignore").strip()
+    return text or None
+
+
+def query_printer_id(host: str, port: int, timeout: float) -> dict[str, str] | None:
+    """Best-effort printer identification via GS I over raw TCP.
+
+    Returns {"manufacturer": ..., "model": ...} (either key may be
+    absent), or None when nothing was identified. Never raises.
+    """
+    result: dict[str, str] = {}
+    try:
+        with socket.create_connection((host, port), timeout=timeout) as sock:
+            sock.settimeout(_ID_READ_TIMEOUT)
+            for key, command in (("manufacturer", _GS_I_MAKER), ("model", _GS_I_MODEL)):
+                sock.sendall(command)
+                value = _read_id_reply(sock)
+                if value is None:
+                    break  # no answer: don't wait out a second timeout
+                result[key] = value
+    except OSError:
+        _LOGGER.debug("GS I query failed for %s:%s", host, port)
+    return result or None
+```
+
+Note `_read_id_reply` swallows the timeout itself, so `query_printer_id`'s
+`break` fires on silence — a silent clone costs one ~2 s read timeout, not two.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_network_helpers_query.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+Run: `uv run ruff check . && uv run mypy custom_components/`
+Expected: clean.
+
+```bash
+git add custom_components/escpos_printer/_config_flow/network_helpers.py tests/test_network_helpers_query.py
+git commit -m "feat: GS I printer-ID query helper for network printers
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Persist detected fields through the network config flow
+
+**Files:**
+- Modify: `custom_components/escpos_printer/const.py` (add two CONF_ keys near the other configuration keys, ~line 22)
+- Modify: `custom_components/escpos_printer/_config_flow/main_flow.py:46-53` (`__init__`)
+- Modify: `custom_components/escpos_printer/_config_flow/network_steps.py`
+- Modify: `tests/test_config_flow.py` (existing network-step tests must patch the new query)
+- Test: `tests/test_config_flow.py` (new tests appended)
+
+**Interfaces:**
+- Consumes: `query_printer_id(host, port, timeout) -> dict[str, str] | None` from Task 1 (keys `"manufacturer"`/`"model"`).
+- Produces:
+  - `const.CONF_DETECTED_MANUFACTURER = "detected_manufacturer"` and `const.CONF_DETECTED_MODEL = "detected_model"` — `entry.data` keys later tasks read.
+  - `EscposConfigFlow._detected: dict[str, str]` — raw query result (keys `"manufacturer"`/`"model"`), populated by discovery (Task 5) or by the network submit; consumed by the network step.
+
+- [ ] **Step 1: Add the constants**
+
+In `custom_components/escpos_printer/const.py`, after `CONF_ALLOW_LOCAL_IMAGE_URLS`:
+
+```python
+# Best-effort GS I identification captured during config flow (network
+# printers only). Absent when the printer didn't answer.
+CONF_DETECTED_MANUFACTURER = "detected_manufacturer"
+CONF_DETECTED_MODEL = "detected_model"
+```
+
+- [ ] **Step 2: Update existing tests to patch the query (they would otherwise open real sockets)**
+
+Every existing test that patches `network_steps._can_connect` drives the network submit path, which now also calls `query_printer_id`. Find them:
+
+Run: `grep -rn "network_steps._can_connect" tests/`
+
+In **each** listed `with patch(...)` context (files: `tests/test_config_flow.py`, `tests/test_config_flow_options_and_duplicate.py`, `tests/test_config_flow_reconfigure.py`, `tests/test_config_flow_negative.py` — confirm via the grep), add a second patch alongside:
+
+```python
+patch(
+    "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+    return_value=None,
+),
+```
+
+(Patch target is `network_steps.query_printer_id` because Step 3 imports it into that namespace.) Tests that only exercise `cannot_connect` never reach the query, but patching uniformly is harmless and future-proof.
+
+- [ ] **Step 3: Write the failing new tests**
+
+Append to `tests/test_config_flow.py`:
+
+```python
+async def test_network_flow_persists_detected_fields(hass):
+    """GS I result lands in entry.data as detected_manufacturer/model."""
+    from custom_components.escpos_printer.const import (
+        CONF_DETECTED_MANUFACTURER,
+        CONF_DETECTED_MODEL,
+    )
+
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value={"manufacturer": "EPSON", "model": "TM-T20II"},
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.168.10.157", CONF_PORT: 9100}
+        )
+        # Complete the codepage step with defaults to create the entry.
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_DETECTED_MANUFACTURER] == "EPSON"
+    assert result["data"][CONF_DETECTED_MODEL] == "TM-T20II"
+
+
+async def test_network_flow_no_reply_omits_detected_fields(hass):
+    """query_printer_id -> None leaves entry.data without detected keys."""
+    from custom_components.escpos_printer.const import CONF_DETECTED_MODEL
+
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.168.10.157", CONF_PORT: 9100}
+        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert CONF_DETECTED_MODEL not in result["data"]
+```
+
+Match the file's existing import style — it already imports `DOMAIN`, `CONF_HOST`, `CONF_PORT`, `config_entries`, `FlowResultType`, `patch`, and the codepage-step submit pattern (see the happy-path test at the top of the file); reuse those instead of re-importing. If the codepage step needs explicit fields in existing tests, copy the exact dict those tests pass.
+
+- [ ] **Step 4: Run new tests to verify they fail**
+
+Run: `uv run pytest tests/test_config_flow.py -v -k detected`
+Expected: FAIL — `ImportError` (constants) or missing keys in `result["data"]`
+
+- [ ] **Step 5: Implement flow persistence**
+
+In `custom_components/escpos_printer/_config_flow/main_flow.py` `__init__` (line ~49), add:
+
+```python
+        self._detected: dict[str, str] = {}
+```
+
+In `custom_components/escpos_printer/_config_flow/network_steps.py`:
+
+1. Extend the `.network_helpers` import (line 26):
+
+```python
+from .network_helpers import _can_connect, query_printer_id
+```
+
+2. Extend the `..const` import block (lines 18-25) with `CONF_DETECTED_MANUFACTURER, CONF_DETECTED_MODEL`.
+
+3. In `async_step_network`, in the `if ok:` branch (after line 79's debug log, before `self._user_data = {...}`), run the query — reusing a discovery-time result when present:
+
+```python
+                detected = self._detected or (
+                    await self.hass.async_add_executor_job(
+                        query_printer_id, host, port, timeout
+                    )
+                    or {}
+                )
+```
+
+and after the `self._user_data = {...}` assignment (line 89), merge it in:
+
+```python
+                if detected.get("manufacturer"):
+                    self._user_data[CONF_DETECTED_MANUFACTURER] = detected["manufacturer"]
+                if detected.get("model"):
+                    self._user_data[CONF_DETECTED_MODEL] = detected["model"]
+```
+
+4. In `async_step_reconfigure_network`, in its `if ok:` branch (before the `title` logic at line 158), add:
+
+```python
+                detected = (
+                    await self.hass.async_add_executor_job(
+                        query_printer_id, host, port, timeout
+                    )
+                    or {}
+                )
+```
+
+and extend `data_updates` (lines 167-171):
+
+```python
+                data_updates={
+                    CONF_HOST: host,
+                    CONF_PORT: port,
+                    CONF_TIMEOUT: timeout,
+                    **(
+                        {CONF_DETECTED_MANUFACTURER: detected["manufacturer"]}
+                        if detected.get("manufacturer")
+                        else {}
+                    ),
+                    **(
+                        {CONF_DETECTED_MODEL: detected["model"]}
+                        if detected.get("model")
+                        else {}
+                    ),
+                },
+```
+
+`type: ignore[attr-defined]` comments follow the file's existing pattern for mixin attributes if mypy complains about `self._detected`; prefer declaring it in the mixin's expected-attributes block (add `_detected: dict[str, str]` under `_user_data: dict[str, Any]` at line 47).
+
+- [ ] **Step 6: Run the full flow test files**
+
+Run: `uv run pytest tests/test_config_flow.py tests/test_config_flow_options_and_duplicate.py tests/test_config_flow_reconfigure.py tests/test_config_flow_negative.py -q`
+Expected: all PASS (including the pre-existing tests updated in Step 2)
+
+- [ ] **Step 7: Lint, type-check, commit**
+
+Run: `uv run ruff check . && uv run mypy custom_components/`
+
+```bash
+git add custom_components/escpos_printer/const.py custom_components/escpos_printer/_config_flow/main_flow.py custom_components/escpos_printer/_config_flow/network_steps.py tests/
+git commit -m "feat: persist GS I detected manufacturer/model in network entries
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Device registry shows detected manufacturer/model
+
+**Files:**
+- Modify: `custom_components/escpos_printer/device.py:57-72`
+- Test: `tests/test_device_info.py`
+
+**Interfaces:**
+- Consumes: `CONF_DETECTED_MANUFACTURER` / `CONF_DETECTED_MODEL` from Task 2.
+- Produces: no new interface — `build_device_info(entry)` behavior change only.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_device_info.py` (mirror its existing entry-fixture style — it builds `MockConfigEntry` objects with `data={...}`; copy the exact constructor form used by the existing network test):
+
+```python
+def test_device_info_prefers_detected_fields():
+    entry = _make_entry(  # use the file's existing helper/constructor pattern
+        data={
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK,
+            CONF_DETECTED_MANUFACTURER: "EPSON",
+            CONF_DETECTED_MODEL: "TM-T20II",
+        }
+    )
+    info = build_device_info(entry)
+    assert info["manufacturer"] == "EPSON"
+    assert info["model"] == "TM-T20II"
+
+
+def test_device_info_falls_back_without_detected_fields():
+    entry = _make_entry(data={CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK})
+    info = build_device_info(entry)
+    assert info["manufacturer"] == "ESC/POS"
+    assert info["model"] == "Network Printer"
+```
+
+(Adapt `_make_entry` to whatever the file actually uses; the assertions are the contract.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_device_info.py -v`
+Expected: new tests FAIL (manufacturer is `"ESC/POS"`)
+
+- [ ] **Step 3: Implement**
+
+In `custom_components/escpos_printer/device.py`, extend the `.const` import with `CONF_DETECTED_MANUFACTURER, CONF_DETECTED_MODEL`, then change `build_device_info`:
+
+```python
+def build_device_info(entry: ConfigEntry) -> DeviceInfo:
+    """Build the DeviceInfo shared by every entity on a config entry."""
+    connection_type = entry.data.get(CONF_CONNECTION_TYPE, CONNECTION_TYPE_NETWORK)
+    model = entry.data.get(CONF_DETECTED_MODEL) or _MODEL_BY_CONNECTION_TYPE.get(
+        connection_type, "Network Printer"
+    )
+    manufacturer = entry.data.get(CONF_DETECTED_MANUFACTURER) or "ESC/POS"
+
+    info = DeviceInfo(
+        identifiers={(DOMAIN, entry.entry_id)},
+        name=f"ESC/POS Printer {entry.title}",
+        manufacturer=manufacturer,
+        model=model,
+    )
+    if connection_type == CONNECTION_TYPE_USB:
+        serial = _usb_serial_number(entry)
+        if serial:
+            info["serial_number"] = serial
+    return info
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_device_info.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+Run: `uv run ruff check . && uv run mypy custom_components/`
+
+```bash
+git add custom_components/escpos_printer/device.py tests/test_device_info.py
+git commit -m "feat: device registry shows GS I detected manufacturer/model
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Calibration share-link model prefill
+
+**Files:**
+- Modify: `custom_components/escpos_printer/_config_flow/calibration_steps.py` (`async_step_calibrate_summary`, the `vol.Optional("model", default="")` schema)
+- Test: `tests/test_calibration_flow.py`
+
+**Interfaces:**
+- Consumes: `CONF_DETECTED_MODEL` from Task 2 (via `self.config_entry.data`).
+- Produces: no new interface.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_calibration_flow.py`, following its existing options-flow setup pattern (it initializes the options flow and steps to `calibrate_summary`; copy the shortest existing summary-step test's scaffolding):
+
+```python
+async def test_calibrate_summary_prefills_detected_model(hass):
+    """The share-link model field defaults to entry.data's detected model."""
+    # Build the entry exactly like the file's existing summary tests, but
+    # with CONF_DETECTED_MODEL: "TM-T20II" added to the entry data dict.
+    ...  # scaffold copied from existing test
+    # Reach the calibrate_summary form, then:
+    schema = result["data_schema"].schema
+    model_key = next(k for k in schema if k.schema == "model")
+    assert model_key.default() == "TM-T20II"
+```
+
+(The scaffold is intentionally copied from the neighboring test in the same file — the new assertion block is the contract. Voluptuous stores defaults as callables, hence `model_key.default()`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_calibration_flow.py -v -k prefills`
+Expected: FAIL — default is `""`
+
+- [ ] **Step 3: Implement**
+
+In `custom_components/escpos_printer/_config_flow/calibration_steps.py`:
+
+1. Extend the `..const` import with `CONF_DETECTED_MODEL`.
+2. In `async_step_calibrate_summary`, change the schema line:
+
+```python
+        schema = vol.Schema(
+            {
+                vol.Optional(
+                    "model",
+                    default=self.config_entry.data.get(CONF_DETECTED_MODEL, ""),
+                ): str,
+                vol.Required("action", default="save"): vol.In(_SUMMARY_ACTION_CHOICES),
+            }
+        )
+```
+
+- [ ] **Step 4: Run test file to verify it passes**
+
+Run: `uv run pytest tests/test_calibration_flow.py -q`
+Expected: all PASS
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+Run: `uv run ruff check . && uv run mypy custom_components/`
+
+```bash
+git add custom_components/escpos_printer/_config_flow/calibration_steps.py tests/test_calibration_flow.py
+git commit -m "feat: calibrate share-link model prefills from GS I detection
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+**Note:** `calibration_steps.py` has uncommitted user changes in the worktree. Do NOT `git stash`/`git reset`. Commit only the specific files listed (`git add` exactly those paths); if the user's uncommitted hunks are in the same file, commit the file as-is (their changes ride along is NOT acceptable — instead use `git add -p`-free approach: verify with `git diff --cached` before committing that only intended hunks are staged; if the user's unrelated hunks would be swept in, stop and report instead of committing).
+
+---
+
+### Task 5: DHCP discovery step
+
+**Files:**
+- Modify: `custom_components/escpos_printer/manifest.json` (add `dhcp` key)
+- Create: `custom_components/escpos_printer/_config_flow/discovery_steps.py`
+- Modify: `custom_components/escpos_printer/_config_flow/main_flow.py` (mixin wiring)
+- Modify: `custom_components/escpos_printer/strings.json` + `custom_components/escpos_printer/translations/en.json` (`flow_title`, `abort.cannot_connect`)
+- Test: `tests/test_config_flow_dhcp.py` (new)
+
+**Interfaces:**
+- Consumes: `query_printer_id` (Task 1), `self._detected` (Task 2), `_can_connect` (existing), `CONF_DETECTED_MODEL` (Task 2).
+- Produces: `DiscoveryFlowMixin.async_step_dhcp(discovery_info: DhcpServiceInfo) -> ConfigFlowResult`; sets `self._detected` and `self._discovery_host` (a `str | None`, consumed by Task 6's network-form prefill).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_config_flow_dhcp.py`:
+
+```python
+"""DHCP discovery flow tests."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.escpos_printer.const import DOMAIN
+
+DISCOVERY = DhcpServiceInfo(
+    ip="192.168.10.157",
+    hostname="TM-T20II-628E52",
+    macaddress="50579c628e52",
+)
+
+
+async def _start_dhcp_flow(hass, can_connect=True, query_result=None):
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.discovery_steps._can_connect",
+            return_value=can_connect,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.discovery_steps.query_printer_id",
+            return_value=query_result,
+        ),
+    ):
+        return await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_DHCP}, data=DISCOVERY
+        )
+
+
+async def test_dhcp_discovery_shows_network_form(hass):
+    result = await _start_dhcp_flow(
+        hass, query_result={"manufacturer": "EPSON", "model": "TM-T20II"}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "network"
+    # Host is prefilled from discovery.
+    assert result["data_schema"]({})["host"] == "192.168.10.157"
+
+
+async def test_dhcp_discovery_title_uses_detected_model(hass):
+    await _start_dhcp_flow(hass, query_result={"model": "TM-T20II"})
+    flow = hass.config_entries.flow.async_progress()[0]
+    assert flow["context"]["title_placeholders"] == {"name": "TM-T20II (192.168.10.157)"}
+
+
+async def test_dhcp_discovery_title_falls_back_to_hostname(hass):
+    await _start_dhcp_flow(hass, query_result=None)
+    flow = hass.config_entries.flow.async_progress()[0]
+    assert flow["context"]["title_placeholders"] == {
+        "name": "TM-T20II-628E52 (192.168.10.157)"
+    }
+
+
+async def test_dhcp_discovery_aborts_when_port_closed(hass):
+    result = await _start_dhcp_flow(hass, can_connect=False)
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+async def test_dhcp_discovery_aborts_when_already_configured(hass):
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="192.168.10.157:9100",
+        data={"connection_type": "network", "host": "192.168.10.157", "port": 9100},
+    ).add_to_hass(hass)
+    result = await _start_dhcp_flow(hass)
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+```
+
+If `result["data_schema"]({})` errors on other required-field defaults, assert the suggested value instead: `result["data_schema"].schema` iteration checking the `host` marker's `description["suggested_value"]` — pick whichever mechanism Task 6 Step 3 implements (suggested values; see that task).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_config_flow_dhcp.py -v`
+Expected: FAIL — flow raises `UnknownStep` / `data_entry_flow.UnknownHandler` for source `dhcp`
+
+- [ ] **Step 3: Add the manifest matchers**
+
+In `custom_components/escpos_printer/manifest.json`, after the `"documentation"` key (alphabetical-ish placement with the existing keys, matching hassfest ordering: `dhcp` sorts after `documentation`... hassfest requires: domain, name, then alphabetical. Place `"dhcp"` between `"config_flow"` and `"documentation"`):
+
+```json
+  "dhcp": [
+    { "hostname": "tm-*" },
+    { "hostname": "rongta_*" }
+  ],
+```
+
+Evidence (do not extend this list): Epson FAQ KA-01071 documents "product name + last 6 MAC digits" defaults (`TM-T88VI-C3FE21`, `TM-m30-FED95E`; user-verified `TM-T20II-628E52`); user-verified `Rongta_RP820`, generalized to the brand prefix because Rongta manufactures only printers.
+
+- [ ] **Step 4: Create the discovery mixin**
+
+Create `custom_components/escpos_printer/_config_flow/discovery_steps.py`:
+
+```python
+"""DHCP discovery step mixin.
+
+Evidence-only hostname matchers live in manifest.json ("tm-*", "rongta_*").
+A match is confirmed by a TCP probe of port 9100 before the user ever sees
+a discovery card, so matcher false positives abort silently. The existing
+network form is the confirmation UI — discovery just prefills it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+
+from ..const import DEFAULT_PORT, DEFAULT_TIMEOUT
+from .network_helpers import _can_connect, query_printer_id
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DiscoveryFlowMixin:
+    """Mixin providing the DHCP discovery entry point.
+
+    Expects from the composed flow class:
+    - hass, async_set_unique_id(), _abort_if_unique_id_configured(),
+      async_abort(), async_step_network()
+    - _detected: dict[str, str] (main_flow.__init__)
+    - _discovery_host: str | None (main_flow.__init__)
+    """
+
+    hass: Any
+    _detected: dict[str, str]
+    _discovery_host: str | None
+
+    async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> ConfigFlowResult:
+        """Handle a DHCP-discovered printer candidate."""
+        host = discovery_info.ip
+        await self.async_set_unique_id(f"{host.lower()}:{DEFAULT_PORT}")  # type: ignore[attr-defined]
+        self._abort_if_unique_id_configured()  # type: ignore[attr-defined]
+
+        if not await self.hass.async_add_executor_job(
+            _can_connect, host, DEFAULT_PORT, DEFAULT_TIMEOUT
+        ):
+            _LOGGER.debug("DHCP match %s (%s) not listening on %s; ignoring",
+                          discovery_info.hostname, host, DEFAULT_PORT)
+            return self.async_abort(reason="cannot_connect")  # type: ignore[attr-defined,no-any-return]
+
+        self._detected = (
+            await self.hass.async_add_executor_job(
+                query_printer_id, host, DEFAULT_PORT, DEFAULT_TIMEOUT
+            )
+            or {}
+        )
+        self._discovery_host = host
+        name = self._detected.get("model") or discovery_info.hostname
+        self.context["title_placeholders"] = {"name": f"{name} ({host})"}  # type: ignore[attr-defined]
+        return await self.async_step_network()  # type: ignore[attr-defined,no-any-return]
+```
+
+- [ ] **Step 5: Wire the mixin and flow state**
+
+In `custom_components/escpos_printer/_config_flow/main_flow.py`:
+
+1. Import: `from .discovery_steps import DiscoveryFlowMixin`
+2. Add `DiscoveryFlowMixin,` to the `EscposConfigFlow(...)` base list (after `NetworkFlowMixin,`).
+3. In `__init__`, alongside `self._detected` (Task 2), add:
+
+```python
+        self._discovery_host: str | None = None
+```
+
+- [ ] **Step 6: Add strings**
+
+In `custom_components/escpos_printer/strings.json` **and** `custom_components/escpos_printer/translations/en.json` (mirror exactly), inside the `"config"` object:
+
+1. Top-level of `"config"` (sibling of `"step"`):
+
+```json
+"flow_title": "{name}",
+```
+
+2. In `"config"."abort"`, add:
+
+```json
+"cannot_connect": "The discovered device is not accepting printer connections."
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `uv run pytest tests/test_config_flow_dhcp.py -v`
+Expected: the abort tests PASS; the two form tests may still FAIL on host prefill (delivered by Task 6). If so, mark them `@pytest.mark.xfail(reason="host prefill lands in next task", strict=True)` **only** for `test_dhcp_discovery_shows_network_form`, and remove the xfail in Task 6. The title tests must pass now.
+
+- [ ] **Step 8: Lint, type-check, commit**
+
+Run: `uv run ruff check . && uv run mypy custom_components/`
+
+```bash
+git add custom_components/escpos_printer/manifest.json custom_components/escpos_printer/_config_flow/discovery_steps.py custom_components/escpos_printer/_config_flow/main_flow.py custom_components/escpos_printer/strings.json custom_components/escpos_printer/translations/en.json tests/test_config_flow_dhcp.py
+git commit -m "feat: DHCP discovery for Epson TM and Rongta network printers
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Network form prefill + profile preselect for discovery flows
+
+**Files:**
+- Modify: `custom_components/escpos_printer/_config_flow/network_steps.py` (form-building tail of `async_step_network`, lines 101-115)
+- Test: `tests/test_config_flow_dhcp.py` (extend; remove Task 5's xfail)
+
+**Interfaces:**
+- Consumes: `self._discovery_host`, `self._detected` (Tasks 2/5), `suggest_profile(product, vid, pid) -> str | None` from `..capabilities.suggestions` (existing).
+- Produces: no new interface — discovery-initiated network forms open with host suggested and profile default preselected.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_config_flow_dhcp.py`: remove the `xfail` marker from `test_dhcp_discovery_shows_network_form` (if applied), and append:
+
+```python
+async def test_dhcp_discovery_preselects_suggested_profile(hass):
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_steps.suggest_profile",
+        return_value="TM-T20II",
+    ):
+        result = await _start_dhcp_flow(hass, query_result={"model": "TM-T20II"})
+    assert result["step_id"] == "network"
+    defaults = result["data_schema"]({"host": "192.168.10.157"})
+    assert defaults["profile"] == "TM-T20II"
+
+
+async def test_dhcp_discovery_unknown_model_keeps_auto_profile(hass):
+    from custom_components.escpos_printer.capabilities import PROFILE_AUTO
+
+    result = await _start_dhcp_flow(hass, query_result={"model": "Mystery-9000"})
+    defaults = result["data_schema"]({"host": "192.168.10.157"})
+    assert defaults["profile"] == PROFILE_AUTO
+```
+
+(`suggest_profile` must be importable from `network_steps`' namespace — Step 3 imports it there. The second test uses the real `suggest_profile`, which returns no match for "Mystery-9000".)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_config_flow_dhcp.py -v`
+Expected: new tests FAIL (`suggest_profile` not in `network_steps`, profile default is `PROFILE_AUTO`, host not prefilled)
+
+- [ ] **Step 3: Implement**
+
+In `custom_components/escpos_printer/_config_flow/network_steps.py`:
+
+1. Add import: `from ..capabilities.suggestions import suggest_profile`
+2. Declare the mixin-expected attribute under `_user_data` (line 47): `_discovery_host: str | None`
+3. Replace the form-building tail (lines 101-115) with:
+
+```python
+        # Build profile choices dynamically
+        profile_choices = await self.hass.async_add_executor_job(get_profile_choices_dict)
+
+        # Discovery flows ran the GS I query before this form is shown, so
+        # the detected model can preselect the profile dropdown (preselect
+        # only -- the user always confirms). Manual flows query on submit.
+        default_profile = PROFILE_AUTO
+        detected_model = self._detected.get("model") if self._discovery_host else None
+        if detected_model:
+            suggestion = await self.hass.async_add_executor_job(
+                suggest_profile, detected_model, None, None
+            )
+            if suggestion and suggestion in profile_choices:
+                default_profile = suggestion
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_HOST): str,
+                vol.Optional(CONF_PORT, default=DEFAULT_PORT): vol.All(
+                    vol.Coerce(int), vol.Range(min=1, max=65535)
+                ),
+                vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.Coerce(float),
+                vol.Optional(CONF_PROFILE, default=default_profile): vol.In(profile_choices),
+            }
+        )
+        if self._discovery_host:
+            data_schema = self.add_suggested_values_to_schema(  # type: ignore[attr-defined]
+                data_schema, {CONF_HOST: self._discovery_host}
+            )
+
+        return self.async_show_form(step_id="network", data_schema=data_schema, errors=errors)  # type: ignore[attr-defined,no-any-return]
+```
+
+Note: `add_suggested_values_to_schema` sets the form's suggested value; adjust Task 5's `test_dhcp_discovery_shows_network_form` host assertion to read the suggested value from the schema marker if `schema({})` doesn't materialize it:
+
+```python
+    host_marker = next(k for k in result["data_schema"].schema if k.schema == "host")
+    assert host_marker.description["suggested_value"] == "192.168.10.157"
+```
+
+4. Also declare `_detected: dict[str, str]` in the mixin-expected attributes if Task 2 didn't already.
+
+- [ ] **Step 4: Run the dhcp + network flow tests**
+
+Run: `uv run pytest tests/test_config_flow_dhcp.py tests/test_config_flow.py -q`
+Expected: all PASS (manual-flow tests unaffected: `_discovery_host` is None there, so default stays `PROFILE_AUTO` and no suggested host is injected)
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+Run: `uv run ruff check . && uv run mypy custom_components/`
+
+```bash
+git add custom_components/escpos_printer/_config_flow/network_steps.py tests/test_config_flow_dhcp.py
+git commit -m "feat: discovery prefills host and preselects suggested profile
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Docs — CHANGELOG and README
+
+**Files:**
+- Modify: `CHANGELOG.md` (`## [Unreleased]` section — file has uncommitted user edits; append without touching existing hunks, commit only if the staged diff contains only these lines, otherwise report)
+- Modify: `README.md` (add a short "Discovery" subsection near the existing setup/connection docs)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: CHANGELOG entries**
+
+Under `## [Unreleased]` → `### Added` (create the subsection if absent, matching the file's existing style):
+
+```markdown
+- Network printers are identified at setup via ESC/POS `GS I` queries: the
+  device page shows the real manufacturer/model (e.g. EPSON TM-T20II), and
+  the calibration share link prefills the model name. Printers that don't
+  answer (most clones) behave exactly as before.
+- DHCP discovery for network thermal printers: Home Assistant now offers to
+  set up Epson TM-series (`tm-*`) and Rongta (`rongta_*`) printers it sees
+  join the network. Candidates are probed on port 9100 first, so matches
+  that aren't printers are ignored silently. Discovered setups preselect
+  the matching printer profile when one is known.
+```
+
+- [ ] **Step 2: README "Discovery" note**
+
+Locate the network setup section (`grep -n "Network" README.md | head`) and add beneath it:
+
+```markdown
+### Automatic discovery
+
+Epson TM-series and Rongta network printers announce recognizable DHCP
+hostnames; Home Assistant will offer to set them up automatically when they
+appear on your network (Settings → Devices & Services → Discovered). Other
+brands and printers with hostname broadcasting disabled can always be added
+manually by IP address. During setup, the integration asks the printer to
+identify itself (ESC/POS `GS I`); Epson printers answer with their real
+model name, which fills the device page and suggests the matching profile.
+Printers that don't answer are configured exactly as before.
+```
+
+Adjust heading level/placement to match the README's existing structure.
+
+- [ ] **Step 3: Verify docs and commit**
+
+Run: `git diff --cached` after staging to confirm ONLY the new lines are included (CHANGELOG.md and ROADMAP.md carry unrelated uncommitted user edits — if the user's hunks can't be separated with a plain `git add`, stop and report rather than committing them).
+
+```bash
+git add README.md
+git add CHANGELOG.md   # only if the diff check above confirmed separability; otherwise report
+git commit -m "docs: changelog and README for GS I identification and DHCP discovery
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 4: Full verification sweep**
+
+Run: `uv run pytest -q && uv run ruff check . && uv run mypy custom_components/`
+Expected: all green. Report the final output verbatim.

--- a/docs/superpowers/specs/2026-08-10-network-printer-identification-design.md
+++ b/docs/superpowers/specs/2026-08-10-network-printer-identification-design.md
@@ -1,0 +1,160 @@
+# Network Printer Identification & DHCP Discovery — Design
+
+Date: 2026-08-10
+Status: approved
+
+## Problem
+
+Network printers register in the HA device registry as manufacturer "ESC/POS",
+model "Network Printer" (`device.py:57-72`), and the integration has no network
+discovery — users must know the printer's IP and type it in. Meanwhile the
+printer itself will happily tell us what it is (Epson answers ESC/POS
+`GS I` transmit-printer-ID queries over the same TCP 9100 socket we already
+print through), and thermal printers announce identifiable DHCP hostnames
+(vendor-documented for Epson, user-verified for Epson and Rongta).
+
+## Scope
+
+Two features sharing one core:
+
+1. **`GS I` model query** — best-effort identification of the connected
+   printer's maker/model during config flow, persisted to the entry and used in
+   three existing surfaces.
+2. **DHCP discovery** — evidence-backed hostname matchers so HA offers to set
+   up a thermal printer it sees join the network.
+
+### Explicitly out of scope (and why)
+
+- **Zeroconf/mDNS discovery.** Research found no verifiable documentation of
+  Epson TM mDNS behavior; HA core ships no printer DHCP prior art; and an
+  empirical browse on the author's own network (where mDNS demonstrably
+  flows — HA's `_home-assistant._tcp` was visible) showed the TM-T20II
+  advertises no service at all. Add later with evidence.
+- **OUI-based matchers.** Epson's 22 OUIs are shared with projectors/inkjets.
+  Bixolon's `00:15:94` is the one credible candidate (single-purpose printer
+  vendor) but guarantees only "Bixolon printer", not "ESC/POS receipt
+  printer" — deferred until a user report confirms one working.
+- **MAC-based unique IDs.** unique_id stays `host:port`; a printer whose DHCP
+  lease changes IP is re-discovered as a new device. The fix (entry migration
+  to MAC-keyed IDs) isn't worth it now; a DHCP reservation is the standard
+  answer.
+- **Querying at adapter start / device-registry refresh after setup.** The
+  model can't change between setups of the same printer; existing entries pick
+  the fields up on their next reconfigure.
+
+## Feature 1: `GS I` model query
+
+### Helper
+
+`query_printer_id(host, port, timeout) -> dict | None` in
+`_config_flow/network_helpers.py`, next to `_can_connect` (same raw-socket
+style, `network_helpers.py:29-46`; no adapter needed in the flow). Runs on an
+executor job.
+
+- Opens a socket, sends `GS I 66` (0x1D 0x49 0x42 — maker name) then
+  `GS I 67` (0x1D 0x49 0x43 — model name).
+- Reads replies framed as `0x5F <ascii string> 0x00` with a short (~2 s) read
+  timeout per reply.
+- Returns `{"manufacturer": str, "model": str}` (either key may be absent if
+  only one reply parsed) or `None` on timeout / garbage / connection error.
+- Never raises out of the helper; never prints or changes printer state
+  (transmit-ID commands are read-only). Printers that ignore the commands
+  (non-Epson clones) hit the read timeout → `None` → behavior identical to
+  today.
+
+### Call site
+
+`async_step_network` (and the reconfigure path) in
+`_config_flow/network_steps.py`, immediately after `_can_connect` succeeds
+(`network_steps.py:83-85`). Result stored in flow state.
+
+### Persistence
+
+Two new `entry.data` keys, written on create and on reconfigure:
+`detected_manufacturer`, `detected_model` (const.py: `CONF_DETECTED_MANUFACTURER`,
+`CONF_DETECTED_MODEL`). Absent when the query returned nothing.
+
+### Consumers (all existing surfaces, no new UI)
+
+1. **Device registry** — `build_device_info()` prefers
+   `entry.data[detected_manufacturer/detected_model]`, falling back to the
+   current `"ESC/POS"` / `_MODEL_BY_CONNECTION_TYPE` values.
+2. **Profile preselect** — the network step feeds the detected model through
+   the existing `suggest_profile(model, None, None)`
+   (`capabilities/suggestions.py:26-45`) to preselect the profile dropdown
+   default, exactly as Bluetooth does with the advertised name
+   (`bluetooth_steps.py:55-68`). Preselect only — never auto-commit.
+3. **Calibrate share link** — the free-text model field on the calibration
+   summary (`calibration_steps.py:537-538`) defaults to
+   `entry.data[detected_model]` when present, instead of the empty
+   placeholder.
+
+## Feature 2: DHCP discovery
+
+### Manifest matchers (evidence-only)
+
+```json
+"dhcp": [
+  {"hostname": "tm-*"},
+  {"hostname": "rongta_*"}
+]
+```
+
+- `tm-*`: Epson FAQ KA-01071 documents the default network name rule as
+  "printer product name + last 6 MAC hex digits", with literal examples
+  `TM-T88VI-C3FE21` and `TM-m30-FED95E`; user-verified `TM-T20II-628E52`.
+  Every Epson receipt printer's product name starts with `TM-`.
+- `rongta_*`: user-verified `Rongta_RP820`; generalized to the brand prefix
+  because anything announcing `rongta_*` is a Rongta device and Rongta makes
+  only printers.
+
+Known Epson caveat (same FAQ): some older boards (UB-R03/R04, some TM-T20II
+variants) announce no hostname — those simply aren't discovered; manual setup
+still works.
+
+### Flow
+
+New `_config_flow/discovery_steps.py` mixin (mirrors the file-per-transport
+layout) added to `EscposConfigFlow`:
+
+`async_step_dhcp(discovery_info)`:
+
+1. `unique_id = f"{ip}:9100"`; `_abort_if_unique_id_configured()` — already-set-up
+   printers and in-progress flows abort silently.
+2. Executor probe `_can_connect(ip, 9100, short_timeout)` — a hostname match
+   that isn't listening on 9100 aborts silently (`abort` reason
+   `cannot_connect`), so matcher false positives never nag the user.
+3. `query_printer_id(...)` — best-effort, result carried into the flow.
+4. Hand off to the existing `async_step_network` form with host prefilled and
+   the detected model (or the DHCP hostname) in the step's
+   `description_placeholders`. The network form is the confirmation step — no
+   new confirm UI; everything downstream (profile preselect, codepage,
+   calibrate) is reused unchanged.
+
+Discovery card title uses the detected model when available ("TM-T20II at
+192.168.10.157"), else the DHCP hostname.
+
+## Strings & docs
+
+- `strings.json` + `translations/en.json`: discovery step title/description
+  placeholders, abort reasons (reuse existing `cannot_connect` /
+  `already_configured` where possible).
+- CHANGELOG `[Unreleased]`: one entry per feature.
+- README: short "Discovery" note (what gets auto-discovered, what doesn't and
+  why manual setup is always available).
+
+## Testing
+
+- **Parser unit tests** for `query_printer_id` framing: happy path, no reply
+  (timeout), garbage bytes, missing NUL terminator, maker-only reply,
+  connection refused. Socket mocked; follow `tests/test_config_flow.py`'s
+  `_can_connect` patch style (`tests/test_config_flow.py:25`).
+- **Config flow**: network step persists detected fields; reconfigure
+  refreshes them; profile preselect honors the detected model; query returning
+  `None` leaves behavior unchanged.
+- **Discovery flow**: dhcp step happy path (→ prefilled network form →
+  entry created with detected fields), abort on already-configured, abort on
+  probe failure, duplicate in-progress flow.
+- **Device info**: `tests/test_device_info.py` extended — detected fields
+  preferred, fallback intact.
+- **Calibration**: model field prefill from `entry.data`.

--- a/docs/superpowers/specs/2026-08-10-network-printer-identification-design.md
+++ b/docs/superpowers/specs/2026-08-10-network-printer-identification-design.md
@@ -79,11 +79,15 @@ Two new `entry.data` keys, written on create and on reconfigure:
 1. **Device registry** — `build_device_info()` prefers
    `entry.data[detected_manufacturer/detected_model]`, falling back to the
    current `"ESC/POS"` / `_MODEL_BY_CONNECTION_TYPE` values.
-2. **Profile preselect** — the network step feeds the detected model through
-   the existing `suggest_profile(model, None, None)`
+2. **Profile preselect (discovery flows only)** — when discovery ran the
+   query before the network form is shown, the detected model feeds the
+   existing `suggest_profile(model, None, None)`
    (`capabilities/suggestions.py:26-45`) to preselect the profile dropdown
    default, exactly as Bluetooth does with the advertised name
-   (`bluetooth_steps.py:55-68`). Preselect only — never auto-commit.
+   (`bluetooth_steps.py:55-68`). Preselect only — never auto-commit. In the
+   *manual* flow the profile dropdown is on the same form as the host field,
+   so the query (which runs on submit) cannot preselect it — manual entries
+   get the detected fields persisted but keep their chosen profile.
 3. **Calibrate share link** — the free-text model field on the calibration
    summary (`calibration_steps.py:537-538`) defaults to
    `entry.data[detected_model]` when present, instead of the empty
@@ -125,11 +129,12 @@ layout) added to `EscposConfigFlow`:
    that isn't listening on 9100 aborts silently (`abort` reason
    `cannot_connect`), so matcher false positives never nag the user.
 3. `query_printer_id(...)` — best-effort, result carried into the flow.
-4. Hand off to the existing `async_step_network` form with host prefilled and
-   the detected model (or the DHCP hostname) in the step's
-   `description_placeholders`. The network form is the confirmation step — no
-   new confirm UI; everything downstream (profile preselect, codepage,
-   calibrate) is reused unchanged.
+4. Hand off to the existing `async_step_network` form with host prefilled.
+   The network form is the confirmation step — no new confirm UI; everything
+   downstream (profile preselect, codepage, calibrate) is reused unchanged.
+   The network step's strings.json description stays static (it is shared
+   with the manual flow, which supplies no placeholders); the discovery card
+   title carries the identification instead.
 
 Discovery card title uses the detected model when available ("TM-T20II at
 192.168.10.157"), else the DHCP hostname.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -28,6 +28,24 @@ DHCP lease churn or sleep mode. Assign a static IP, disable sleep, optionally en
 
 Another app is using the printer, or it's in an error state (paper out, cover open). Power-cycle.
 
+### Printer not auto-discovered
+
+Discovery only matches DHCP hostnames starting with `tm-` (Epson TM-series)
+or `rongta_` (Rongta). Other brands and clones aren't matched: add them
+manually by IP address instead. `tm-*` hostnames also have to answer an
+ESC/POS `GS I` identity query before the discovery card appears, so an
+Epson printer with that query disabled won't show up either. Disabled
+hostname broadcast on the printer, or the printer sitting on a separate
+VLAN/subnet from Home Assistant, also prevents discovery: DHCP snooping is
+LAN-local and can't cross those boundaries.
+
+### Device page shows "ESC/POS / Network Printer" instead of my model
+
+The printer didn't answer the `GS I` identity query at setup (or
+reconfigure) time. Most non-Epson clones don't implement it. This is
+harmless: identification is cosmetic and every printing feature still
+works. Epson owners can retry via **Reconfigure**.
+
 ## USB issues
 
 ### "Permission denied" / "Access denied"

--- a/info.md
+++ b/info.md
@@ -9,7 +9,7 @@ Native Home Assistant control for ESC/POS thermal receipt printers connected via
 - **Paper status sensor**: `ok` / `low` / `out` for network and USB printers, so you can automate on paper running low
 - **Battery sensor**: reports battery level for portable BT printers that expose `org.bluez.Battery1`
 - **Image-print diagnostics sensor**: tracks image print success/failure counts and details of the last print, for every connection type
-- **Auto-discovery**: USB printers matched against known thermal-printer vendor IDs
+- **Auto-discovery**: USB printers matched against known thermal-printer vendor IDs; Epson/Rongta network printers matched by DHCP hostname plus a connection probe
 - **Fully local**: no cloud, no account
 
 ## Setup

--- a/tests/test_calibration_flow.py
+++ b/tests/test_calibration_flow.py
@@ -832,10 +832,7 @@ async def test_save_abort_screen_carries_personalized_share_url(hass, monkeypatc
 
 async def test_calibrate_summary_prefills_detected_model(hass):  # type: ignore[no-untyped-def]
     """The share-link model field defaults to entry.data's detected model."""
-    entry, _adapter = _make_entry(
-        hass,
-        data_extra={CONF_DETECTED_MODEL: "TM-T20II"}
-    )
+    entry, _adapter = _make_entry(hass, data_extra={CONF_DETECTED_MODEL: "TM-T20II"})
     result = await _advance_to_summary(hass, entry)
 
     schema = result["data_schema"].schema

--- a/tests/test_calibration_flow.py
+++ b/tests/test_calibration_flow.py
@@ -15,6 +15,7 @@ from custom_components.escpos_printer.capabilities.loader import _get_capabiliti
 from custom_components.escpos_printer.const import (
     CONF_CODEPAGE,
     CONF_CONNECTION_TYPE,
+    CONF_DETECTED_MODEL,
     CONF_IMPL,
     CONF_LINE_WIDTH,
     CONF_PROFILE,
@@ -60,17 +61,20 @@ def test_codepage_candidates_are_real_encodings():
 
 
 def _make_entry(
-    hass, *, loaded: bool = True, options: dict | None = None
+    hass, *, loaded: bool = True, options: dict | None = None, data_extra: dict | None = None
 ) -> tuple[MockConfigEntry, MagicMock]:
     """A MockConfigEntry with a mock adapter wired onto runtime_data."""
+    data = {
+        CONF_HOST: "1.2.3.4",
+        CONF_PORT: 9100,
+        CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK,
+    }
+    if data_extra:
+        data.update(data_extra)
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="1.2.3.4:9100",
-        data={
-            CONF_HOST: "1.2.3.4",
-            CONF_PORT: 9100,
-            CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK,
-        },
+        data=data,
         options=options or {},
         unique_id="1.2.3.4:9100",
     )
@@ -824,3 +828,16 @@ async def test_save_abort_screen_carries_personalized_share_url(hass, monkeypatc
     share_url = result2["description_placeholders"]["share_url"]
     assert "Rongta%20RP850P" in share_url
     assert "576" in share_url
+
+
+async def test_calibrate_summary_prefills_detected_model(hass):  # type: ignore[no-untyped-def]
+    """The share-link model field defaults to entry.data's detected model."""
+    entry, _adapter = _make_entry(
+        hass,
+        data_extra={CONF_DETECTED_MODEL: "TM-T20II"}
+    )
+    result = await _advance_to_summary(hass, entry)
+
+    schema = result["data_schema"].schema
+    model_key = next(k for k in schema if k.schema == "model")
+    assert model_key.default() == "TM-T20II"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -21,9 +21,15 @@ from custom_components.escpos_printer.const import (
 
 async def test_config_flow_success(hass):  # type: ignore[no-untyped-def]
     """Test successful three-step config flow for network printer."""
-    with patch(
-        "custom_components.escpos_printer._config_flow.network_steps._can_connect",
-        return_value=True,
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
     ):
         # Step 1: Connection type selection
         result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
@@ -75,9 +81,15 @@ async def test_config_flow_success(hass):  # type: ignore[no-untyped-def]
 
 async def test_config_flow_connection_failure(hass):  # type: ignore[no-untyped-def]
     """Test config flow with connection failure."""
-    with patch(
-        "custom_components.escpos_printer._config_flow.network_steps._can_connect",
-        return_value=False,
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=False,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
     ):
         # Step 1: Connection type selection
         result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
@@ -108,9 +120,15 @@ async def test_config_flow_connection_failure(hass):  # type: ignore[no-untyped-
 
 async def test_config_flow_with_profile_selection(hass):  # type: ignore[no-untyped-def]
     """Test config flow with profile selection."""
-    with patch(
-        "custom_components.escpos_printer._config_flow.network_steps._can_connect",
-        return_value=True,
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
     ):
         # Step 1: Connection type selection
         result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
@@ -154,9 +172,15 @@ async def test_config_flow_with_profile_selection(hass):  # type: ignore[no-unty
 
 async def test_config_flow_custom_profile(hass):  # type: ignore[no-untyped-def]
     """Test config flow with custom profile entry."""
-    with patch(
-        "custom_components.escpos_printer._config_flow.network_steps._can_connect",
-        return_value=True,
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
     ):
         # Step 1: Connection type selection
         result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
@@ -215,6 +239,10 @@ async def test_config_flow_custom_codepage(hass):  # type: ignore[no-untyped-def
             "custom_components.escpos_printer._config_flow.settings_steps.is_valid_codepage_for_profile",
             return_value=True,
         ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
     ):
         # Step 1: Connection type selection
         result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
@@ -259,9 +287,15 @@ async def test_config_flow_custom_codepage(hass):  # type: ignore[no-untyped-def
 
 async def test_config_flow_custom_line_width(hass):  # type: ignore[no-untyped-def]
     """Test config flow with custom line width entry."""
-    with patch(
-        "custom_components.escpos_printer._config_flow.network_steps._can_connect",
-        return_value=True,
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
     ):
         # Step 1: Connection type selection
         result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
@@ -318,6 +352,10 @@ async def test_config_flow_custom_codepage_and_custom_line_width(hass):  # type:
             "custom_components.escpos_printer._config_flow.settings_steps.is_valid_codepage_for_profile",
             return_value=True,
         ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
     ):
         result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
         result2 = await hass.config_entries.flow.async_configure(
@@ -369,6 +407,10 @@ async def test_config_flow_custom_codepage_and_line_width_keep_impl_and_width_pi
             "custom_components.escpos_printer._config_flow.settings_steps.is_valid_codepage_for_profile",
             return_value=True,
         ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
     ):
         result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
         result2 = await hass.config_entries.flow.async_configure(
@@ -401,3 +443,62 @@ async def test_config_flow_custom_codepage_and_line_width_keep_impl_and_width_pi
         assert result6["type"] == "create_entry"
         assert result6["data"][CONF_IMPL] == "bitImageColumn"
         assert result6["data"][CONF_WIDTH_PIXELS] == 576
+
+
+async def test_network_flow_persists_detected_fields(hass):  # type: ignore[no-untyped-def]
+    """GS I result lands in entry.data as detected_manufacturer/model."""
+    from custom_components.escpos_printer.const import (
+        CONF_DETECTED_MANUFACTURER,
+        CONF_DETECTED_MODEL,
+    )
+
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value={"manufacturer": "EPSON", "model": "TM-T20II"},
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.168.10.157", CONF_PORT: 9100}
+        )
+        # Complete the codepage step with defaults to create the entry.
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_DETECTED_MANUFACTURER] == "EPSON"
+    assert result["data"][CONF_DETECTED_MODEL] == "TM-T20II"
+
+
+async def test_network_flow_no_reply_omits_detected_fields(hass):  # type: ignore[no-untyped-def]
+    """query_printer_id -> None leaves entry.data without detected keys."""
+    from custom_components.escpos_printer.const import CONF_DETECTED_MODEL
+
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.168.10.157", CONF_PORT: 9100}
+        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] == "create_entry"
+    assert CONF_DETECTED_MODEL not in result["data"]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -479,7 +479,10 @@ async def test_network_flow_persists_detected_fields(hass):  # type: ignore[no-u
 
 async def test_network_flow_no_reply_omits_detected_fields(hass):  # type: ignore[no-untyped-def]
     """query_printer_id -> None leaves entry.data without detected keys."""
-    from custom_components.escpos_printer.const import CONF_DETECTED_MODEL
+    from custom_components.escpos_printer.const import (
+        CONF_DETECTED_MANUFACTURER,
+        CONF_DETECTED_MODEL,
+    )
 
     with (
         patch(
@@ -502,3 +505,34 @@ async def test_network_flow_no_reply_omits_detected_fields(hass):  # type: ignor
 
     assert result["type"] == "create_entry"
     assert CONF_DETECTED_MODEL not in result["data"]
+    assert CONF_DETECTED_MANUFACTURER not in result["data"]
+
+
+async def test_network_flow_reuses_preset_detected_result(hass):  # type: ignore[no-untyped-def]
+    """A pre-populated self._detected (e.g. from discovery) short-circuits the query."""
+    from custom_components.escpos_printer.const import CONF_DETECTED_MODEL
+
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK}
+        )
+
+        flow = hass.config_entries.flow._progress[result["flow_id"]]
+        flow._detected = {"model": "TM-T20II"}
+
+        with patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+        ) as mock_query:
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], {CONF_HOST: "192.168.10.157", CONF_PORT: 9100}
+            )
+        mock_query.assert_not_called()
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_DETECTED_MODEL] == "TM-T20II"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -525,6 +525,7 @@ async def test_network_flow_reuses_preset_detected_result(hass):  # type: ignore
         flow = hass.config_entries.flow._progress[result["flow_id"]]
         flow._detected = {"model": "TM-T20II"}
         flow._discovery_host = "192.168.10.157"
+        flow._discovery_port = 9100
 
         with patch(
             "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -509,7 +509,8 @@ async def test_network_flow_no_reply_omits_detected_fields(hass):  # type: ignor
 
 
 async def test_network_flow_reuses_preset_detected_result(hass):  # type: ignore[no-untyped-def]
-    """A pre-populated self._detected (e.g. from discovery) short-circuits the query."""
+    """A pre-populated self._detected (e.g. from discovery) short-circuits the
+    query when the submitted host still matches the discovery host."""
     from custom_components.escpos_printer.const import CONF_DETECTED_MODEL
 
     with patch(
@@ -523,6 +524,7 @@ async def test_network_flow_reuses_preset_detected_result(hass):  # type: ignore
 
         flow = hass.config_entries.flow._progress[result["flow_id"]]
         flow._detected = {"model": "TM-T20II"}
+        flow._discovery_host = "192.168.10.157"
 
         with patch(
             "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",

--- a/tests/test_config_flow_dhcp.py
+++ b/tests/test_config_flow_dhcp.py
@@ -133,6 +133,38 @@ async def test_dhcp_discovery_edited_host_requeries_instead_of_reusing_detection
     mock_query.assert_called_once_with(edited_host, 9100, ANY)
 
 
+async def test_dhcp_discovery_edited_port_requeries_instead_of_reusing_detection(hass):
+    """Editing only the port (same discovery host) must not carry over the
+    discovery-time GS I result -- DHCP always probes DEFAULT_PORT, so a
+    different port may be a different service on the same address."""
+    result = await _start_dhcp_flow(
+        hass, query_result={"manufacturer": "EPSON", "model": "TM-T20II"}
+    )
+    assert result["step_id"] == "network"
+
+    edited_port = 9101
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value={"manufacturer": "OTHER", "model": "RP820"},
+        ) as mock_query,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "192.168.10.157", "port": edited_port}
+        )
+        # Complete the codepage step with defaults to create the entry.
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"]["detected_manufacturer"] == "OTHER"
+    assert result["data"]["detected_model"] == "RP820"
+    mock_query.assert_called_once_with("192.168.10.157", edited_port, ANY)
+
+
 async def test_dhcp_discovery_aborts_when_already_configured(hass):
     MockConfigEntry(
         domain=DOMAIN,

--- a/tests/test_config_flow_dhcp.py
+++ b/tests/test_config_flow_dhcp.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
-import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.escpos_printer.const import DOMAIN
@@ -74,15 +73,44 @@ async def test_dhcp_discovery_title_uses_detected_model(hass):
 async def test_dhcp_discovery_title_falls_back_to_hostname(hass):
     await _start_dhcp_flow(hass, query_result=None)
     flow = hass.config_entries.flow.async_progress()[0]
-    assert flow["context"]["title_placeholders"] == {
-        "name": "TM-T20II-628E52 (192.168.10.157)"
-    }
+    assert flow["context"]["title_placeholders"] == {"name": "TM-T20II-628E52 (192.168.10.157)"}
 
 
 async def test_dhcp_discovery_aborts_when_port_closed(hass):
     result = await _start_dhcp_flow(hass, can_connect=False)
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
+
+
+async def test_dhcp_discovery_edited_host_requeries_instead_of_reusing_detection(hass):
+    """Editing the suggested host to a different printer must not carry over
+    the discovery-time GS I result for the original printer."""
+    result = await _start_dhcp_flow(
+        hass, query_result={"manufacturer": "EPSON", "model": "TM-T20II"}
+    )
+    assert result["step_id"] == "network"
+
+    edited_host = "192.168.10.200"
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value={"manufacturer": "OTHER", "model": "RP820"},
+        ) as mock_query,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": edited_host, "port": 9100}
+        )
+        # Complete the codepage step with defaults to create the entry.
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"]["detected_manufacturer"] == "OTHER"
+    assert result["data"]["detected_model"] == "RP820"
+    mock_query.assert_called_once_with(edited_host, 9100, mock_query.call_args.args[2])
 
 
 async def test_dhcp_discovery_aborts_when_already_configured(hass):

--- a/tests/test_config_flow_dhcp.py
+++ b/tests/test_config_flow_dhcp.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResultType
@@ -17,8 +17,18 @@ DISCOVERY = DhcpServiceInfo(
     macaddress="50579c628e52",
 )
 
+# "tm-*" also matches Prometheus node_exporter's default port 9100, so
+# hostname-fallback (no GS I answer) title tests use a brand-exclusive
+# "rongta_*" hostname instead -- port-probe-only identification still
+# applies there.
+DISCOVERY_RONGTA = DhcpServiceInfo(
+    ip="192.168.10.158",
+    hostname="Rongta_RP820",
+    macaddress="50579c628e53",
+)
 
-async def _start_dhcp_flow(hass, can_connect=True, query_result=None):
+
+async def _start_dhcp_flow(hass, can_connect=True, query_result=None, discovery=DISCOVERY):
     with (
         patch(
             "custom_components.escpos_printer._config_flow.discovery_steps._can_connect",
@@ -30,7 +40,7 @@ async def _start_dhcp_flow(hass, can_connect=True, query_result=None):
         ),
     ):
         return await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_DHCP}, data=DISCOVERY
+            DOMAIN, context={"source": config_entries.SOURCE_DHCP}, data=discovery
         )
 
 
@@ -71,9 +81,19 @@ async def test_dhcp_discovery_title_uses_detected_model(hass):
 
 
 async def test_dhcp_discovery_title_falls_back_to_hostname(hass):
-    await _start_dhcp_flow(hass, query_result=None)
+    # rongta_* is brand-exclusive, so a silent GS I query still shows a
+    # discovery card with the hostname as the fallback title.
+    await _start_dhcp_flow(hass, query_result=None, discovery=DISCOVERY_RONGTA)
     flow = hass.config_entries.flow.async_progress()[0]
-    assert flow["context"]["title_placeholders"] == {"name": "TM-T20II-628E52 (192.168.10.157)"}
+    assert flow["context"]["title_placeholders"] == {"name": "Rongta_RP820 (192.168.10.158)"}
+
+
+async def test_dhcp_discovery_tm_hostname_aborts_without_gs_i_answer(hass):
+    """tm-* also matches node_exporter's default port 9100 -- a silent GS I
+    query must abort instead of showing a bogus discovery card."""
+    result = await _start_dhcp_flow(hass, can_connect=True, query_result=None)
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
 
 
 async def test_dhcp_discovery_aborts_when_port_closed(hass):
@@ -110,7 +130,7 @@ async def test_dhcp_discovery_edited_host_requeries_instead_of_reusing_detection
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"]["detected_manufacturer"] == "OTHER"
     assert result["data"]["detected_model"] == "RP820"
-    mock_query.assert_called_once_with(edited_host, 9100, mock_query.call_args.args[2])
+    mock_query.assert_called_once_with(edited_host, 9100, ANY)
 
 
 async def test_dhcp_discovery_aborts_when_already_configured(hass):
@@ -122,3 +142,48 @@ async def test_dhcp_discovery_aborts_when_already_configured(hass):
     result = await _start_dhcp_flow(hass)
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_dhcp_discovery_end_to_end_creates_entry_with_detection(hass):
+    """DHCP discovery -> network form, submitted with the unchanged
+    suggested host, creates an entry carrying the GS I detection and the
+    preselected profile."""
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_steps.suggest_profile",
+        return_value="TM-T20II",
+    ):
+        result = await _start_dhcp_flow(
+            hass, query_result={"manufacturer": "EPSON", "model": "TM-T20II"}
+        )
+        assert result["step_id"] == "network"
+        assert result["data_schema"]({"host": "192.168.10.157"})["profile"] == "TM-T20II"
+
+        with patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], {"host": "192.168.10.157", "port": 9100}
+            )
+            # Complete the codepage step with defaults to create the entry.
+            result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"]["detected_manufacturer"] == "EPSON"
+    assert result["data"]["detected_model"] == "TM-T20II"
+    assert result["data"]["profile"] == "TM-T20II"
+
+
+async def test_dhcp_discovery_duplicate_in_progress_aborts(hass):
+    """A second DHCP discovery for the same IP while the first flow is
+    still open (unanswered form) aborts as already_in_progress."""
+    result = await _start_dhcp_flow(
+        hass, query_result={"manufacturer": "EPSON", "model": "TM-T20II"}
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    result2 = await _start_dhcp_flow(
+        hass, query_result={"manufacturer": "EPSON", "model": "TM-T20II"}
+    )
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "already_in_progress"

--- a/tests/test_config_flow_dhcp.py
+++ b/tests/test_config_flow_dhcp.py
@@ -35,7 +35,6 @@ async def _start_dhcp_flow(hass, can_connect=True, query_result=None):
         )
 
 
-@pytest.mark.xfail(reason="host prefill lands in next task", strict=True)
 async def test_dhcp_discovery_shows_network_form(hass):
     result = await _start_dhcp_flow(
         hass, query_result={"manufacturer": "EPSON", "model": "TM-T20II"}
@@ -43,7 +42,27 @@ async def test_dhcp_discovery_shows_network_form(hass):
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "network"
     # Host is prefilled from discovery.
-    assert result["data_schema"]({})["host"] == "192.168.10.157"
+    host_marker = next(k for k in result["data_schema"].schema if k.schema == "host")
+    assert host_marker.description["suggested_value"] == "192.168.10.157"
+
+
+async def test_dhcp_discovery_preselects_suggested_profile(hass):
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_steps.suggest_profile",
+        return_value="TM-T20II",
+    ):
+        result = await _start_dhcp_flow(hass, query_result={"model": "TM-T20II"})
+    assert result["step_id"] == "network"
+    defaults = result["data_schema"]({"host": "192.168.10.157"})
+    assert defaults["profile"] == "TM-T20II"
+
+
+async def test_dhcp_discovery_unknown_model_keeps_auto_profile(hass):
+    from custom_components.escpos_printer.capabilities import PROFILE_AUTO
+
+    result = await _start_dhcp_flow(hass, query_result={"model": "Mystery-9000"})
+    defaults = result["data_schema"]({"host": "192.168.10.157"})
+    assert defaults["profile"] == PROFILE_AUTO
 
 
 async def test_dhcp_discovery_title_uses_detected_model(hass):

--- a/tests/test_config_flow_dhcp.py
+++ b/tests/test_config_flow_dhcp.py
@@ -1,0 +1,77 @@
+"""DHCP discovery flow tests."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.escpos_printer.const import DOMAIN
+
+DISCOVERY = DhcpServiceInfo(
+    ip="192.168.10.157",
+    hostname="TM-T20II-628E52",
+    macaddress="50579c628e52",
+)
+
+
+async def _start_dhcp_flow(hass, can_connect=True, query_result=None):
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.discovery_steps._can_connect",
+            return_value=can_connect,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.discovery_steps.query_printer_id",
+            return_value=query_result,
+        ),
+    ):
+        return await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_DHCP}, data=DISCOVERY
+        )
+
+
+@pytest.mark.xfail(reason="host prefill lands in next task", strict=True)
+async def test_dhcp_discovery_shows_network_form(hass):
+    result = await _start_dhcp_flow(
+        hass, query_result={"manufacturer": "EPSON", "model": "TM-T20II"}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "network"
+    # Host is prefilled from discovery.
+    assert result["data_schema"]({})["host"] == "192.168.10.157"
+
+
+async def test_dhcp_discovery_title_uses_detected_model(hass):
+    await _start_dhcp_flow(hass, query_result={"model": "TM-T20II"})
+    flow = hass.config_entries.flow.async_progress()[0]
+    assert flow["context"]["title_placeholders"] == {"name": "TM-T20II (192.168.10.157)"}
+
+
+async def test_dhcp_discovery_title_falls_back_to_hostname(hass):
+    await _start_dhcp_flow(hass, query_result=None)
+    flow = hass.config_entries.flow.async_progress()[0]
+    assert flow["context"]["title_placeholders"] == {
+        "name": "TM-T20II-628E52 (192.168.10.157)"
+    }
+
+
+async def test_dhcp_discovery_aborts_when_port_closed(hass):
+    result = await _start_dhcp_flow(hass, can_connect=False)
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+async def test_dhcp_discovery_aborts_when_already_configured(hass):
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="192.168.10.157:9100",
+        data={"connection_type": "network", "host": "192.168.10.157", "port": 9100},
+    ).add_to_hass(hass)
+    result = await _start_dhcp_flow(hass)
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/test_config_flow_negative.py
+++ b/tests/test_config_flow_negative.py
@@ -12,9 +12,15 @@ from custom_components.escpos_printer.const import (
 
 async def test_config_flow_cannot_connect(hass):  # type: ignore[no-untyped-def]
     """Test config flow with connection failure shows error."""
-    with patch(
-        "custom_components.escpos_printer._config_flow.network_steps._can_connect",
-        return_value=False,
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=False,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
     ):
         # Step 1: Connection type selection
         result = await hass.config_entries.flow.async_init(

--- a/tests/test_config_flow_options_and_duplicate.py
+++ b/tests/test_config_flow_options_and_duplicate.py
@@ -150,9 +150,15 @@ async def test_duplicate_unique_id_aborts(hass):  # type: ignore[no-untyped-def]
     entry.add_to_hass(hass)
 
     # Start new flow with same host/port
-    with patch(
-        "custom_components.escpos_printer._config_flow.network_steps._can_connect",
-        return_value=True,
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
     ):
         # Step 1: Connection type selection
         result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})

--- a/tests/test_config_flow_reconfigure.py
+++ b/tests/test_config_flow_reconfigure.py
@@ -111,6 +111,10 @@ async def test_reconfigure_network_happy_path(hass):  # type: ignore[no-untyped-
             "custom_components.escpos_printer._config_flow.network_steps._can_connect",
             return_value=True,
         ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
         patch("custom_components.escpos_printer.async_setup_entry", return_value=True),
     ):
         result = await entry.start_reconfigure_flow(hass)
@@ -156,6 +160,10 @@ async def test_reconfigure_network_preserves_manual_rename(hass):  # type: ignor
             "custom_components.escpos_printer._config_flow.network_steps._can_connect",
             return_value=True,
         ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
         patch("custom_components.escpos_printer.async_setup_entry", return_value=True),
     ):
         result = await entry.start_reconfigure_flow(hass)
@@ -189,9 +197,15 @@ async def test_reconfigure_network_cannot_connect(hass):  # type: ignore[no-unty
     )
     entry.add_to_hass(hass)
 
-    with patch(
-        "custom_components.escpos_printer._config_flow.network_steps._can_connect",
-        return_value=False,
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=False,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
     ):
         result = await entry.start_reconfigure_flow(hass)
         result2 = await hass.config_entries.flow.async_configure(
@@ -608,10 +622,16 @@ async def test_reconfigure_network_case_insensitive_collision_aborts(hass):  # t
     entry.add_to_hass(hass)
     entry_id = entry.entry_id
 
-    with patch(
-        "custom_components.escpos_printer._config_flow.network_steps._can_connect",
-        return_value=True,
-    ) as mock_connect:
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ) as mock_connect,
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
+    ):
         result = await entry.start_reconfigure_flow(hass)
         assert result["step_id"] == "reconfigure_network"
 

--- a/tests/test_config_flow_reconfigure.py
+++ b/tests/test_config_flow_reconfigure.py
@@ -13,6 +13,8 @@ from custom_components.escpos_printer.const import (
     CONF_CONNECTION_TYPE,
     CONF_DEFAULT_ALIGN,
     CONF_DEFAULT_CUT,
+    CONF_DETECTED_MANUFACTURER,
+    CONF_DETECTED_MODEL,
     CONF_IN_EP,
     CONF_LINE_WIDTH,
     CONF_OUT_EP,
@@ -180,6 +182,82 @@ async def test_reconfigure_network_preserves_manual_rename(hass):  # type: ignor
     assert updated is not None
     assert updated.data[CONF_HOST] == "5.6.7.8"
     assert updated.title == "Front Counter Printer"  # untouched
+
+
+async def test_reconfigure_network_detected_fields_replace_on_requery(hass):  # type: ignore[no-untyped-def]
+    """A fresh GS I result on reconfigure REPLACES prior detected state.
+
+    Reconfigure may point the entry at a different printer, so a detected
+    manufacturer/model must overwrite when present and be removed (not just
+    left stale) when the fresh query comes back empty.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="1.2.3.4:9100",
+        data={
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 9100,
+            CONF_TIMEOUT: 4.0,
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK,
+        },
+        unique_id="1.2.3.4:9100",
+    )
+    entry.add_to_hass(hass)
+    entry_id = entry.entry_id
+
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value={"manufacturer": "EPSON", "model": "TM-T20II"},
+        ),
+        patch("custom_components.escpos_printer.async_setup_entry", return_value=True),
+    ):
+        result = await entry.start_reconfigure_flow(hass)
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "5.6.7.8", CONF_PORT: 9100},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "reconfigure_successful"
+
+    updated = hass.config_entries.async_get_entry(entry_id)
+    assert updated is not None
+    assert updated.data[CONF_DETECTED_MANUFACTURER] == "EPSON"
+    assert updated.data[CONF_DETECTED_MODEL] == "TM-T20II"
+
+    # Reconfigure again onto a printer that doesn't answer GS I -- the
+    # previous printer's detected fields must be removed, not kept stale.
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
+        patch("custom_components.escpos_printer.async_setup_entry", return_value=True),
+    ):
+        result3 = await entry.start_reconfigure_flow(hass)
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
+            {CONF_HOST: "9.9.9.9", CONF_PORT: 9100},
+        )
+        await hass.async_block_till_done()
+
+    assert result4["type"] == "abort"
+    assert result4["reason"] == "reconfigure_successful"
+
+    updated2 = hass.config_entries.async_get_entry(entry_id)
+    assert updated2 is not None
+    assert CONF_DETECTED_MANUFACTURER not in updated2.data
+    assert CONF_DETECTED_MODEL not in updated2.data
 
 
 async def test_reconfigure_network_cannot_connect(hass):  # type: ignore[no-untyped-def]

--- a/tests/test_config_flow_reconfigure.py
+++ b/tests/test_config_flow_reconfigure.py
@@ -260,6 +260,55 @@ async def test_reconfigure_network_detected_fields_replace_on_requery(hass):  # 
     assert CONF_DETECTED_MODEL not in updated2.data
 
 
+async def test_reconfigure_network_detected_fields_survive_transient_requery_failure(
+    hass,
+):  # type: ignore[no-untyped-def]
+    """Reconfiguring only the timeout (same host/port) while the printer is
+    busy (query returns None) must not destroy a good prior detection."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="1.2.3.4:9100",
+        data={
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 9100,
+            CONF_TIMEOUT: 4.0,
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK,
+            CONF_DETECTED_MANUFACTURER: "EPSON",
+            CONF_DETECTED_MODEL: "TM-T20II",
+        },
+        unique_id="1.2.3.4:9100",
+    )
+    entry.add_to_hass(hass)
+    entry_id = entry.entry_id
+
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
+        patch("custom_components.escpos_printer.async_setup_entry", return_value=True),
+    ):
+        result = await entry.start_reconfigure_flow(hass)
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "1.2.3.4", CONF_PORT: 9100, CONF_TIMEOUT: 8.0},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "reconfigure_successful"
+
+    updated = hass.config_entries.async_get_entry(entry_id)
+    assert updated is not None
+    assert updated.data[CONF_TIMEOUT] == 8.0
+    assert updated.data[CONF_DETECTED_MANUFACTURER] == "EPSON"
+    assert updated.data[CONF_DETECTED_MODEL] == "TM-T20II"
+
+
 async def test_reconfigure_network_cannot_connect(hass):  # type: ignore[no-untyped-def]
     """A failed connection probe re-renders the form with cannot_connect and leaves the entry alone."""
     entry = MockConfigEntry(

--- a/tests/test_config_flow_usb.py
+++ b/tests/test_config_flow_usb.py
@@ -830,6 +830,10 @@ class TestUsbYamlImport:
                 "custom_components.escpos_printer._config_flow.network_steps._can_connect",
                 return_value=True,
             ),
+            patch(
+                "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+                return_value=None,
+            ),
             patch.object(flow, "async_set_unique_id", return_value=None),
             patch.object(flow, "_abort_if_unique_id_configured"),
         ):

--- a/tests/test_device_info.py
+++ b/tests/test_device_info.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from custom_components.escpos_printer.const import (
     CONF_CONNECTION_TYPE,
+    CONF_DETECTED_MANUFACTURER,
+    CONF_DETECTED_MODEL,
     CONNECTION_TYPE_BLUETOOTH,
     CONNECTION_TYPE_NETWORK,
     CONNECTION_TYPE_SERIAL,
@@ -93,3 +95,23 @@ def test_non_usb_transports_never_get_serial_number() -> None:
     )
     info = build_device_info(entry)  # type: ignore[arg-type]
     assert "serial_number" not in info
+
+
+def test_device_info_prefers_detected_fields() -> None:
+    entry = _FakeEntry(
+        data={
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK,
+            CONF_DETECTED_MANUFACTURER: "EPSON",
+            CONF_DETECTED_MODEL: "TM-T20II",
+        }
+    )
+    info = build_device_info(entry)  # type: ignore[arg-type]
+    assert info["manufacturer"] == "EPSON"
+    assert info["model"] == "TM-T20II"
+
+
+def test_device_info_falls_back_without_detected_fields() -> None:
+    entry = _FakeEntry(data={CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK})
+    info = build_device_info(entry)  # type: ignore[arg-type]
+    assert info["manufacturer"] == "ESC/POS"
+    assert info["model"] == "Network Printer"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -8,6 +8,8 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.escpos_printer.const import (
     CONF_BT_MAC,
     CONF_CONNECTION_TYPE,
+    CONF_DETECTED_MANUFACTURER,
+    CONF_DETECTED_MODEL,
     CONF_IN_EP,
     CONF_OUT_EP,
     CONF_PRODUCT_ID,
@@ -28,7 +30,12 @@ async def test_diagnostics_network_entry(hass):  # type: ignore[no-untyped-def]
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="1.2.3.4:9100",
-        data={CONF_HOST: "1.2.3.4", CONF_PORT: 9100},
+        data={
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 9100,
+            CONF_DETECTED_MANUFACTURER: "EPSON",
+            CONF_DETECTED_MODEL: "TM-T20II",
+        },
         unique_id="1.2.3.4:9100",
     )
     entry.add_to_hass(hass)
@@ -45,6 +52,9 @@ async def test_diagnostics_network_entry(hass):  # type: ignore[no-untyped-def]
     # Host is redacted
     assert diag["entry"]["data"][CONF_HOST] == "**REDACTED**"
     assert diag["entry"]["data"][CONF_PORT] == 9100
+    # GS I detection fields surface for triage
+    assert diag["entry"]["data"][CONF_DETECTED_MANUFACTURER] == "EPSON"
+    assert diag["entry"]["data"][CONF_DETECTED_MODEL] == "TM-T20II"
     # Runtime contains adapter-derived fields
     assert diag["runtime"]["connection_type"] == CONNECTION_TYPE_NETWORK
     assert "profile" in diag["runtime"]

--- a/tests/test_network_helpers_query.py
+++ b/tests/test_network_helpers_query.py
@@ -6,6 +6,8 @@ import socket
 from unittest.mock import MagicMock, patch
 
 from custom_components.escpos_printer._config_flow.network_helpers import (
+    _ID_DRAIN_MAX,
+    _ID_MAX_LEN,
     _read_id_reply,
     query_printer_id,
 )
@@ -65,6 +67,35 @@ def test_read_id_reply_strips_nonascii():
 def test_read_id_reply_strips_control_bytes():
     # An untrusted peer could stuff C0 control/escape bytes into the reply.
     assert _read_id_reply(FakeSocket(b"\x5fTM\x07-T20\x1b\x00")) == "TM-T20"
+
+
+class DripFeedSocket:
+    """recv() never runs dry -- proves the drain loop is capped, not hung."""
+
+    def __init__(self) -> None:
+        self.recv_calls = 0
+
+    def recv(self, _n: int) -> bytes:
+        self.recv_calls += 1
+        return b"\x5f" if self.recv_calls == 1 else b"A"
+
+    def settimeout(self, _t: float) -> None:
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def test_read_id_reply_drain_loop_is_capped():
+    # A device that drip-feeds bytes forever (each recv resets the 2s
+    # timeout) must not hang the drain loop -- it stops after _ID_DRAIN_MAX
+    # bytes instead of consuming the stream forever.
+    sock = DripFeedSocket()
+    assert _read_id_reply(sock) == "A" * (_ID_MAX_LEN - 1)
+    assert sock.recv_calls == _ID_MAX_LEN + _ID_DRAIN_MAX
 
 
 def test_read_id_reply_oversized_reply_drains_before_returning():

--- a/tests/test_network_helpers_query.py
+++ b/tests/test_network_helpers_query.py
@@ -1,0 +1,112 @@
+"""Tests for the GS I printer-ID query helper."""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import MagicMock, patch
+
+from custom_components.escpos_printer._config_flow.network_helpers import (
+    _read_id_reply,
+    query_printer_id,
+)
+
+
+class FakeSocket:
+    """recv() feeds back a canned byte stream one byte at a time."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._buf = list(payload)
+        self.sent: list[bytes] = []
+
+    def recv(self, _n: int) -> bytes:
+        if not self._buf:
+            raise TimeoutError("timed out")
+        return bytes([self._buf.pop(0)])
+
+    def sendall(self, data: bytes) -> None:
+        self.sent.append(data)
+
+    def settimeout(self, _t: float) -> None:
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def test_read_id_reply_happy_path():
+    assert _read_id_reply(FakeSocket(b"\x5fTM-T20II\x00")) == "TM-T20II"
+
+
+def test_read_id_reply_no_data_times_out():
+    assert _read_id_reply(FakeSocket(b"")) is None
+
+
+def test_read_id_reply_missing_header_is_garbage():
+    assert _read_id_reply(FakeSocket(b"TM-T20II\x00")) is None
+
+
+def test_read_id_reply_missing_nul_hits_length_cap():
+    # 200 printable bytes, no terminator: reply is capped, then rejected
+    # only if the header is absent; with header it returns the capped text.
+    assert _read_id_reply(FakeSocket(b"\x5f" + b"A" * 200)) == "A" * 79
+
+
+def test_read_id_reply_empty_string_reply():
+    assert _read_id_reply(FakeSocket(b"\x5f\x00")) is None
+
+
+def test_read_id_reply_strips_nonascii():
+    assert _read_id_reply(FakeSocket(b"\x5fTM\xff-T20\x00")) == "TM-T20"
+
+
+def test_query_printer_id_both_replies():
+    payload = b"\x5fEPSON\x00\x5fTM-T20II\x00"
+    fake = FakeSocket(payload)
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_helpers.socket.create_connection",
+        return_value=fake,
+    ):
+        result = query_printer_id("192.168.10.157", 9100, 4.0)
+    assert result == {"manufacturer": "EPSON", "model": "TM-T20II"}
+    assert fake.sent == [b"\x1d\x49\x42", b"\x1d\x49\x43"]
+
+
+def test_query_printer_id_silent_clone_returns_none():
+    # Clone never answers: first read times out -> None, no exception.
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_helpers.socket.create_connection",
+        return_value=FakeSocket(b""),
+    ):
+        assert query_printer_id("192.168.10.157", 9100, 4.0) is None
+
+
+def test_query_printer_id_maker_only():
+    # Maker answers, model read times out -> partial dict survives.
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_helpers.socket.create_connection",
+        return_value=FakeSocket(b"\x5fEPSON\x00"),
+    ):
+        assert query_printer_id("192.168.10.157", 9100, 4.0) == {"manufacturer": "EPSON"}
+
+
+def test_query_printer_id_connection_refused_returns_none():
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_helpers.socket.create_connection",
+        side_effect=ConnectionRefusedError,
+    ):
+        assert query_printer_id("192.168.10.157", 9100, 4.0) is None
+
+
+def test_query_printer_id_never_raises_on_weird_oserror():
+    sock = MagicMock()
+    sock.__enter__ = MagicMock(return_value=sock)
+    sock.__exit__ = MagicMock(return_value=False)
+    sock.sendall.side_effect = OSError("broken pipe")
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_helpers.socket.create_connection",
+        return_value=sock,
+    ):
+        assert query_printer_id("192.168.10.157", 9100, 4.0) is None

--- a/tests/test_network_helpers_query.py
+++ b/tests/test_network_helpers_query.py
@@ -62,6 +62,22 @@ def test_read_id_reply_strips_nonascii():
     assert _read_id_reply(FakeSocket(b"\x5fTM\xff-T20\x00")) == "TM-T20"
 
 
+def test_read_id_reply_strips_control_bytes():
+    # An untrusted peer could stuff C0 control/escape bytes into the reply.
+    assert _read_id_reply(FakeSocket(b"\x5fTM\x07-T20\x1b\x00")) == "TM-T20"
+
+
+def test_read_id_reply_oversized_reply_drains_before_returning():
+    # Longer than the cap but properly NUL-terminated: the excess must be
+    # drained so the socket is left positioned at the start of the NEXT
+    # reply, not mid-payload.
+    sock = FakeSocket(b"\x5f" + b"A" * 150 + b"\x00" + b"\x5fTM-T20II\x00")
+    assert _read_id_reply(sock) == "A" * 79
+    # The drain consumed the rest of the oversized reply including its NUL;
+    # the next read starts cleanly on the following reply.
+    assert _read_id_reply(sock) == "TM-T20II"
+
+
 def test_query_printer_id_both_replies():
     payload = b"\x5fEPSON\x00\x5fTM-T20II\x00"
     fake = FakeSocket(payload)
@@ -81,6 +97,20 @@ def test_query_printer_id_silent_clone_returns_none():
         return_value=FakeSocket(b""),
     ):
         assert query_printer_id("192.168.10.157", 9100, 4.0) is None
+
+
+def test_query_printer_id_oversized_maker_reply_still_parses_model():
+    # Maker answers with an oversized, NUL-terminated reply (capped and
+    # drained); the model reply that follows on the same stream must still
+    # parse cleanly instead of desyncing.
+    payload = b"\x5f" + b"A" * 150 + b"\x00" + b"\x5fTM-T20II\x00"
+    fake = FakeSocket(payload)
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_helpers.socket.create_connection",
+        return_value=fake,
+    ):
+        result = query_printer_id("192.168.10.157", 9100, 4.0)
+    assert result == {"manufacturer": "A" * 79, "model": "TM-T20II"}
 
 
 def test_query_printer_id_maker_only():

--- a/tests/test_network_helpers_query.py
+++ b/tests/test_network_helpers_query.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import socket
 from unittest.mock import MagicMock, patch
 
 from custom_components.escpos_printer._config_flow.network_helpers import (


### PR DESCRIPTION
## Summary

- **`GS I` printer identification**: network setups and reconfigures query the printer's identity over the existing TCP connection (ESC/POS `GS I` 66/67). The device page shows the real manufacturer/model (e.g. EPSON TM-T20II) instead of generic "ESC/POS / Network Printer", and the calibration share-link model field prefills. Printers that don't answer (most clones) behave exactly as before. Diagnostics exports include the detected fields.
- **DHCP discovery**: evidence-backed hostname matchers (`tm-*` per Epson's documented naming rule + user-verified, `rongta_*` brand prefix). Candidates are probed on TCP 9100 and — for `tm-*` — must answer `GS I` before a discovery card is shown (kills Prometheus node_exporter false positives on port 9100). Discovered setups open the normal network form with host prefilled and the matching profile preselected.
- **Field-tested against real hardware**: a Rongta RP820 clone that answers `GS I` as "EPSON TM-T88III" (protocol emulation) is now identified by its truthful brand hostname instead — device page says Rongta / RP820, and calibration share links aren't mislabeled. Implausible font column counts from a buggy upstream profile entry (NT-80-V-UL declares 9/12 columns on an 80 mm printer — dot widths mis-encoded as columns) are filtered out of the characters-per-line choices.
- **MAC-tracked identity**: discovery-created entries store the printer's MAC (also shown as a device-registry network connection); when a DHCP lease change moves the printer, the existing entry's host/unique_id/auto-title follow the new IP silently instead of a duplicate discovery card appearing. Already-configured entries adopt the MAC the first time discovery sees them at their current IP, so pre-existing setups gain lease tracking too. Reconfiguring to a different address clears the stored MAC.

Spec: `docs/superpowers/specs/2026-08-10-network-printer-identification-design.md` (includes deliberate out-of-scope: zeroconf — verified this printer generation advertises no mDNS; OUI matchers).

## Robustness details

- Reconfigure replaces detected identity only when the printer address changed or a fresh answer arrived — a transient query miss on an unchanged address keeps the known identity.
- Discovery-time identification is only reused when both host **and** port still match the probed target; any edit triggers a fresh query.
- `GS I` replies are header-validated, length-capped, control-character-filtered, and the read stream resyncs (bounded to 4 KB drain) on oversized replies. The helper never raises and never mutates printer state.
- Discovery false positives abort silently before any user-visible card; MAC relocation never clobbers a user's manual entry rename and skips on unique-id collisions.

## Review trail

Built via subagent-driven development: per-task spec+quality reviews, a whole-branch review, three independent angle reviews (senior dev / product owner / documentation), and an Opus review of the MAC-tracking feature — each followed by verified fix waves.

## Testing

- 1296 passed (106 new), `ruff check` / `ruff format --check` / `mypy` clean; CodeQL PR finding fixed.
- New coverage: GS I framing parser edge cases (timeouts, garbage, oversized/drip-fed replies), discovery flow (abort paths, title, duplicate flows, edited host/port re-query), MAC relocation (title follow/preserve, entry-port unique IDs, reload fired, collision safety, adoption into existing entries), reconfigure identity semantics, device-info fallbacks + MAC connection, calibrate prefill.

## Follow-ups (deliberately not in this PR)

- Discovery retry for the printer-boot race (DHCP fires before port 9100 is up)
- One-time backfill of detected identity for pre-existing entries (interim: docs point users at Reconfigure; MAC adoption already covers lease tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hjUZ6aEMCJwQjyuFuTW3h
