### PR TITLE
Recognize Bluetooth printers by cached SPP SDP record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- The Bluetooth device picker now also recognizes printers by their cached
+  Serial Port Profile (SPP) record, not just the imaging device class —
+  cheap printers that don't advertise the imaging class show up in the
+  filtered dropdown instead of hiding behind "Show all".
 - Adding a printer without a real profile ("Generic (no profile)" or the
   generic `default` profile) now shows a tip on the success screen
   pointing at the calibration wizard (Configure → Calibrate printer).

--- a/custom_components/escpos_printer/_config_flow/bluetooth_helpers.py
+++ b/custom_components/escpos_printer/_config_flow/bluetooth_helpers.py
@@ -146,25 +146,35 @@ async def _list_paired_bluetooth_devices() -> list[dict[str, Any]]:
     return await list_paired_bluetooth_devices()
 
 
+def _is_printer_candidate(device: dict[str, Any]) -> bool:
+    """Likely a printer: imaging Class-of-Device OR a cached SPP SDP record.
+
+    Cheap ESC/POS printers frequently skip the imaging class but still
+    advertise Serial Port Profile — either signal keeps the device in the
+    filtered dropdown.
+    """
+    return bool(device.get("is_imaging") or device.get("has_spp"))
+
+
 def _build_bt_device_choices(
-    devices: list[dict[str, Any]], *, imaging_only: bool = True
+    devices: list[dict[str, Any]], *, printers_only: bool = True
 ) -> dict[str, str]:
     """Build the dropdown for the bluetooth_select step.
 
-    Filters to imaging-class devices by default so users see only their
-    printer rather than every paired phone/headset on the host. Some cheap
-    printers don't advertise the class — when no imaging devices are found
-    the caller falls back to ``imaging_only=False`` to show everything.
+    Filters to printer-like devices (see :func:`_is_printer_candidate`) by
+    default so users see only their printer rather than every paired
+    phone/headset on the host. When no candidates are found the caller
+    falls back to ``printers_only=False`` to show everything.
 
     Always offers a manual-entry fallback so users without bluez D-Bus
     access can still configure paired devices.
     """
-    candidates = [d for d in devices if d.get("is_imaging")] if imaging_only else list(devices)
+    candidates = [d for d in devices if _is_printer_candidate(d)] if printers_only else list(devices)
     choices: dict[str, str] = {d["_choice_key"]: d["label"] for d in candidates}
-    # Surface "Show all" only when filtering imaging-only AND there's something
-    # the user can't currently see (avoids redundant choice when no filter is in
-    # effect or when nothing is hidden).
-    if imaging_only and len(candidates) < len(devices):
+    # Surface "Show all" only when the printer filter is on AND there's
+    # something the user can't currently see (avoids redundant choice when no
+    # filter is in effect or when nothing is hidden).
+    if printers_only and len(candidates) < len(devices):
         choices[BT_SHOW_ALL_KEY] = "Show all paired Bluetooth devices..."
     choices[BT_MANUAL_ENTRY_KEY] = "Manual MAC entry..."
     return choices

--- a/custom_components/escpos_printer/_config_flow/bluetooth_steps.py
+++ b/custom_components/escpos_printer/_config_flow/bluetooth_steps.py
@@ -35,6 +35,7 @@ from .bluetooth_helpers import (
     _build_bt_device_choices,
     _can_connect_bluetooth,
     _generate_bt_unique_id,
+    _is_printer_candidate,
     _list_paired_bluetooth_devices,
     _normalize_bt_mac,
 )
@@ -157,15 +158,17 @@ class BluetoothFlowMixin:
         if not self._paired_bt_devices:
             return await self.async_step_bluetooth_no_devices()
 
-        # Filter to imaging-class devices unless the user explicitly opted to
-        # see everything. If the imaging filter would yield zero entries we
-        # transparently disable it — handles printers that don't advertise the
-        # class correctly (most cheap ESC/POS hardware doesn't).
-        imaging_only = not self._show_all_bt_devices
-        if imaging_only and not any(d.get("is_imaging") for d in self._paired_bt_devices):
-            imaging_only = False
+        # Filter to printer-like devices (imaging class or SPP SDP record)
+        # unless the user explicitly opted to see everything. If the filter
+        # would yield zero entries we transparently disable it — handles
+        # printers that advertise neither signal.
+        printers_only = not self._show_all_bt_devices
+        if printers_only and not any(
+            _is_printer_candidate(d) for d in self._paired_bt_devices
+        ):
+            printers_only = False
         device_choices = _build_bt_device_choices(
-            self._paired_bt_devices, imaging_only=imaging_only
+            self._paired_bt_devices, printers_only=printers_only
         )
         profile_choices = await self.hass.async_add_executor_job(get_profile_choices_dict)
         default_device = next(iter(device_choices.keys()))

