### PR TITLE
Discovery boot-race retry and model-based network entry titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - "Rongta RP820" is recognized as a compatible model (the network identity
   RP850P hardware announces), so discovered Rongta printers preselect the
   matching 80mm profile.
+- Network printer entries are now titled by their detected model (e.g.
+  "TM-T20II (192.168.1.50:9100)") instead of the bare address. Manual
+  renames are still never overwritten when a lease change or reconfigure
+  updates the address.
+- Discovery now retries the port-9100 probe for up to a minute, so a
+  printer whose network stack is still booting when its DHCP lease lands
+  no longer misses its discovery card until the next lease renewal.
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,7 +46,32 @@ Needs a new `_last_print` field set only in the print paths: the existing
 `_last_ok` is also updated by status probes, so it means "last successful
 operation", not "last print".
 
-### 6. Smaller items
+### 6. Print confirmation for network printers
+
+Today a TCP send to port 9100 proves bytes left the NIC, not that paper moved —
+a link that drops mid-stream (e.g. a flaky WiFi bridge) looks like success.
+Neither variant exists in python-escpos (it only implements the DLE EOT
+real-time queries, which answer from the receive buffer and don't confirm
+printing), so both need raw command + response parsing in the adapter:
+
+- **Epson (`GS ( H` process ID response)**: queue a 4-byte ID after the job;
+  the printer echoes it back only once everything before it has been
+  processed. Supported by TM-series printers (incl. TM-T20II). Reuses the
+  send-then-read round trip the paper sensor already does.
+- **Star (ETB counter in the ASB status block)**: append an ETB byte (0x17)
+  after the job, read the ASB ETB counter before and poll after; it only
+  advances when the printer physically feeds past the marker. Counter
+  position/step varies by model (mC-Print3: byte 7, +2 per ETB), so keep the
+  parsing per-profile. Only relevant if Star ASB support lands.
+
+**Retry policy (applies to any confirmation work)**: delivered-but-unconfirmed
+is not failed. If the job was sent but the confirmation read dies, report
+"unconfirmed" and do **not** retry — the print likely succeeded and a blind
+retry double-prints. Retry only on positive evidence the job did not go
+through, and keep everything after the committed send exception-safe so it
+cannot re-fire.
+
+### 7. Smaller items
 
 - **`hw("INIT")` reset service**: cheap recovery path for a wedged printer.
 - **Native QR rendering** (`qr(native=True)`): faster and sharper than the

--- a/custom_components/escpos_printer/_config_flow/discovery_steps.py
+++ b/custom_components/escpos_printer/_config_flow/discovery_steps.py
@@ -8,6 +8,7 @@ network form is the confirmation UI — discovery just prefills it.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -18,9 +19,21 @@ from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 
 from ..const import CONF_MAC_ADDRESS, DEFAULT_PORT, DEFAULT_TIMEOUT, DOMAIN
