### PR TITLE
MAC-tracked discovery, clone identity fixes, RP820 alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   that aren't printers are ignored silently; `tm-*` hostnames additionally
   require a real `GS I` answer, since port 9100 is also Prometheus
   node_exporter's default. Discovered setups preselect
-  the matching printer profile when one is known.
+  the matching printer profile when one is known. Discovered entries are
+  additionally tracked by MAC address, so a DHCP lease change updates the
+  existing entry's host in place instead of offering a duplicate.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Text wrapping no longer strips a trailing newline, so calibration
   test-page labels flush before each pattern instead of being dropped
   into or merged with the following image (seen on Ronga RP850P).
+- Clone printers announcing a brand hostname (e.g. `rongta_*`) no longer
+  masquerade as their emulation target in discovery/device info, even
+  when their firmware's `GS I` reply claims to be a different brand.
+- Implausible font column counts from the profile database (an upstream
+  data bug encoding font dot widths as column counts) no longer surface
+  as characters-per-line choices.
 
 ## [1.1.0] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   the matching printer profile when one is known. Discovered entries are
   additionally tracked by MAC address, so a DHCP lease change updates the
   existing entry's host in place instead of offering a duplicate.
+- "Rongta RP820" is recognized as a compatible model (the network identity
+  RP850P hardware announces), so discovered Rongta printers preselect the
+  matching 80mm profile.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ Services → Discovered), with the host prefilled and the matching profile
 preselected. Manual setup still runs the `GS I` query, but the profile
 dropdown is already on the same form when you submit it, so there's no
 discovered result yet to preselect a profile from — you pick the profile
-yourself, same as before.
+yourself, same as before. Discovered printers are tracked by MAC address, so
+a DHCP lease change updates the existing entry instead of offering a
+duplicate.
 
 **Upgrading?** Printers configured before this feature pick up their
 detected model the next time you run **Reconfigure** on the entry.

--- a/custom_components/escpos_printer/_config_flow/discovery_steps.py
+++ b/custom_components/escpos_printer/_config_flow/discovery_steps.py
@@ -15,6 +15,7 @@ from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 
 from ..const import CONF_MAC_ADDRESS, DEFAULT_PORT, DEFAULT_TIMEOUT, DOMAIN
 from .network_helpers import _can_connect, query_printer_id
@@ -64,14 +65,27 @@ class DiscoveryFlowMixin:
             )
             if colliding is not None and colliding.entry_id != entry.entry_id:
                 break  # unique_id already owned by a different entry
+            # Only follow the address to a new auto-generated title -- a
+            # user's manual rename must never be clobbered (same heuristic
+            # as network_steps.async_step_reconfigure_network).
+            title: str | UndefinedType = UNDEFINED
+            if entry.title == f"{entry.data.get(CONF_HOST)}:{entry_port}":
+                title = f"{host}:{entry_port}"
             self.hass.config_entries.async_update_entry(
-                entry, data={**entry.data, CONF_HOST: host}, unique_id=new_unique_id
+                entry, data={**entry.data, CONF_HOST: host}, unique_id=new_unique_id, title=title
             )
             self.hass.config_entries.async_schedule_reload(entry.entry_id)
             return self.async_abort(reason="already_configured")  # type: ignore[attr-defined,no-any-return]
 
         await self.async_set_unique_id(f"{host.lower()}:{DEFAULT_PORT}")  # type: ignore[attr-defined]