--- a/custom_components/escpos_printer/bluez.py
+++ b/custom_components/escpos_printer/bluez.py
@@ -33,12 +33,25 @@ _LOGGER = logging.getLogger(__name__)
 # and most ESC/POS receipt printers.
 _BT_MAJOR_CLASS_IMAGING = 0x06
 
+# Serial Port Profile — the RFCOMM service ESC/POS printers actually speak.
+# Cheap printers often skip setting the imaging Class-of-Device but still
+# advertise SPP in their SDP record, which bluez caches at pairing time —
+# reading it here is radio-silent.
+_SPP_UUID = "00001101-0000-1000-8000-00805f9b34fb"
+
 
 def is_imaging_device(class_value: int | None) -> bool:
     """Return True if the bluez Class-of-Device value is the Imaging major class."""
     if class_value is None:
         return False
     return ((class_value >> 8) & 0x1F) == _BT_MAJOR_CLASS_IMAGING
+
+
+def has_spp_uuid(uuids: list[str] | None) -> bool:
+    """Return True if the cached SDP UUID list advertises Serial Port Profile."""
+    if not uuids:
+        return False
+    return any(str(u).lower() == _SPP_UUID for u in uuids)
 
 
 def _normalize_mac(mac: Any) -> str | None:
@@ -91,8 +104,8 @@ async def list_paired_bluetooth_devices() -> list[dict[str, Any]]:
     """Enumerate Bluetooth devices paired on the host.
 
     Returns a list of ``{mac, name, alias, label, class, is_imaging,
-    _choice_key}`` dicts. Returns an empty list when bluez isn't reachable
-    so callers can degrade to manual MAC entry.
+    has_spp, _choice_key}`` dicts. Returns an empty list when bluez isn't
+    reachable so callers can degrade to manual MAC entry.
     """
     bus = await _connect_system_bus()
     if bus is None:
@@ -126,6 +139,11 @@ async def list_paired_bluetooth_devices() -> list[dict[str, Any]]:
         class_value: int | None = (
             int(getattr(class_var, "value", 0)) if class_var is not None else None
         )
+        uuids_var = device_props.get("UUIDs")
+        uuids_value = getattr(uuids_var, "value", None) if uuids_var is not None else None
+        uuids = (
+            [str(u) for u in uuids_value] if isinstance(uuids_value, (list, tuple)) else []
+        )
         devices.append(
             {
                 "mac": mac,
@@ -134,6 +152,7 @@ async def list_paired_bluetooth_devices() -> list[dict[str, Any]]:
                 "label": label,
                 "class": class_value,
                 "is_imaging": is_imaging_device(class_value),
+                "has_spp": has_spp_uuid(uuids),
                 "_choice_key": mac,
             }
         )

