### PR TITLE
Print each calibration page over a single printer connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Calibration test pages now print each page over a single printer
+  connection instead of one connection per label/pattern. With the
+  reconnect-per-operation model, printers that accept a new connection
+  before draining the previous one could print the fragments out of
+  order (seen on TM-T20II: TEST 1/3/2 labels shuffled, garbled pattern
+  rows, and the trailing feed landing mid-page).
+
 ### Added
 
 - The Bluetooth device picker now also recognizes printers by their cached

--- a/custom_components/escpos_printer/_config_flow/calibration_steps.py
+++ b/custom_components/escpos_printer/_config_flow/calibration_steps.py
@@ -162,7 +162,7 @@ class CalibrationFlowMixin:
             return None
         return self.config_entry.runtime_data.adapter
 
-    async def _print_step_header(self, adapter: Any, title: str, instruction: str) -> None:
+    async def _print_step_header(self, page: Any, title: str, instruction: str) -> None:
         """Print a compact on-paper title + one-line instruction.
 
         Both lines are kept under ~30 chars so they don't wrap even on
@@ -171,55 +171,56 @@ class CalibrationFlowMixin:
         error handling.
         """
         with contextlib.suppress(Exception):
-            await adapter.print_text(
-                self.hass, text=f"= {title} =\n{instruction}\n", cut="none", feed=0
-            )
+            await page.print_text(text=f"= {title} =\n{instruction}\n", feed=0)
 
-    async def _print_step_trailer(self, adapter: Any, feed: int = 5) -> None:
+    async def _print_step_trailer(self, page: Any, feed: int = 5) -> None:
         """Blank feed after a step's page so steps separate on the roll."""
         with contextlib.suppress(Exception):
-            await adapter.print_text(self.hass, text="", cut="none", feed=feed)
+            await page.feed(feed)
 
     async def _print_impl_candidates(self, adapter: Any) -> bool:
         """Print a labeled test page per image-implementation candidate.
+
+        The whole page runs on one connection (``batch_connection``):
+        with reconnect-per-operation, each label/pattern went out on its
+        own short-lived TCP connection, and printers that accept the
+        next connection before draining the previous one printed the
+        fragments out of order (seen on TM-T20II: TEST 1/3/2).
 
         Each candidate is attempted independently so one rejecting a
         transport-level command (e.g. "graphics") can't brick the rest
         of the wizard. Returns True if at least one candidate printed.
         """
-        await self._print_step_header(
-            adapter, "CALIBRATE 1/4: IMAGE MODE", "Check clean patterns in app"
-        )
         any_ok = False