-from .network_helpers import _can_connect, query_printer_id
+from .network_helpers import (
+    _can_connect,
+    is_auto_network_title,
+    make_network_entry_title,
+    query_printer_id,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+# A printer's DHCP lease often lands tens of seconds before port 9100 starts
+# listening (the network stack boots first), so a single probe at discovery
+# time misses freshly powered-on printers -- and HA won't re-fire discovery
+# until the next DHCP packet, typically a lease renewal hours later. Probe
+# again after these sleeps before giving up on the card.
+_PROBE_RETRY_DELAYS: tuple[float, ...] = (0, 5, 10, 15, 30)
 
 # Brand hostname prefixes (lowercase, matching the manifest's DHCP hostname
 # matchers) that GS I identity may not be trusted against -- see
@@ -93,11 +106,12 @@ class DiscoveryFlowMixin:
             # Only follow the address to a new auto-generated title -- a
             # user's manual rename must never be clobbered (same heuristic
             # as network_steps.async_step_reconfigure_network).
+            new_data = {**entry.data, CONF_HOST: host}
             title: str | UndefinedType = UNDEFINED
-            if entry.title == f"{entry.data.get(CONF_HOST)}:{entry_port}":
-                title = f"{host}:{entry_port}"
+            if is_auto_network_title(entry.title, entry.data):
+                title = make_network_entry_title(new_data)
             self.hass.config_entries.async_update_entry(
-                entry, data={**entry.data, CONF_HOST: host}, unique_id=new_unique_id, title=title
+                entry, data=new_data, unique_id=new_unique_id, title=title
             )
             self.hass.config_entries.async_schedule_reload(entry.entry_id)
             return self.async_abort(reason="already_configured")  # type: ignore[attr-defined,no-any-return]
@@ -112,14 +126,20 @@ class DiscoveryFlowMixin:
         else:
             self._abort_if_unique_id_configured()  # type: ignore[attr-defined]
 
-        if not await self.hass.async_add_executor_job(
-            _can_connect, host, DEFAULT_PORT, DEFAULT_TIMEOUT
-        ):
+        for delay in _PROBE_RETRY_DELAYS:
+            if delay:
+                await asyncio.sleep(delay)
+            if await self.hass.async_add_executor_job(
+                _can_connect, host, DEFAULT_PORT, DEFAULT_TIMEOUT
+            ):
+                break
+        else:
             _LOGGER.debug(
-                "DHCP match %s (%s) not listening on %s; ignoring",
+                "DHCP match %s (%s) not listening on %s after %d probes; ignoring",
                 discovery_info.hostname,
                 host,
                 DEFAULT_PORT,
+                len(_PROBE_RETRY_DELAYS),
             )
             return self.async_abort(reason="cannot_connect")  # type: ignore[attr-defined,no-any-return]
 

--- a/custom_components/escpos_printer/_config_flow/network_helpers.py
+++ b/custom_components/escpos_printer/_config_flow/network_helpers.py
@@ -2,11 +2,37 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
 import socket
 from typing import Any
 
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+from ..const import CONF_DETECTED_MODEL, DEFAULT_PORT
+
 _LOGGER = logging.getLogger(__name__)
+
+
+def make_network_entry_title(data: Mapping[str, Any]) -> str:
+    """Auto-generated title for a network entry: model-based when detected."""
+    host = data.get(CONF_HOST, "")
+    port = data.get(CONF_PORT, DEFAULT_PORT)
+    model = data.get(CONF_DETECTED_MODEL)
+    return f"{model} ({host}:{port})" if model else f"{host}:{port}"
+
+
+def is_auto_network_title(title: str, data: Mapping[str, Any]) -> bool:
+    """True when ``title`` is one this integration generated from ``data``.
+
+    The auto title is a pure function of stored entry data, so "has the
+    user renamed this entry?" is answered by recomputing it -- no stored
+    original-title field to keep in sync. The bare "host:port" form is
+    always included: entries created before model-based titles carry it
+    even when a detected model is stored alongside.
+    """
+    legacy = f"{data.get(CONF_HOST, '')}:{data.get(CONF_PORT, DEFAULT_PORT)}"
+    return title in {legacy, make_network_entry_title(data)}
 
 
 def validate_custom_line_width(value: Any) -> tuple[int | None, str | None]:

--- a/custom_components/escpos_printer/_config_flow/network_steps.py
+++ b/custom_components/escpos_printer/_config_flow/network_steps.py
@@ -27,7 +27,12 @@ from ..const import (
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
 )
-from .network_helpers import _can_connect, query_printer_id
+from .network_helpers import (
+    _can_connect,
+    is_auto_network_title,
+    make_network_entry_title,
+    query_printer_id,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -218,14 +223,6 @@ class NetworkFlowMixin:
                     or {}
                 )
 
-                # Only follow the address to a new auto-generated title
-                # when the entry still carries the original auto-generated
-                # one -- a user's manual rename must never be clobbered.
-                title: str | UndefinedType = UNDEFINED
-                old_host = reconfigure_entry.data.get(CONF_HOST, "")
-                old_port = reconfigure_entry.data.get(CONF_PORT, DEFAULT_PORT)
-                if reconfigure_entry.title == f"{old_host}:{old_port}":
-                    title = f"{host}:{port}"
                 # A fresh GS I query result REPLACES prior detected state
                 # (present -> overwrite, absent -> key removed) since
                 # reconfigure may point the entry at a different printer.
@@ -259,6 +256,14 @@ class NetworkFlowMixin:
                 # MAC no longer describes), never on a transient query miss.
                 if addr_changed:
                     new_data.pop(CONF_MAC_ADDRESS, None)
+
+                # Only regenerate the title when the entry still carries an
+                # auto-generated one -- a user's manual rename must never be
+                # clobbered. Built from new_data so a fresh detection (or a
+                # cleared one) is reflected in the new title.
+                title: str | UndefinedType = UNDEFINED
+                if is_auto_network_title(reconfigure_entry.title, reconfigure_entry.data):
+                    title = make_network_entry_title(new_data)
 
                 return self.async_update_reload_and_abort(  # type: ignore[attr-defined,no-any-return]
                     reconfigure_entry,

--- a/custom_components/escpos_printer/_config_flow/settings_steps.py
+++ b/custom_components/escpos_printer/_config_flow/settings_steps.py
@@ -23,10 +23,8 @@ from ..const import (
     CONF_CONNECTION_TYPE,
     CONF_DEFAULT_ALIGN,
     CONF_DEFAULT_CUT,
-    CONF_HOST,
     CONF_IMPL,
     CONF_LINE_WIDTH,
-    CONF_PORT,
     CONF_PRODUCT_ID,
     CONF_PROFILE,
     CONF_SERIAL_PORT,
@@ -42,6 +40,7 @@ from ..const import (
     IMPL_AUTO,
     IMPL_CHOICE_LABELS,
 )
+from .network_helpers import make_network_entry_title
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,7 +69,7 @@ def _make_entry_title(data: dict[str, Any], user_data: dict[str, Any]) -> str:
                 f"Serial Printer {data.get(CONF_SERIAL_PORT, '')}",
             )
         )
-    return f"{data[CONF_HOST]}:{data[CONF_PORT]}"
+    return make_network_entry_title(data)
 
 
 def _create_entry_description(data: dict[str, Any]) -> str | None:

--- a/tests/test_config_flow_dhcp.py
+++ b/tests/test_config_flow_dhcp.py
@@ -35,6 +35,12 @@ async def _start_dhcp_flow(hass, can_connect=True, query_result=None, discovery=
             "custom_components.escpos_printer._config_flow.discovery_steps._can_connect",
             return_value=can_connect,
         ),
+        # Collapse the boot-race retry schedule so a closed port aborts
+        # immediately instead of sleeping through the real delays.
+        patch(
+            "custom_components.escpos_printer._config_flow.discovery_steps._PROBE_RETRY_DELAYS",
+            (0,),
+        ),
         patch(
             "custom_components.escpos_printer._config_flow.discovery_steps.query_printer_id",
             return_value=query_result,
@@ -101,6 +107,32 @@ async def test_dhcp_discovery_aborts_when_port_closed(hass):
     result = await _start_dhcp_flow(hass, can_connect=False)
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
+
+
+async def test_dhcp_discovery_retries_probe_for_booting_printer(hass):
+    """The DHCP lease lands before port 9100 is up on a booting printer --
+    the probe must retry instead of aborting on the first refusal."""
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.discovery_steps._can_connect",
+            side_effect=[False, False, True],
+        ) as mock_connect,
+        patch(
+            "custom_components.escpos_printer._config_flow.discovery_steps._PROBE_RETRY_DELAYS",
+            (0, 0, 0),
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.discovery_steps.query_printer_id",
+            return_value={"manufacturer": "EPSON", "model": "TM-T20II"},
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_DHCP}, data=DISCOVERY
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "network"
+    assert mock_connect.call_count == 3
 
 
 async def test_dhcp_discovery_edited_host_requeries_instead_of_reusing_detection(hass):
@@ -205,6 +237,8 @@ async def test_dhcp_discovery_end_to_end_creates_entry_with_detection(hass):
     assert result["data"]["detected_manufacturer"] == "EPSON"
     assert result["data"]["detected_model"] == "TM-T20II"
     assert result["data"]["profile"] == "TM-T20II"
+    # Entry title is model-based when a model was detected.
+    assert result["title"] == "TM-T20II (192.168.10.157:9100)"
 
 
 async def test_dhcp_discovery_persists_mac_address(hass):
@@ -294,6 +328,43 @@ async def test_dhcp_discovery_known_mac_new_ip_updates_existing_entry(hass):
     assert updated.data["host"] == "192.168.10.200"
     assert updated.unique_id == "192.168.10.200:9100"
     assert updated.title == "192.168.10.200:9100"  # auto-generated title follows
+
+
+async def test_dhcp_discovery_known_mac_new_ip_model_title_follows(hass):
+    """A model-based auto title ("TM-T20II (host:port)") counts as
+    auto-generated too and follows the relocation."""
+    mac = format_mac(DISCOVERY.macaddress)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="TM-T20II (192.168.10.157:9100)",
+        unique_id="192.168.10.157:9100",
+        data={
+            "connection_type": "network",
+            "host": "192.168.10.157",
+            "port": 9100,
+            "detected_manufacturer": "EPSON",
+            "detected_model": "TM-T20II",
+            CONF_MAC_ADDRESS: mac,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with patch("custom_components.escpos_printer.async_setup_entry", return_value=True):
+        result = await _start_dhcp_flow(
+            hass,
+            discovery=DhcpServiceInfo(
+                ip="192.168.10.200",
+                hostname="TM-T20II-628E52",
+                macaddress=DISCOVERY.macaddress,
+            ),
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    updated = hass.config_entries.async_get_entry(entry.entry_id)
+    assert updated is not None
+    assert updated.data["host"] == "192.168.10.200"
+    assert updated.title == "TM-T20II (192.168.10.200:9100)"
 
 
 async def test_dhcp_discovery_known_mac_new_ip_preserves_manual_rename(hass):

--- a/tests/test_config_flow_reconfigure.py
+++ b/tests/test_config_flow_reconfigure.py
@@ -231,6 +231,8 @@ async def test_reconfigure_network_detected_fields_replace_on_requery(hass):  # 
     assert updated is not None
     assert updated.data[CONF_DETECTED_MANUFACTURER] == "EPSON"
     assert updated.data[CONF_DETECTED_MODEL] == "TM-T20II"
+    # The auto-generated title picks up the fresh detection.
+    assert updated.title == "TM-T20II (5.6.7.8:9100)"
 
     # Reconfigure again onto a printer that doesn't answer GS I -- the
     # previous printer's detected fields must be removed, not kept stale.
@@ -259,6 +261,9 @@ async def test_reconfigure_network_detected_fields_replace_on_requery(hass):  # 
     assert updated2 is not None
     assert CONF_DETECTED_MANUFACTURER not in updated2.data
     assert CONF_DETECTED_MODEL not in updated2.data
+    # The model-based title is still recognised as auto-generated, so it
+    # follows the address and drops the no-longer-detected model.
+    assert updated2.title == "9.9.9.9:9100"
 
 
 async def test_reconfigure_network_detected_fields_survive_transient_requery_failure(

--- a/uv.lock
+++ b/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "diff-cover"
-version = "10.4.2"
+version = "10.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chardet" },
@@ -962,9 +962,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/3d/939ac74b1880b65b58ebdb696803c51ab0c18ff2c738ca106f9c26176860/diff_cover-10.4.2.tar.gz", hash = "sha256:cf96e907775f510c44972d9bc1f26ff12c66423c506b17f7008b0867594d0603", size = 109601, upload-time = "2026-08-07T02:40:45.984Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/c7/b2883d341261dfa1cdc4386929e967ff4af9c201405f6f72275abefd5f2a/diff_cover-10.5.0.tar.gz", hash = "sha256:a1734543baaaa7d0860a6526016d487be24a0ffe9efb4eca0824c391d4a09d06", size = 110762, upload-time = "2026-08-08T17:25:19.494Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/6c/ec42b7b3392d7c7c55b7ecb5d12c642ae209cd699460499b0951c84fc4d0/diff_cover-10.4.2-py3-none-any.whl", hash = "sha256:dde8ffa4379e2e0e09f33a4bebd525fcbaca1d2fbd9669cff56c7dbc999f2284", size = 60686, upload-time = "2026-08-07T02:40:44.668Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c8/5345dfb7c955639454fffc767c3eaf9863d79a1cdb0081392a71102fedfa/diff_cover-10.5.0-py3-none-any.whl", hash = "sha256:5619f924e838b8f8c4c7b243b32a6068d8c449c1766c6f6a1110b152195ed9b9", size = 61184, upload-time = "2026-08-08T17:25:18.337Z" },
 ]
 
 [[package]]
@@ -1209,7 +1209,7 @@ requires-dist = [
     { name = "bandit-sarif-formatter", marker = "extra == 'dev'", specifier = "==1.1.1" },
     { name = "bandit-sarif-formatter", marker = "extra == 'security'", specifier = "==1.1.1" },
     { name = "dbus-fast", specifier = "==5.0.22" },
-    { name = "diff-cover", marker = "extra == 'dev'", specifier = "==10.4.2" },
+    { name = "diff-cover", marker = "extra == 'dev'", specifier = "==10.5.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "pillow", specifier = "==12.3.0" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = "==2.10.1" },


### PR DESCRIPTION
Two follow-ups from the MAC-tracked discovery work (#136):

## Discovery retry for the printer-boot race

A printer's DHCP lease often lands tens of seconds before port 9100 starts listening, and HA won't re-fire discovery until the next DHCP packet (typically a lease renewal hours later) — so a freshly powered-on printer could miss its discovery card entirely. The probe now retries on a 0/5/10/15/30s schedule before giving up. While waiting, the flow is already registered, so duplicate discoveries abort as `already_in_progress`.

## Model-based entry titles

Network entries created with a successful GS I identification are now titled `TM-T20II (192.168.1.50:9100)` instead of the bare `host:port`.

The "is this title auto-generated or a user rename?" check is recomputed from data the entry already stores (`detected_model` + host + port) rather than persisting an original-title field — `is_auto_network_title()` recognises both the model-based and the legacy `host:port` forms, so:

- lease-follow and reconfigure still update auto titles and never clobber manual renames,
- pre-existing `host:port`-titled entries are grandfathered in and upgrade to a model title on their next reconfigure that detects one,
- a reconfigure that clears detection drops the title back to `host:port`.

Also includes a roadmap note (separate commit) for print confirmation on network printers.

## Testing

- New tests: probe retry succeeds on third attempt, discovery-created entry gets model title, model-titled entry follows a lease relocation, reconfigure title follows fresh/cleared detection.
- Full suite: 1298 passed; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hjUZ6aEMCJwQjyuFuTW3h