-        self._abort_if_unique_id_configured()  # type: ignore[attr-defined]
+        # When discovery matches an already-configured entry at its current
+        # IP, fold the (possibly new) MAC into it -- pre-existing and
+        # manually-created entries gain lease tracking the first time
+        # discovery sees them. Reload only fires on an actual data change.
+        if mac:
+            self._abort_if_unique_id_configured(updates={CONF_MAC_ADDRESS: mac})  # type: ignore[attr-defined]
+        else:
+            self._abort_if_unique_id_configured()  # type: ignore[attr-defined]
 
         if not await self.hass.async_add_executor_job(
             _can_connect, host, DEFAULT_PORT, DEFAULT_TIMEOUT

--- a/custom_components/escpos_printer/_config_flow/discovery_steps.py
+++ b/custom_components/escpos_printer/_config_flow/discovery_steps.py
@@ -12,9 +12,11 @@ import logging
 from typing import Any
 
 from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from ..const import DEFAULT_PORT, DEFAULT_TIMEOUT
+from ..const import CONF_MAC_ADDRESS, DEFAULT_PORT, DEFAULT_TIMEOUT, DOMAIN
 from .network_helpers import _can_connect, query_printer_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -29,16 +31,45 @@ class DiscoveryFlowMixin:
     - _detected: dict[str, str] (main_flow.__init__)
     - _discovery_host: str | None (main_flow.__init__)
     - _discovery_port: int | None (main_flow.__init__)
+    - _discovery_mac: str | None (main_flow.__init__)
     """
 
     hass: Any
     _detected: dict[str, str]
     _discovery_host: str | None
     _discovery_port: int | None
+    _discovery_mac: str | None
 
     async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> ConfigFlowResult:
         """Handle a DHCP-discovered printer candidate."""
         host = discovery_info.ip
+        mac = format_mac(discovery_info.macaddress)
+        self._discovery_mac = mac
+
+        # A known MAC at a new IP (DHCP lease change) updates the existing
+        # entry in place instead of offering a duplicate -- see "Follow-up:
+        # MAC-tracked discovery identity" in the design doc. Only one
+        # network entry can plausibly carry a given MAC, so the first match
+        # wins; a same-IP match just falls through to the normal
+        # already-configured abort below.
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if entry.data.get(CONF_MAC_ADDRESS) != mac:
+                continue
+            if str(entry.data.get(CONF_HOST, "")).lower() == host.lower():
+                break
+            entry_port = entry.data.get(CONF_PORT, DEFAULT_PORT)
+            new_unique_id = f"{host.lower()}:{entry_port}"
+            colliding = self.hass.config_entries.async_entry_for_domain_unique_id(
+                DOMAIN, new_unique_id
+            )
+            if colliding is not None and colliding.entry_id != entry.entry_id:
+                break  # unique_id already owned by a different entry
+            self.hass.config_entries.async_update_entry(
+                entry, data={**entry.data, CONF_HOST: host}, unique_id=new_unique_id
+            )
+            self.hass.config_entries.async_schedule_reload(entry.entry_id)
+            return self.async_abort(reason="already_configured")  # type: ignore[attr-defined,no-any-return]
+
         await self.async_set_unique_id(f"{host.lower()}:{DEFAULT_PORT}")  # type: ignore[attr-defined]
         self._abort_if_unique_id_configured()  # type: ignore[attr-defined]
 

--- a/custom_components/escpos_printer/_config_flow/discovery_steps.py
+++ b/custom_components/escpos_printer/_config_flow/discovery_steps.py
@@ -22,6 +22,31 @@ from .network_helpers import _can_connect, query_printer_id
 
 _LOGGER = logging.getLogger(__name__)
 
+# Brand hostname prefixes (lowercase, matching the manifest's DHCP hostname
+# matchers) that GS I identity may not be trusted against -- see
+# _override_clone_identity.
+BRAND_HOSTNAME_PREFIXES = {"rongta": "Rongta"}
+
+
+def _override_clone_identity(hostname: str, detected: dict[str, str]) -> dict[str, str]:
+    """Replace a borrowed GS I identity with the DHCP hostname's brand.
+
+    Some clone firmware answers GS I with the manufacturer/model of the
+    printer it emulates (e.g. a Rongta board claiming "EPSON TM-T88III").
+    A brand-exclusive hostname prefix is stronger evidence than that reply,
+    so when the two disagree the hostname wins.
+    """
+    hostname_lower = hostname.lower()
+    for prefix, brand in BRAND_HOSTNAME_PREFIXES.items():
+        if not hostname_lower.startswith(prefix):
+            continue
+        manufacturer = detected.get("manufacturer", "")
+        if detected.get("model") and manufacturer.lower() != brand.lower():
+            model = hostname[len(prefix) :].lstrip("_-.") or hostname
+            return {"manufacturer": brand, "model": model}
+        break
+    return detected
+
 
 class DiscoveryFlowMixin:
     """Mixin providing the DHCP discovery entry point.
@@ -104,6 +129,7 @@ class DiscoveryFlowMixin:
             )
             or {}
         )
+        detected = _override_clone_identity(discovery_info.hostname, detected)
 
         # "tm-*" also matches Prometheus node_exporter's default port 9100,
         # so a port-probe alone is not brand-exclusive evidence for it -- a