-        for n, candidate in enumerate(IMPL_CANDIDATES, start=1):
-            try:
-                # Trailing \n is load-bearing: with feed=0, ESC/POS only
-                # flushes the text line buffer on a newline or feed. Without
-                # it, raster printers drop the buffered label and column
-                # printers merge it into the pattern line (seen on RP850P).
-                await adapter.print_text(self.hass, text=f"TEST {n}\n", cut="none", feed=0)
-                await adapter.print_image(
-                    self.hass,
-                    image=checkerboard_data_uri(),
-                    impl=candidate,
-                    cut="none",
-                    feed=1,
-                    dither="threshold",
-                    auto_resize=False,
-                )
-                any_ok = True
-            except Exception as err:
-                _LOGGER.warning(
-                    "Calibration impl candidate %s failed to print: %s",
-                    candidate,
-                    sanitize_log_message(str(err)),
-                )
-                with contextlib.suppress(Exception):
-                    await adapter.print_text(
-                        self.hass, text=f"TEST {n}: FAILED TO SEND\n", cut="none", feed=0
+        async with adapter.batch_connection(self.hass) as page:
+            await self._print_step_header(
+                page, "CALIBRATE 1/4: IMAGE MODE", "Check clean patterns in app"
+            )
+            for n, candidate in enumerate(IMPL_CANDIDATES, start=1):
+                try:
+                    # Trailing \n is load-bearing: with feed=0, ESC/POS only
+                    # flushes the text line buffer on a newline or feed. Without
+                    # it, raster printers drop the buffered label and column
+                    # printers merge it into the pattern line (seen on RP850P).
+                    await page.print_text(text=f"TEST {n}\n", feed=0)
+                    await page.print_image(
+                        image=checkerboard_data_uri(),
+                        impl=candidate,
+                        feed=1,
+                        dither="threshold",
+                        auto_resize=False,
                     )
-        if any_ok:
-            await self._print_step_trailer(adapter)
+                    any_ok = True
+                except Exception as err:
+                    _LOGGER.warning(
+                        "Calibration impl candidate %s failed to print: %s",
+                        candidate,
+                        sanitize_log_message(str(err)),
+                    )
+                    with contextlib.suppress(Exception):
+                        await page.print_text(text=f"TEST {n}: FAILED TO SEND\n", feed=0)
+            if any_ok:
+                await self._print_step_trailer(page)
         return any_ok
 
     async def async_step_calibrate_impl(
@@ -271,25 +272,24 @@ class CalibrationFlowMixin:
 
     async def _print_width_bars(self, adapter: Any) -> None:
         """Print one bar per candidate width, using the impl chosen so far."""
-        await self._print_step_header(
-            adapter, "CALIBRATE 2/4: WIDTH BARS", "First bar equal to bottom?"
-        )
         impl = self._calib.get("impl") or getattr(adapter, "default_impl", None) or DEFAULT_IMPL
-        for w in WIDTH_CANDIDATES:
-            # width=w beats a narrower profile/opts width in the image
-            # pipeline (process_image only ever downscales, never
-            # upscales), so each bar prints at its true pixel width
-            # instead of all four being clamped to the same width.
-            await adapter.print_image(
-                self.hass,
-                image=width_bar_data_uri(w),
-                impl=impl,
-                width=w,
-                cut="none",
-                feed=1,
-                auto_resize=False,
+        async with adapter.batch_connection(self.hass) as page:
+            await self._print_step_header(
+                page, "CALIBRATE 2/4: WIDTH BARS", "First bar equal to bottom?"
             )
-        await self._print_step_trailer(adapter, feed=4)
+            for w in WIDTH_CANDIDATES:
+                # width=w beats a narrower profile/opts width in the image
+                # pipeline (process_image only ever downscales, never
+                # upscales), so each bar prints at its true pixel width
+                # instead of all four being clamped to the same width.
+                await page.print_image(
+                    image=width_bar_data_uri(w),
+                    impl=impl,
+                    width=w,
+                    feed=1,
+                    auto_resize=False,
+                )
+            await self._print_step_trailer(page, feed=4)
 
     async def async_step_calibrate_width(
         self, user_input: dict[str, Any] | None = None
@@ -341,17 +341,14 @@ class CalibrationFlowMixin:
                     reason="printer_not_ready"
                 )
             try:
-                # On-paper instruction so the wrapped remainder lines are
-                # explicitly ignorable without consulting the screen.
-                await adapter.print_text(
-                    self.hass,
-                    text="= CALIBRATE 3/4: COLUMNS =\n1st line: last number + dots\n",
-                    cut="none",
-                    feed=0,
-                )
-                await adapter.print_text(
-                    self.hass, text=build_ruler(96), cut="none", feed=5, wrap=False
-                )
+                async with adapter.batch_connection(self.hass) as page:
+                    # On-paper instruction so the wrapped remainder lines are
+                    # explicitly ignorable without consulting the screen.
+                    await page.print_text(
+                        text="= CALIBRATE 3/4: COLUMNS =\n1st line: last number + dots\n",
+                        feed=0,
+                    )
+                    await page.print_text(text=build_ruler(96), feed=5, wrap=False)
             except Exception as err:
                 _LOGGER.warning("Calibration ruler step failed: %s", sanitize_log_message(str(err)))
                 errors["base"] = "calibration_print_failed"
@@ -409,32 +406,31 @@ class CalibrationFlowMixin:
         printer rejects can't brick the rest of the step. Returns the
         candidates that printed successfully, mapped to their line number.
         """
-        await self._print_step_header(
-            adapter, "CALIBRATE 4/4: ENCODING", "Check matching lines in app"
-        )
         printed: dict[str, int] = {}
-        for n, cp in enumerate(candidates, start=1):
-            try:
-                await adapter.print_text(
-                    self.hass,
-                    # The codepage name is plain ASCII, so it renders
-                    # correctly under every candidate encoding — the paper
-                    # then correlates directly with the checkbox labels
-                    # without hopping back to the screen.
-                    text=f"{n} {cp}: {codepage_sample_line(cp)}\n",
-                    encoding=cp,
-                    cut="none",
-                    feed=0,
-                )
-                printed[cp] = n
-            except Exception as err:
-                _LOGGER.debug(
-                    "Calibration codepage candidate %s failed to print: %s",
-                    cp,
-                    sanitize_log_message(str(err)),
-                )
-        if printed:
-            await self._print_step_trailer(adapter)
+        async with adapter.batch_connection(self.hass) as page:
+            await self._print_step_header(
+                page, "CALIBRATE 4/4: ENCODING", "Check matching lines in app"
+            )
+            for n, cp in enumerate(candidates, start=1):
+                try:
+                    await page.print_text(
+                        # The codepage name is plain ASCII, so it renders
+                        # correctly under every candidate encoding — the paper
+                        # then correlates directly with the checkbox labels
+                        # without hopping back to the screen.
+                        text=f"{n} {cp}: {codepage_sample_line(cp)}\n",
+                        encoding=cp,
+                        feed=0,
+                    )
+                    printed[cp] = n
+                except Exception as err:
+                    _LOGGER.debug(
+                        "Calibration codepage candidate %s failed to print: %s",
+                        cp,
+                        sanitize_log_message(str(err)),
+                    )
+            if printed:
+                await self._print_step_trailer(page)
         return printed
 
     async def async_step_calibrate_codepage(

--- a/custom_components/escpos_printer/printer/base_adapter.py
+++ b/custom_components/escpos_printer/printer/base_adapter.py
@@ -652,6 +652,33 @@ class EscposPrinterAdapterBase(
         self._last_error_errno = None
         self._notify_status_change(True)
 
+    @contextlib.asynccontextmanager
+    async def batch_connection(self, hass: HomeAssistant) -> AsyncIterator[_BatchPage]:
+        """Run several prints over one lock acquisition and one connection.
+
+        The reconnect-per-operation model sends each print on its own
+        short-lived connection. Printer interfaces that accept the next
+        connection before the previous one's buffer has drained can
+        reorder or interleave the fragments on paper (observed on a
+        TM-T20II ethernet interface during calibration: labels printed
+        out of order and one raster row garbled mid-stream). Any page
+        that must render in order belongs on a single connection.
+
+        Yields a :class:`_BatchPage` bound to the held connection. An
+        exception escaping the ``with`` body releases the connection
+        with ``failed=True`` (offline signal + keepalive invalidation),
+        matching the per-operation methods.
+        """
+        async with self._lock:
+            printer, owned = await self._acquire_printer_or_offline(hass)
+            failed = True
+            try:
+                yield _BatchPage(self, hass, printer)
+                failed = False
+            finally:
+                await self._release_printer(hass, printer, owned=owned, failed=failed)
+        await self._mark_success()
+
     async def print_text_with_image(
         self,
         hass: HomeAssistant,
@@ -719,3 +746,74 @@ class EscposPrinterAdapterBase(
             finally:
                 await self._release_printer(hass, printer, owned=owned, failed=failed)
         await self._mark_success()
+
+
+class _BatchPage:
+    """Print primitives bound to one held connection.
+
+    Created only by :meth:`EscposPrinterAdapterBase.batch_connection`;
+    valid only inside that ``with`` block. Never cuts — a batch page is
+    a fragment stream, the caller feeds/cuts via :meth:`feed` or a
+    follow-up operation.
+    """
+
+    def __init__(self, adapter: EscposPrinterAdapterBase, hass: HomeAssistant, printer: Any):
+        self._adapter = adapter
+        self._hass = hass
+        self._printer = printer
+
+    async def print_text(
+        self,
+        *,
+        text: str,
+        encoding: str | None = None,
+        wrap: bool = True,
+        feed: int | None = 0,
+    ) -> None:
+        """Print text on the held connection (mirrors ``adapter.print_text``)."""
+        await _print_text_under_lock(
+            self._adapter,
+            self._hass,
+            self._printer,
+            text=text,
+            align=None,
+            bold=None,
+            underline=None,
+            width=None,
+            height=None,
+            encoding=encoding,
+            wrap=wrap,
+        )
+        await self._adapter._apply_cut_and_feed(self._hass, self._printer, "none", feed)
+
+    async def print_image(
+        self,
+        *,
+        image: str,
+        impl: str | None = None,
+        width: int | None = None,
+        dither: str = "floyd-steinberg",
+        auto_resize: bool = False,
+        feed: int | None = 0,
+    ) -> None:
+        """Print an image on the held connection (mirrors ``adapter.print_image``).
+
+        Image prep runs while the lock is held — callers pass small
+        generated data URIs (calibration patterns), not slow camera or
+        URL sources.
+        """
+        prepared = await prepare_image_for_print(
+            self._adapter,
+            self._hass,
+            image,
+            impl=impl,
+            width=width,
+            dither=dither,
+            auto_resize=auto_resize,
+        )
+        await _print_prepared_under_lock(self._hass, self._printer, prepared)
+        await self._adapter._apply_cut_and_feed(self._hass, self._printer, "none", feed)
+
+    async def feed(self, lines: int) -> None:
+        """Feed blank lines on the held connection."""
+        await self._adapter._apply_cut_and_feed(self._hass, self._printer, "none", lines)

--- a/tests/test_adapter_lifecycle.py
+++ b/tests/test_adapter_lifecycle.py
@@ -469,3 +469,47 @@ async def test_network_status_check_skips_when_lock_held(hass):  # type: ignore[
 
     assert adapter._last_check is prior_check  # type: ignore[attr-defined]
     assert adapter.get_status() is prior_status
+
+
+async def test_batch_connection_uses_one_connection_for_the_whole_page(hass):  # type: ignore[no-untyped-def]
+    """batch_connection: all prints ride one connection, closed once at the end.
+
+    The reconnect-per-operation model sends each print on its own TCP
+    connection; printers that accept the next connection before the
+    previous buffer drains can reorder the fragments on paper (seen on
+    TM-T20II during calibration). One page = one connection is the fix.
+    """
+    entry = await _setup_entry(hass)
+    adapter = entry.runtime_data.adapter
+
+    fake_printer = MagicMock()
+    with patch.object(adapter, "_connect", return_value=fake_printer) as connect:
+        async with adapter.batch_connection(hass) as page:
+            await page.print_text(text="TEST 1\n")
+            await page.print_text(text="TEST 2\n")
+            await page.feed(5)
+
+    assert connect.call_count == 1
+    assert fake_printer.close.call_count == 1
+    assert [c.args[0] for c in fake_printer.text.call_args_list] == ["TEST 1\n", "TEST 2\n"]
+    fake_printer.ln.assert_called_once_with(5)
+    assert adapter.get_status() is True
+
+
+async def test_batch_connection_failure_closes_connection_and_marks_offline(hass):  # type: ignore[no-untyped-def]
+    """An exception escaping the batch releases the connection with failed=True."""
+    import pytest
+
+    entry = await _setup_entry(hass)
+    adapter = entry.runtime_data.adapter
+
+    fake_printer = MagicMock()
+    with (
+        patch.object(adapter, "_connect", return_value=fake_printer),
+        pytest.raises(RuntimeError),
+    ):
+        async with adapter.batch_connection(hass):
+            raise RuntimeError("boom")
+
+    assert fake_printer.close.call_count == 1
+    assert adapter.get_status() is False

--- a/tests/test_calibration_flow.py
+++ b/tests/test_calibration_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -82,8 +83,22 @@ def _make_entry(
     if loaded:
         entry.mock_state(hass, ConfigEntryState.LOADED)
     adapter = MagicMock()
-    adapter.print_image = AsyncMock()
-    adapter.print_text = AsyncMock()
+    # Calibration prints through a single-connection batch page
+    # (adapter.batch_connection). The page's mocks are aliased onto the
+    # adapter so assertions read naturally as adapter.print_text/_image.
+    page = MagicMock()
+    page.print_text = AsyncMock()
+    page.print_image = AsyncMock()
+    page.feed = AsyncMock()
+
+    @asynccontextmanager
+    async def _batch_connection(hass):  # type: ignore[no-untyped-def]
+        yield page
+
+    adapter.batch_connection = _batch_connection
+    adapter.print_text = page.print_text
+    adapter.print_image = page.print_image
+    adapter.page_feed = page.feed
     entry.runtime_data = SimpleNamespace(adapter=adapter)
     return entry, adapter
 
@@ -156,8 +171,9 @@ async def test_calibrate_confirm_start_advances_to_impl_step(hass):  # type: ign
 
     assert result["type"] == "form"
     assert result["step_id"] == "calibrate_impl"
-    # header + 3 labels + trailing feed
-    assert adapter.print_text.await_count == 5
+    # header + 3 labels (the trailing separator is a page feed, not text)
+    assert adapter.print_text.await_count == 4
+    assert adapter.page_feed.await_count == 1
 
 
 async def test_calibrate_prints_impl_candidates_and_shows_form(hass):  # type: ignore[no-untyped-def]
@@ -170,8 +186,8 @@ async def test_calibrate_prints_impl_candidates_and_shows_form(hass):  # type: i
     assert result["step_id"] == "calibrate_impl"
     assert result.get("errors") in (None, {})
 
-    # header + 3 labels + trailing feed
-    assert adapter.print_text.await_count == 5
+    # header + 3 labels (the trailing separator is a page feed, not text)
+    assert adapter.print_text.await_count == 4
     texts = [call.kwargs["text"] for call in adapter.print_text.await_args_list]
     # First print is the on-paper title + instruction header.
     assert texts[0].startswith("= CALIBRATE 1/4")
@@ -197,8 +213,8 @@ async def test_impl_reprint_reprints_and_reshows_same_step(hass):  # type: ignor
 
     assert result2["type"] == "form"
     assert result2["step_id"] == "calibrate_impl"
-    # Two full passes: (header + 3 labels + trailer) x 2
-    assert adapter.print_text.await_count == 10
+    # Two full passes: (header + 3 labels) x 2; trailers are page feeds
+    assert adapter.print_text.await_count == 8
     assert adapter.print_image.await_count == 6
 
 
@@ -553,8 +569,8 @@ async def test_codepage_reprint_reprints(hass, monkeypatch):  # type: ignore[no-
 
     assert result2["type"] == "form"
     assert result2["step_id"] == "calibrate_codepage"
-    # header + one line per candidate + trailing feed
-    assert adapter.print_text.await_count == before + len(CODEPAGE_CANDIDATES) + 2
+    # header + one line per candidate (the trailing separator is a page feed)
+    assert adapter.print_text.await_count == before + len(CODEPAGE_CANDIDATES) + 1
 
 
 async def test_codepage_continue_stores_first_in_candidate_order(hass, monkeypatch):  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Problem

Calibration test pages printed out of order on an Epson TM-T20II (network): TEST labels shuffled (1/3/2), a garbled raster row, the trailing feed landing mid-page, and on the width-bar step a partial page (3 of 5 bars) plus a "Printing the test page failed" error.

## Root cause

With keepalive off (the default), every print operation opens its own TCP connection, sends, and closes. The wizard fired 6–8 tiny operations per page back-to-back, and the printer's interface accepts the next connection before it has drained the previous one — so fragments print out of order, interleave mid-raster, or a connection in the burst gets refused and aborts the rest of the step. The earlier trailing-`\n` flush fix addressed a different (RP850P) symptom in the same area; this is the remaining transport-level cause.

## Fix

- New `batch_connection` async context manager on the base adapter: holds the operation lock and **one** connection across multiple prints, releasing with the same failure semantics (offline signal + keepalive invalidation) as the per-operation methods. Same atomicity pattern `print_text_with_image` already uses.
- All four calibration pages (image mode, width bars, ruler, encoding) now print through it — one connection per page, so the printer physically cannot reorder within a page. Per-candidate error isolation within a page is preserved.

Normal service calls are unchanged: reconnect-per-operation stays the default model (self-healing across printer power cycles/idle timeouts, doesn't monopolize shared printers); keepalive remains the opt-in for chained multi-call bursts.

## Testing

- Calibration flow tests updated for the batched call shape (40 pass).
- Two new adapter tests pin the invariant: one connect + one close per batch page, and failure inside a batch closes the connection and marks the adapter offline.
- Full unit suite: 1304 passed; ruff and mypy clean.
- Hardware verification on the TM-T20II pending (out-of-order symptom reproduced on the pre-fix code; post-fix reprint expected in order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)