--- a/tests/test_config_flow_bluetooth.py
+++ b/tests/test_config_flow_bluetooth.py
@@ -13,6 +13,7 @@ from custom_components.escpos_printer._config_flow.bluetooth_helpers import (
 from custom_components.escpos_printer._config_flow.bluetooth_steps import (
     SECTION_BT_ADVANCED,
 )
+from custom_components.escpos_printer.bluez import has_spp_uuid
 from custom_components.escpos_printer.capabilities import PROFILE_AUTO
 from custom_components.escpos_printer.config_flow import EscposConfigFlow
 from custom_components.escpos_printer.const import (
@@ -438,6 +439,65 @@ class TestBluetoothImagingFilter:
         ]
         choices = bt_device.container
         assert "AA:BB:CC:DD:EE:FF" in choices  # surfaced despite non-imaging
+
+    @pytest.mark.asyncio
+    async def test_spp_only_device_survives_filter(self, hass):
+        """A printer with no imaging class but a cached SPP UUID stays in the
+        filtered dropdown; a device with neither signal is hidden."""
+        flow = EscposConfigFlow()
+        flow.hass = hass
+        flow._user_data = {CONF_CONNECTION_TYPE: CONNECTION_TYPE_BLUETOOTH}
+
+        devices = [
+            {
+                "mac": "AA:BB:CC:DD:EE:FF",
+                "name": "Cheap Printer",
+                "alias": "Cheap Printer",
+                "label": "Cheap Printer (AA:BB:CC:DD:EE:FF)",
+                "class": 0x000000,  # no imaging class advertised
+                "is_imaging": False,
+                "has_spp": True,
+                "_choice_key": "AA:BB:CC:DD:EE:FF",
+            },
+            {
+                "mac": "11:22:33:44:55:66",
+                "name": "Pixel 8",
+                "alias": "Pixel 8",
+                "label": "Pixel 8 (11:22:33:44:55:66)",
+                "class": 0x5A020C,
+                "is_imaging": False,
+                "has_spp": False,
+                "_choice_key": "11:22:33:44:55:66",
+            },
+        ]
+        with patch(
+            "custom_components.escpos_printer._config_flow.bluetooth_steps."
+            "_list_paired_bluetooth_devices",
+            return_value=devices,
+        ):
+            result = await flow.async_step_bluetooth_select()
+
+        bt_device = result["data_schema"].schema[
+            next(k for k in result["data_schema"].schema if k == "bt_device")
+        ]
+        choices = bt_device.container
+        assert "AA:BB:CC:DD:EE:FF" in choices  # SPP kept it in the filter
+        assert "11:22:33:44:55:66" not in choices  # phone still hidden
+        assert "__show_all__" in choices
+
+
+class TestSppUuidDetection:
+    """bluez.has_spp_uuid recognizes the Serial Port Profile SDP UUID."""
+
+    def test_spp_uuid_matches_case_insensitively(self):
+        assert has_spp_uuid(["00001101-0000-1000-8000-00805F9B34FB"])
+        assert has_spp_uuid(["0000110b-0000-1000-8000-00805f9b34fb",
+                             "00001101-0000-1000-8000-00805f9b34fb"])
+
+    def test_non_spp_or_empty_lists_rejected(self):
+        assert not has_spp_uuid(["0000110b-0000-1000-8000-00805f9b34fb"])  # A2DP sink
+        assert not has_spp_uuid([])
+        assert not has_spp_uuid(None)
 
 
 class TestBluetoothChannelHidden:

--- a/tests/test_config_flow_bluetooth.py
+++ b/tests/test_config_flow_bluetooth.py
@@ -1,10 +1,12 @@
 """Tests for Bluetooth Classic / RFCOMM config flow."""
 
 import errno
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.escpos_printer import bluez
 from custom_components.escpos_printer._config_flow.bluetooth_helpers import (
     _bt_error_to_key,
     _can_connect_bluetooth,
@@ -498,6 +500,46 @@ class TestSppUuidDetection:
         assert not has_spp_uuid(["0000110b-0000-1000-8000-00805f9b34fb"])  # A2DP sink
         assert not has_spp_uuid([])
         assert not has_spp_uuid(None)
+
+    @pytest.mark.asyncio
+    async def test_list_paired_devices_extracts_cached_uuids(self):
+        """list_paired_bluetooth_devices reads the cached SDP UUID list off the
+        Device1 props and sets has_spp; a device without UUIDs gets has_spp
+        False rather than blowing up."""
+        var = lambda v: SimpleNamespace(value=v)  # noqa: E731 — bluez Variant stand-in
+        managed = {
+            "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF": {
+                "org.bluez.Device1": {
+                    "Paired": var(True),
+                    "Address": var("AA:BB:CC:DD:EE:FF"),
+                    "Alias": var("Cheap Printer"),
+                    "Class": var(0x000000),
+                    "UUIDs": var(["00001101-0000-1000-8000-00805F9B34FB"]),
+                }
+            },
+            "/org/bluez/hci0/dev_11_22_33_44_55_66": {
+                "org.bluez.Device1": {
+                    "Paired": var(True),
+                    "Address": var("11:22:33:44:55:66"),
+                    "Alias": var("Pixel 8"),
+                    "Class": var(0x5A020C),
+                    # no UUIDs key — bluez omits it for some devices
+                }
+            },
+        }
+        with (
+            patch.object(
+                bluez, "_connect_system_bus", AsyncMock(return_value=MagicMock())
+            ),
+            patch.object(
+                bluez, "_get_managed_objects", AsyncMock(return_value=managed)
+            ),
+        ):
+            devices = await bluez.list_paired_bluetooth_devices()
+
+        by_mac = {d["mac"]: d for d in devices}
+        assert by_mac["AA:BB:CC:DD:EE:FF"]["has_spp"] is True
+        assert by_mac["11:22:33:44:55:66"]["has_spp"] is False
 
 
 class TestBluetoothChannelHidden:


### PR DESCRIPTION
## Summary

The Bluetooth device picker filtered paired devices on the imaging Class-of-Device alone, so cheap printers that don't set CoD fell through to the "Show all paired devices" fallback. bluez caches each device's SDP UUID list at pairing time, and a Serial Port Profile record (`00001101-0000-1000-8000-00805f9b34fb`) is a strong printer signal for this integration — RFCOMM/SPP is the transport it prints over. Reading the cached list is radio-silent: no scanning, no connections.

- `bluez.list_paired_bluetooth_devices()` now reads the cached `UUIDs` property from each `Device1` and sets a `has_spp` flag via the new `has_spp_uuid()` helper
- New `_is_printer_candidate()` predicate (imaging class OR SPP) drives the dropdown filter; `imaging_only` renamed to `printers_only` to match
- The zero-candidates fallback in `bluetooth_steps.py` uses the same predicate, so an SPP-only printer keeps the filter on instead of dumping every paired phone into the list

## Testing

- Flow-level test: an SPP-only printer survives the default filter while a phone stays hidden
- Unit tests for `has_spp_uuid`: case-insensitivity, non-SPP UUIDs, empty/None
- Full suite: 1301 passed; ruff and mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hjUZ6aEMCJwQjyuFuTW3h