--- a/custom_components/escpos_printer/_config_flow/main_flow.py
+++ b/custom_components/escpos_printer/_config_flow/main_flow.py
@@ -51,6 +51,7 @@ class EscposConfigFlow(
         self._detected: dict[str, str] = {}
         self._discovery_host: str | None = None
         self._discovery_port: int | None = None
+        self._discovery_mac: str | None = None
         self._discovered_printers: list[dict[str, Any]] = []
         self._all_usb_devices: list[dict[str, Any]] = []
         self._paired_bt_devices: list[dict[str, Any]] = []

--- a/custom_components/escpos_printer/_config_flow/network_steps.py
+++ b/custom_components/escpos_printer/_config_flow/network_steps.py
@@ -20,6 +20,7 @@ from ..const import (
     CONF_CONNECTION_TYPE,
     CONF_DETECTED_MANUFACTURER,
     CONF_DETECTED_MODEL,
+    CONF_MAC_ADDRESS,
     CONF_PROFILE,
     CONF_TIMEOUT,
     CONNECTION_TYPE_NETWORK,
@@ -51,6 +52,7 @@ class NetworkFlowMixin:
     _detected: dict[str, str]
     _discovery_host: str | None
     _discovery_port: int | None
+    _discovery_mac: str | None
 
     async def async_step_network(
         self, user_input: dict[str, Any] | None = None
@@ -84,19 +86,18 @@ class NetworkFlowMixin:
             if ok:
                 _LOGGER.debug("Connection test succeeded for %s:%s", host, port)
 
-                # Best-effort GS I identification. Reuse a discovery-time
-                # result (e.g. DHCP discovery step) only when the submitted
-                # host AND port still match the discovered ones -- the host
-                # field is just a suggested value, and if the user points it
-                # at a different printer (or a different port on the same
-                # host) the discovery-time result must not be attributed to
-                # it. DHCP always probes DEFAULT_PORT, so an edited port
-                # alone is enough to misattribute identity.
+                # Discovery-time state (GS I result, MAC) only describes the
+                # probed target -- the host field is just a suggested value,
+                # and if the user points it at a different printer (or a
+                # different port on the same host) that state must not be
+                # attributed to it. DHCP always probes DEFAULT_PORT, so an
+                # edited port alone is enough to misattribute identity.
+                matches_discovery_target = (
+                    host == self._discovery_host and port == self._discovery_port
+                )
                 detected = (
                     self._detected
-                    if self._detected
-                    and host == self._discovery_host
-                    and port == self._discovery_port
+                    if self._detected and matches_discovery_target
                     else (
                         await self.hass.async_add_executor_job(
                             query_printer_id, host, port, timeout
@@ -118,6 +119,8 @@ class NetworkFlowMixin:
                     self._user_data[CONF_DETECTED_MANUFACTURER] = detected["manufacturer"]
                 if detected.get("model"):
                     self._user_data[CONF_DETECTED_MODEL] = detected["model"]
+                if self._discovery_mac and matches_discovery_target:
+                    self._user_data[CONF_MAC_ADDRESS] = self._discovery_mac
 
                 # If custom profile selected, go to custom profile step
                 if profile == PROFILE_CUSTOM:
@@ -250,6 +253,12 @@ class NetworkFlowMixin:
                         new_data[CONF_DETECTED_MANUFACTURER] = detected["manufacturer"]
                     if detected.get("model"):
                         new_data[CONF_DETECTED_MODEL] = detected["model"]
+                # The stored MAC describes the address binding, not the GS I
+                # reply -- it clears only when the address itself changes
+                # (an edit may repoint the entry at different hardware the
+                # MAC no longer describes), never on a transient query miss.
+                if addr_changed:
+                    new_data.pop(CONF_MAC_ADDRESS, None)
 
                 return self.async_update_reload_and_abort(  # type: ignore[attr-defined,no-any-return]
                     reconfigure_entry,

--- a/custom_components/escpos_printer/capabilities/aliases.py
+++ b/custom_components/escpos_printer/capabilities/aliases.py
@@ -62,6 +62,11 @@ ALIAS_MODELS: dict[str, str] = {
     # WRAPS onto extra lines rather than clipping on this firmware. NOT
     # aliased to RP326 because that bundled profile declares no pixel width.
     "Rongta RP850P": "NT-80-V-UL",
+    # "RP820" is the DHCP hostname (Rongta_RP820) that RP850P hardware
+    # announces on the network — observed on the hardware-verified unit
+    # above, so it inherits the same alias target. Covers DHCP-discovery
+    # identity, and any actual RP820 units sharing that network firmware.
+    "Rongta RP820": "NT-80-V-UL",
     # Misc verified 58mm/384dot ESC/POS clones.
     "HOIN HOP-E58": "POS-5890",
     "Goojprt PT-210": "POS-5890",

--- a/custom_components/escpos_printer/capabilities/line_widths.py
+++ b/custom_components/escpos_printer/capabilities/line_widths.py
@@ -9,6 +9,12 @@ from .loader import _get_capabilities
 
 _LOGGER = logging.getLogger(__name__)
 
+# A receipt printer never has fewer than 16 characters per line. Guards
+# against upstream escpos-printer-db data bugs like NT-80-V-UL, whose
+# fonts.columns values (9, 12) are actually font DOT widths mistakenly
+# encoded as column counts (correct values: 48 and 64 on that profile).
+_MIN_PLAUSIBLE_COLUMNS = 16
+
 
 def get_profile_line_widths(profile_key: str | None) -> list[int]:
     """Get list of line widths (column counts) supported by a profile.
@@ -43,7 +49,7 @@ def get_profile_line_widths(profile_key: str | None) -> list[int]:
     for font_data in fonts.values():
         if isinstance(font_data, dict):
             columns = font_data.get("columns")
-            if isinstance(columns, int) and columns > 0:
+            if isinstance(columns, int) and columns >= _MIN_PLAUSIBLE_COLUMNS:
                 widths.add(columns)
 
     if not widths:

--- a/custom_components/escpos_printer/const.py
+++ b/custom_components/escpos_printer/const.py
@@ -26,6 +26,11 @@ CONF_ALLOW_LOCAL_IMAGE_URLS = "allow_local_image_urls"
 CONF_DETECTED_MANUFACTURER = "detected_manufacturer"
 CONF_DETECTED_MODEL = "detected_model"
 
+# DHCP-discovery MAC address (normalized via format_mac), captured only when
+# a discovery-created entry's host/port still match the probed target.
+# Network printers only; manual entries never carry this key.
+CONF_MAC_ADDRESS = "mac_address"
+
 # Connection type configuration
 CONF_CONNECTION_TYPE = "connection_type"
 CONNECTION_TYPE_NETWORK = "network"

--- a/custom_components/escpos_printer/device.py
+++ b/custom_components/escpos_printer/device.py
@@ -8,12 +8,14 @@ binary_sensor.py, sensor.py, and notify.py each used to build independently
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo
 
 from .const import (
     CONF_CONNECTION_TYPE,
     CONF_DETECTED_MANUFACTURER,
     CONF_DETECTED_MODEL,
+    CONF_MAC_ADDRESS,
     CONNECTION_TYPE_BLUETOOTH,
     CONNECTION_TYPE_NETWORK,
     CONNECTION_TYPE_SERIAL,
@@ -74,4 +76,7 @@ def build_device_info(entry: ConfigEntry) -> DeviceInfo:
         serial = _usb_serial_number(entry)
         if serial:
             info["serial_number"] = serial
+    mac = entry.data.get(CONF_MAC_ADDRESS)
+    if mac:
+        info["connections"] = {(CONNECTION_NETWORK_MAC, mac)}
     return info

--- a/docs/network.md
+++ b/docs/network.md
@@ -36,7 +36,8 @@ setup screen.
 
 A discovered printer shows up under **Settings → Devices & Services →
 Discovered**; accepting it prefills the host and preselects the matching
-printer profile.
+printer profile. Discovered printers are tracked by MAC address, so a DHCP
+lease change updates the existing entry instead of offering a duplicate.
 
 Separately from discovery, every network setup and reconfigure queries the
 printer directly with `GS I`. Printers that answer (mostly genuine Epson

--- a/docs/superpowers/specs/2026-08-10-network-printer-identification-design.md
+++ b/docs/superpowers/specs/2026-08-10-network-printer-identification-design.md
@@ -34,10 +34,10 @@ Two features sharing one core:
   Bixolon's `00:15:94` is the one credible candidate (single-purpose printer
   vendor) but guarantees only "Bixolon printer", not "ESC/POS receipt
   printer" — deferred until a user report confirms one working.
-- **MAC-based unique IDs.** unique_id stays `host:port`; a printer whose DHCP
-  lease changes IP is re-discovered as a new device. The fix (entry migration
-  to MAC-keyed IDs) isn't worth it now; a DHCP reservation is the standard
-  answer.
+- **MAC-based unique IDs.** unique_id stays `host:port`. (Superseded in part —
+  see "Follow-up: MAC-tracked discovery identity" below, added after the
+  product review showed discovery turns lease changes into a duplicate-entry
+  trap.)
 - **Querying at adapter start / device-registry refresh after setup.** The
   model can't change between setups of the same printer; existing entries pick
   the fields up on their next reconfigure.
@@ -138,6 +138,25 @@ layout) added to `EscposConfigFlow`:
 
 Discovery card title uses the detected model when available ("TM-T20II at
 192.168.10.157"), else the DHCP hostname.
+
+## Follow-up: MAC-tracked discovery identity (added 2026-08-10)
+
+unique_id stays `host:port`, but discovery-created entries additionally
+persist `entry.data["mac_address"]` (`CONF_MAC_ADDRESS`, normalized via HA's
+`format_mac`) — captured from `DhcpServiceInfo.macaddress`, and only when the
+submitted host/port still match the probed discovery target (the same gate
+that guards detection reuse). Manual entries never carry a MAC.
+
+`async_step_dhcp` checks for an entry with the discovered MAC before anything
+else. Match with a different IP → update that entry's `CONF_HOST` and
+`host:port` unique_id in place (keeping the entry's stored port), schedule a
+reload, abort silently. If the new `ip:port` unique_id collides with a
+*different* entry, skip the auto-update and fall through to normal dedupe.
+Match with the same IP → normal already-configured abort.
+
+Reconfigure that changes the address clears the stored MAC, mirroring the
+detected-identity clearing rule: an address edit may repoint the entry at
+different hardware the MAC no longer describes.
 
 ## Strings & docs
 

--- a/docs/superpowers/specs/2026-08-10-network-printer-identification-design.md
+++ b/docs/superpowers/specs/2026-08-10-network-printer-identification-design.md
@@ -158,6 +158,15 @@ Reconfigure that changes the address clears the stored MAC, mirroring the
 detected-identity clearing rule: an address edit may repoint the entry at
 different hardware the MAC no longer describes.
 
+Two review-driven extensions: (1) relocation follows the auto-generated
+`host:port` title (a user rename is never clobbered), so the reconfigure
+title heuristic keeps working afterwards; (2) when discovery matches an
+already-configured entry at its current IP, the entry adopts the discovered
+MAC (`_abort_if_unique_id_configured(updates=...)`) — pre-existing and
+manually-created entries gain lease tracking the first time discovery sees
+them. The stored MAC is also surfaced as a device-registry network
+connection.
+
 ## Strings & docs
 
 - `strings.json` + `translations/en.json`: discovery step title/description

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -44,7 +44,9 @@ LAN-local and can't cross those boundaries.
 The printer didn't answer the `GS I` identity query at setup (or
 reconfigure) time. Most non-Epson clones don't implement it. This is
 harmless: identification is cosmetic and every printing feature still
-works. Epson owners can retry via **Reconfigure**.
+works. Epson owners can retry via **Reconfigure**. Brand-hostname clones
+(e.g. Rongta) are identified by their announced DHCP hostname even
+though their firmware's `GS I` reply claims to be an Epson.
 
 ## USB issues
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -260,6 +260,38 @@ class TestGetProfileLineWidths:
         assert len(result) > 0
         assert 42 in result  # escpos default profile: Font A = 42 columns
 
+    def test_healthy_profile_unaffected(self):
+        """TM-T88III's real column counts (42, 56) pass the plausibility filter."""
+        result = get_profile_line_widths("TM-T88III")
+        assert result == [42, 56]
+
+    def test_bogus_font_columns_fall_back_to_common(self):
+        """NT-80-V-UL's upstream data bug encodes font DOT widths (9, 12) as
+        column counts on a 576px printer -- both are implausibly small for
+        any receipt printer, so the result must fall back to common widths."""
+        result = get_profile_line_widths("NT-80-V-UL")
+        assert result == COMMON_LINE_WIDTHS
+
+    def test_mixed_bogus_and_plausible_keeps_only_plausible(self):
+        """A profile with one implausible and one plausible font column
+        count keeps only the plausible one."""
+        mock_data = {
+            "profiles": {
+                "mixed": {
+                    "fonts": {
+                        "0": {"columns": 9},
+                        "1": {"columns": 48},
+                    }
+                }
+            },
+        }
+        with patch(
+            "custom_components.escpos_printer.capabilities.line_widths._get_capabilities",
+            return_value=mock_data,
+        ):
+            result = get_profile_line_widths("mixed")
+        assert result == [48]
+
 
 class TestGetAllLineWidths:
     """Tests for get_all_line_widths function."""

--- a/tests/test_config_flow_dhcp.py
+++ b/tests/test_config_flow_dhcp.py
@@ -252,10 +252,56 @@ async def test_dhcp_discovery_edited_host_does_not_persist_mac(hass):
 
 
 async def test_dhcp_discovery_known_mac_new_ip_updates_existing_entry(hass):
-    """A DHCP lease change (same MAC, new IP) updates the existing entry in place."""
+    """A DHCP lease change (same MAC, new IP) updates the existing entry in place.
+
+    The entry's auto-generated title (matching its old "host:port") follows
+    the relocation, and the reload actually fires.
+    """
     mac = format_mac(DISCOVERY.macaddress)
     entry = MockConfigEntry(
         domain=DOMAIN,
+        title="192.168.10.157:9100",
+        unique_id="192.168.10.157:9100",
+        data={
+            "connection_type": "network",
+            "host": "192.168.10.157",
+            "port": 9100,
+            CONF_MAC_ADDRESS: mac,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.escpos_printer.async_setup_entry", return_value=True
+    ) as mock_setup:
+        result = await _start_dhcp_flow(
+            hass,
+            discovery=DhcpServiceInfo(
+                ip="192.168.10.200",
+                hostname="TM-T20II-628E52",
+                macaddress=DISCOVERY.macaddress,
+            ),
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    mock_setup.assert_called_once()  # reload actually fired
+
+    updated = hass.config_entries.async_get_entry(entry.entry_id)
+    assert updated is not None
+    assert updated.data["host"] == "192.168.10.200"
+    assert updated.unique_id == "192.168.10.200:9100"
+    assert updated.title == "192.168.10.200:9100"  # auto-generated title follows
+
+
+async def test_dhcp_discovery_known_mac_new_ip_preserves_manual_rename(hass):
+    """A relocation must never clobber a user-renamed title."""
+    mac = format_mac(DISCOVERY.macaddress)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Front Counter Printer",  # manually renamed, not "host:port"
         unique_id="192.168.10.157:9100",
         data={
             "connection_type": "network",
@@ -278,13 +324,41 @@ async def test_dhcp_discovery_known_mac_new_ip_updates_existing_entry(hass):
         await hass.async_block_till_done()
 
     assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-
     updated = hass.config_entries.async_get_entry(entry.entry_id)
     assert updated is not None
-    assert updated.data["host"] == "192.168.10.200"
-    assert updated.unique_id == "192.168.10.200:9100"
+    assert updated.title == "Front Counter Printer"  # untouched
+
+
+async def test_dhcp_discovery_known_mac_new_ip_keeps_entry_port(hass):
+    """Relocation uses the entry's STORED port, not DEFAULT_PORT."""
+    mac = format_mac(DISCOVERY.macaddress)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="192.168.10.157:9101",
+        data={
+            "connection_type": "network",
+            "host": "192.168.10.157",
+            "port": 9101,
+            CONF_MAC_ADDRESS: mac,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with patch("custom_components.escpos_printer.async_setup_entry", return_value=True):
+        result = await _start_dhcp_flow(
+            hass,
+            discovery=DhcpServiceInfo(
+                ip="192.168.10.200",
+                hostname="TM-T20II-628E52",
+                macaddress=DISCOVERY.macaddress,
+            ),
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    updated = hass.config_entries.async_get_entry(entry.entry_id)
+    assert updated is not None
+    assert updated.unique_id == "192.168.10.200:9101"
 
 
 async def test_dhcp_discovery_known_mac_new_ip_collision_skips_update(hass):
@@ -320,7 +394,9 @@ async def test_dhcp_discovery_known_mac_new_ip_collision_skips_update(hass):
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-    assert hass.config_entries.async_get_entry(tracked.entry_id).data["host"] == "192.168.10.157"
+    tracked_updated = hass.config_entries.async_get_entry(tracked.entry_id)
+    assert tracked_updated.data["host"] == "192.168.10.157"
+    assert tracked_updated.unique_id == "192.168.10.157:9100"  # untouched
     assert len(hass.config_entries.async_entries(DOMAIN)) == 2
 
 
@@ -344,6 +420,26 @@ async def test_dhcp_discovery_known_mac_same_ip_normal_abort(hass):
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_dhcp_discovery_matched_entry_without_mac_adopts_it(hass):
+    """An already-configured entry at the discovered IP that has no stored MAC
+    yet adopts it -- pre-existing and manually-created entries gain lease
+    tracking the first time discovery sees them."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="192.168.10.157:9100",
+        data={"connection_type": "network", "host": "192.168.10.157", "port": 9100},
+    )
+    entry.add_to_hass(hass)
+
+    result = await _start_dhcp_flow(hass)
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    updated = hass.config_entries.async_get_entry(entry.entry_id)
+    assert updated is not None
+    assert updated.data[CONF_MAC_ADDRESS] == format_mac(DISCOVERY.macaddress)
 
 
 async def test_dhcp_discovery_duplicate_in_progress_aborts(hass):

--- a/tests/test_config_flow_dhcp.py
+++ b/tests/test_config_flow_dhcp.py
@@ -455,10 +455,10 @@ async def test_dhcp_discovery_rongta_clone_overrides_epson_emulation(hass):
     flow = hass.config_entries.flow.async_progress()[0]
     assert flow["context"]["title_placeholders"] == {"name": "RP820 (192.168.10.158)"}
 
-    from custom_components.escpos_printer.capabilities import PROFILE_AUTO
-
+    # The overridden identity ("RP820") resolves through the alias table
+    # to the 80mm clone profile -- not to the emulated TM-T88III.
     defaults = result["data_schema"]({"host": "192.168.10.158"})
-    assert defaults["profile"] == PROFILE_AUTO
+    assert defaults["profile"] == "NT-80-V-UL"
 
     with patch(
         "custom_components.escpos_printer._config_flow.network_steps._can_connect",

--- a/tests/test_config_flow_dhcp.py
+++ b/tests/test_config_flow_dhcp.py
@@ -442,6 +442,50 @@ async def test_dhcp_discovery_matched_entry_without_mac_adopts_it(hass):
     assert updated.data[CONF_MAC_ADDRESS] == format_mac(DISCOVERY.macaddress)
 
 
+async def test_dhcp_discovery_rongta_clone_overrides_epson_emulation(hass):
+    """A Rongta board answering GS I as "EPSON TM-T88III" (clone firmware
+    impersonating its emulation target) must not hijack the discovered
+    identity -- the brand hostname is authoritative."""
+    result = await _start_dhcp_flow(
+        hass,
+        query_result={"manufacturer": "EPSON", "model": "TM-T88III"},
+        discovery=DISCOVERY_RONGTA,
+    )
+    assert result["step_id"] == "network"
+    flow = hass.config_entries.flow.async_progress()[0]
+    assert flow["context"]["title_placeholders"] == {"name": "RP820 (192.168.10.158)"}
+
+    from custom_components.escpos_printer.capabilities import PROFILE_AUTO
+
+    defaults = result["data_schema"]({"host": "192.168.10.158"})
+    assert defaults["profile"] == PROFILE_AUTO
+
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "192.168.10.158", "port": 9100}
+        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"]["detected_manufacturer"] == "Rongta"
+    assert result["data"]["detected_model"] == "RP820"
+
+
+async def test_dhcp_discovery_rongta_branded_gs_i_reply_kept(hass):
+    """A rongta_* hostname whose GS I reply IS Rongta-branded keeps that
+    identity untouched -- the override only fires on a brand mismatch."""
+    await _start_dhcp_flow(
+        hass,
+        query_result={"manufacturer": "Rongta", "model": "RP850P"},
+        discovery=DISCOVERY_RONGTA,
+    )
+    flow = hass.config_entries.flow.async_progress()[0]
+    assert flow["context"]["title_placeholders"] == {"name": "RP850P (192.168.10.158)"}
+
+
 async def test_dhcp_discovery_duplicate_in_progress_aborts(hass):
     """A second DHCP discovery for the same IP while the first flow is
     still open (unanswered form) aborts as already_in_progress."""

--- a/tests/test_config_flow_dhcp.py
+++ b/tests/test_config_flow_dhcp.py
@@ -6,10 +6,11 @@ from unittest.mock import ANY, patch
 
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.escpos_printer.const import DOMAIN
+from custom_components.escpos_printer.const import CONF_MAC_ADDRESS, DOMAIN
 
 DISCOVERY = DhcpServiceInfo(
     ip="192.168.10.157",
@@ -204,6 +205,145 @@ async def test_dhcp_discovery_end_to_end_creates_entry_with_detection(hass):
     assert result["data"]["detected_manufacturer"] == "EPSON"
     assert result["data"]["detected_model"] == "TM-T20II"
     assert result["data"]["profile"] == "TM-T20II"
+
+
+async def test_dhcp_discovery_persists_mac_address(hass):
+    """A discovery-created entry (unedited host/port) carries the DHCP MAC."""
+    with patch(
+        "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+        return_value=True,
+    ):
+        result = await _start_dhcp_flow(
+            hass, query_result={"manufacturer": "EPSON", "model": "TM-T20II"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "192.168.10.157", "port": 9100}
+        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_MAC_ADDRESS] == format_mac(DISCOVERY.macaddress)
+    assert result["data"][CONF_MAC_ADDRESS] == "50:57:9c:62:8e:52"
+
+
+async def test_dhcp_discovery_edited_host_does_not_persist_mac(hass):
+    """Editing the suggested host must not attribute the discovery MAC to it."""
+    result = await _start_dhcp_flow(
+        hass, query_result={"manufacturer": "EPSON", "model": "TM-T20II"}
+    )
+
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"host": "192.168.10.200", "port": 9100}
+        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert CONF_MAC_ADDRESS not in result["data"]
+
+
+async def test_dhcp_discovery_known_mac_new_ip_updates_existing_entry(hass):
+    """A DHCP lease change (same MAC, new IP) updates the existing entry in place."""
+    mac = format_mac(DISCOVERY.macaddress)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="192.168.10.157:9100",
+        data={
+            "connection_type": "network",
+            "host": "192.168.10.157",
+            "port": 9100,
+            CONF_MAC_ADDRESS: mac,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with patch("custom_components.escpos_printer.async_setup_entry", return_value=True):
+        result = await _start_dhcp_flow(
+            hass,
+            discovery=DhcpServiceInfo(
+                ip="192.168.10.200",
+                hostname="TM-T20II-628E52",
+                macaddress=DISCOVERY.macaddress,
+            ),
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+    updated = hass.config_entries.async_get_entry(entry.entry_id)
+    assert updated is not None
+    assert updated.data["host"] == "192.168.10.200"
+    assert updated.unique_id == "192.168.10.200:9100"
+
+
+async def test_dhcp_discovery_known_mac_new_ip_collision_skips_update(hass):
+    """If the new ip:port is already owned by a different entry, the MAC-tracked
+    entry is left untouched and normal dedupe applies."""
+    mac = format_mac(DISCOVERY.macaddress)
+    tracked = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="192.168.10.157:9100",
+        data={
+            "connection_type": "network",
+            "host": "192.168.10.157",
+            "port": 9100,
+            CONF_MAC_ADDRESS: mac,
+        },
+    )
+    tracked.add_to_hass(hass)
+    other = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="192.168.10.200:9100",
+        data={"connection_type": "network", "host": "192.168.10.200", "port": 9100},
+    )
+    other.add_to_hass(hass)
+
+    result = await _start_dhcp_flow(
+        hass,
+        discovery=DhcpServiceInfo(
+            ip="192.168.10.200",
+            hostname="TM-T20II-628E52",
+            macaddress=DISCOVERY.macaddress,
+        ),
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert hass.config_entries.async_get_entry(tracked.entry_id).data["host"] == "192.168.10.157"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 2
+
+
+async def test_dhcp_discovery_known_mac_same_ip_normal_abort(hass):
+    """A known MAC at the same IP falls through to the ordinary
+    already-configured unique_id dedupe (no update, no reload)."""
+    mac = format_mac(DISCOVERY.macaddress)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="192.168.10.157:9100",
+        data={
+            "connection_type": "network",
+            "host": "192.168.10.157",
+            "port": 9100,
+            CONF_MAC_ADDRESS: mac,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await _start_dhcp_flow(hass)
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
 
 
 async def test_dhcp_discovery_duplicate_in_progress_aborts(hass):

--- a/tests/test_config_flow_reconfigure.py
+++ b/tests/test_config_flow_reconfigure.py
@@ -17,6 +17,7 @@ from custom_components.escpos_printer.const import (
     CONF_DETECTED_MODEL,
     CONF_IN_EP,
     CONF_LINE_WIDTH,
+    CONF_MAC_ADDRESS,
     CONF_OUT_EP,
     CONF_PRODUCT_ID,
     CONF_RFCOMM_CHANNEL,
@@ -307,6 +308,95 @@ async def test_reconfigure_network_detected_fields_survive_transient_requery_fai
     assert updated.data[CONF_TIMEOUT] == 8.0
     assert updated.data[CONF_DETECTED_MANUFACTURER] == "EPSON"
     assert updated.data[CONF_DETECTED_MODEL] == "TM-T20II"
+
+
+async def test_reconfigure_network_address_change_clears_mac_address(hass):  # type: ignore[no-untyped-def]
+    """An address edit clears the stored discovery MAC -- it may repoint the
+    entry at different hardware the MAC no longer describes."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="1.2.3.4:9100",
+        data={
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 9100,
+            CONF_TIMEOUT: 4.0,
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK,
+            CONF_MAC_ADDRESS: "50:57:9c:62:8e:52",
+        },
+        unique_id="1.2.3.4:9100",
+    )
+    entry.add_to_hass(hass)
+    entry_id = entry.entry_id
+
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
+        patch("custom_components.escpos_printer.async_setup_entry", return_value=True),
+    ):
+        result = await entry.start_reconfigure_flow(hass)
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "5.6.7.8", CONF_PORT: 9100},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "reconfigure_successful"
+
+    updated = hass.config_entries.async_get_entry(entry_id)
+    assert updated is not None
+    assert CONF_MAC_ADDRESS not in updated.data
+
+
+async def test_reconfigure_network_same_address_keeps_mac_on_query_miss(hass):  # type: ignore[no-untyped-def]
+    """Reconfiguring just the timeout (same host/port) while the printer is
+    transiently busy (query returns None) must not clear a good stored MAC --
+    the MAC describes the address binding, not the GS I reply."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="1.2.3.4:9100",
+        data={
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 9100,
+            CONF_TIMEOUT: 4.0,
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK,
+            CONF_MAC_ADDRESS: "50:57:9c:62:8e:52",
+        },
+        unique_id="1.2.3.4:9100",
+    )
+    entry.add_to_hass(hass)
+    entry_id = entry.entry_id
+
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
+        patch("custom_components.escpos_printer.async_setup_entry", return_value=True),
+    ):
+        result = await entry.start_reconfigure_flow(hass)
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "1.2.3.4", CONF_PORT: 9100, CONF_TIMEOUT: 8.0},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "reconfigure_successful"
+
+    updated = hass.config_entries.async_get_entry(entry_id)
+    assert updated is not None
+    assert updated.data[CONF_MAC_ADDRESS] == "50:57:9c:62:8e:52"
 
 
 async def test_reconfigure_network_cannot_connect(hass):  # type: ignore[no-untyped-def]

--- a/tests/test_device_info.py
+++ b/tests/test_device_info.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+
 from custom_components.escpos_printer.const import (
     CONF_CONNECTION_TYPE,
     CONF_DETECTED_MANUFACTURER,
     CONF_DETECTED_MODEL,
+    CONF_MAC_ADDRESS,
     CONNECTION_TYPE_BLUETOOTH,
     CONNECTION_TYPE_NETWORK,
     CONNECTION_TYPE_SERIAL,
@@ -115,3 +118,20 @@ def test_device_info_falls_back_without_detected_fields() -> None:
     info = build_device_info(entry)  # type: ignore[arg-type]
     assert info["manufacturer"] == "ESC/POS"
     assert info["model"] == "Network Printer"
+
+
+def test_device_info_includes_mac_connection_when_tracked() -> None:
+    entry = _FakeEntry(
+        data={
+            CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK,
+            CONF_MAC_ADDRESS: "50:57:9c:62:8e:52",
+        }
+    )
+    info = build_device_info(entry)  # type: ignore[arg-type]
+    assert info["connections"] == {(CONNECTION_NETWORK_MAC, "50:57:9c:62:8e:52")}
+
+
+def test_device_info_no_connections_without_mac() -> None:
+    entry = _FakeEntry(data={CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK})
+    info = build_device_info(entry)  # type: ignore[arg-type]
+    assert "connections" not in info


### PR DESCRIPTION
## Summary

Follow-up to #135 — these commits were pushed to the feature branch after the squash merge, so they need their own PR. Three pieces:

- **MAC-tracked discovery identity**: discovery-created entries store the printer's MAC (shown as a device-registry network connection); a DHCP lease change updates the existing entry's host/unique_id/auto-title in place instead of offering a duplicate discovery card. Already-configured entries adopt the MAC the first time discovery sees them at their current IP, so pre-existing setups gain lease tracking too. Manual renames are never clobbered; unique-id collisions skip the auto-update; reconfiguring to a different address clears the stored MAC.
- **Field-test fixes (real Rongta hardware)**: a clone that answers `GS I` as "EPSON TM-T88III" (protocol emulation) is now identified by its truthful brand hostname — device page says Rongta, and calibration share links aren't mislabeled. Implausible font column counts from a buggy upstream profile entry (NT-80-V-UL declares 9/12 columns on an 80 mm printer — font dot widths mis-encoded as columns; upstream report filed) are filtered out of the characters-per-line choices.
- **Rongta RP820 alias**: RP850P hardware announces DHCP hostname `Rongta_RP820`; the alias maps that identity to the 80 mm clone profile so discovered Rongta printers preselect a real profile instead of Auto.

Spec: `docs/superpowers/specs/2026-08-10-network-printer-identification-design.md` ("Follow-up: MAC-tracked discovery identity" section, updated in this PR).

## Testing

- 1296 passed (34 new since #135), `ruff check` / `ruff format --check` / `mypy` clean.
- New coverage: MAC relocation (title follow/preserve, entry-port unique IDs, reload fired, collision safety, adoption into existing entries), clone-identity override (brand mismatch, brand match kept, tm-* unaffected), column-width filtering (bogus, healthy, mixed profiles), alias-driven profile preselect.

## Review trail

MAC feature: Opus review + verified fix round. Clone fixes: root-caused against live hardware (GS I reply captured from the printer), TDD RED/GREEN, reviewed with edge-case verification (MAC-logic ordering, 16-column floor scanned against every bundled profile — NT-80-V-UL is the only one affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hjUZ6aEMCJwQjyuFuTW3h
