### PR TITLE
Let users type a custom line width directly in setup and options

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -99,8 +99,13 @@ jobs:
 
       - name: Per-patch coverage gate (CI-H1)
         if: github.event_name == 'pull_request'
+        # No --depth on the fetch: a shallow (depth=1) fetch grafts the
+        # base branch's tip with its parents cut off, so as soon as the
+        # base advances past this PR's fork point, `origin/<base>...HEAD`
+        # has no merge base and diff-cover dies. The clone above is full
+        # (fetch-depth: 0), so a plain fetch keeps real history.
         run: |
-          git fetch origin ${{ github.base_ref }} --depth=1
+          git fetch origin ${{ github.base_ref }}
           diff-cover coverage.xml \
             --compare-branch=origin/${{ github.base_ref }} \
             --fail-under=90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   before draining the previous one could print the fragments out of
   order (seen on TM-T20II: TEST 1/3/2 labels shuffled, garbled pattern
   rows, and the trailing feed landing mid-page).
+- The "Characters per line" field in setup and options is now a combobox:
+  pick a preset or type a custom number directly. Previously a
+  "Custom (enter columns)..." choice promised an entry box that only
+  appeared on a follow-up screen after submitting, which read as "no box
+  to enter a value". The legacy two-step path still works.
 
 ### Added
 

--- a/custom_components/escpos_printer/_config_flow/options_flow.py
+++ b/custom_components/escpos_printer/_config_flow/options_flow.py
@@ -7,6 +7,12 @@ from typing import Any
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 import voluptuous as vol
 
 from ..capabilities import (
@@ -57,6 +63,7 @@ from ..const import (
     RELIABILITY_PROFILE_FAST_LAN,
 )
 from .calibration_steps import CalibrationFlowMixin
+from .network_helpers import validate_custom_line_width
 
 _RELIABILITY_LABELS: dict[str, str] = {
     RELIABILITY_PROFILE_AUTO: "Auto (recommended)",
@@ -151,11 +158,22 @@ class EscposOptionsFlowHandler(CalibrationFlowMixin, config_entries.OptionsFlowW
             ):
                 errors["base"] = "bt_status_interval_too_low"
 
+            # The width field is a combobox (custom_value=True), so the
+            # submitted value may be a typed number, not just a preset.
+            # OPTION_CUSTOM is kept as a routed fallback for the legacy
+            # two-step entry path.
+            line_width = user_input.get(CONF_LINE_WIDTH)
+            if not errors and line_width not in (None, OPTION_CUSTOM):
+                width_int, width_err = validate_custom_line_width(line_width)
+                if width_err:
+                    errors["base"] = width_err
+                else:
+                    user_input[CONF_LINE_WIDTH] = width_int
+
             if not errors:
                 # Check for custom options
                 profile = user_input.get(CONF_PROFILE)
                 codepage = user_input.get(CONF_CODEPAGE)
-                line_width = user_input.get(CONF_LINE_WIDTH)
 
                 # Handle profile change - reset dependent options
                 old_profile = self.config_entry.options.get(
@@ -228,7 +246,6 @@ class EscposOptionsFlowHandler(CalibrationFlowMixin, config_entries.OptionsFlowW
         width_choices: dict[str, str] = {}
         for w in width_list:
             width_choices[str(w)] = f"{w} columns"
-        width_choices[OPTION_CUSTOM] = "Custom (enter columns)..."
 
         # Ensure current line width is in choices (backward compatibility).
         # Normalise to str so the lookup works regardless of stored type.
@@ -311,7 +328,19 @@ class EscposOptionsFlowHandler(CalibrationFlowMixin, config_entries.OptionsFlowW
             ): vol.Coerce(float),
             vol.Optional(CONF_PROFILE, default=current_profile): vol.In(profile_choices),
             vol.Optional(CONF_CODEPAGE, default=current_codepage): vol.In(codepage_choices),
-            vol.Optional(CONF_LINE_WIDTH, default=current_line_width_str): vol.In(width_choices),
+            # Combobox rather than vol.In: custom_value lets the user type
+            # a width directly instead of hunting for a "Custom..." choice
+            # that only opens an entry box on the next screen.
+            vol.Optional(CONF_LINE_WIDTH, default=current_line_width_str): SelectSelector(
+                SelectSelectorConfig(
+                    options=[
+                        SelectOptionDict(value=v, label=label)
+                        for v, label in width_choices.items()
+                    ],
+                    custom_value=True,
+                    mode=SelectSelectorMode.DROPDOWN,
+                )
+            ),
             vol.Optional(
                 CONF_WIDTH_PIXELS,
                 description={
@@ -474,8 +503,6 @@ class EscposOptionsFlowHandler(CalibrationFlowMixin, config_entries.OptionsFlowW
         if user_input is not None:
             custom_width = user_input.get("custom_line_width")
             _LOGGER.debug("Options: Custom line width entered: %s", custom_width)
-
-            from .network_helpers import validate_custom_line_width  # noqa: PLC0415
 
             width_int, err_code = validate_custom_line_width(custom_width)
             if err_code:

--- a/custom_components/escpos_printer/_config_flow/settings_steps.py
+++ b/custom_components/escpos_printer/_config_flow/settings_steps.py
@@ -6,6 +6,12 @@ import logging
 from typing import Any
 
 from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 import voluptuous as vol
 
 from ..capabilities import (
@@ -40,7 +46,7 @@ from ..const import (
     IMPL_AUTO,
     IMPL_CHOICE_LABELS,
 )
-from .network_helpers import make_network_entry_title
+from .network_helpers import make_network_entry_title, validate_custom_line_width
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -137,7 +143,7 @@ class SettingsFlowMixin:
             errors=errors,
         )
 
-    async def async_step_codepage(
+    async def async_step_codepage(  # noqa: PLR0912
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle step 2: Codepage and settings selection.
@@ -148,14 +154,26 @@ class SettingsFlowMixin:
         Returns:
             FlowResult with entry creation or custom step
         """
+        errors: dict[str, str] = {}
         if user_input is not None:
             _LOGGER.debug("Config flow codepage step input: %s", user_input)
 
             codepage = user_input.get(CONF_CODEPAGE, "")
             line_width = user_input.get(CONF_LINE_WIDTH)
 
-            # Handle custom codepage
-            if codepage == OPTION_CUSTOM:
+            # The width field is a combobox (custom_value=True), so the
+            # submitted value may be a typed number, not just a preset.
+            # OPTION_CUSTOM is kept as a routed fallback for the legacy
+            # two-step entry path.
+            line_width_int = DEFAULT_LINE_WIDTH
+            if line_width not in (None, "", OPTION_CUSTOM):
+                width_int, width_err = validate_custom_line_width(line_width)
+                if width_err:
+                    errors["base"] = width_err
+                else:
+                    line_width_int = width_int  # type: ignore[assignment]
+
+            if not errors and codepage == OPTION_CUSTOM:
                 # Store current selections and go to custom codepage step
                 self._user_data[CONF_DEFAULT_ALIGN] = user_input.get(
                     CONF_DEFAULT_ALIGN, DEFAULT_ALIGN
@@ -171,13 +189,11 @@ class SettingsFlowMixin:
                 if line_width == OPTION_CUSTOM:
                     self._user_data[CONF_LINE_WIDTH] = OPTION_CUSTOM
                 else:
-                    self._user_data[CONF_LINE_WIDTH] = (
-                        int(line_width) if line_width else DEFAULT_LINE_WIDTH
-                    )
+                    self._user_data[CONF_LINE_WIDTH] = line_width_int
                 return await self.async_step_custom_codepage()
 
-            # Handle custom line width
-            if line_width == OPTION_CUSTOM:
+            # Handle custom line width (legacy sentinel path)
+            if not errors and line_width == OPTION_CUSTOM:
                 # Store current selections and go to custom line width step
                 self._user_data[CONF_CODEPAGE] = codepage or ""
                 self._user_data[CONF_DEFAULT_ALIGN] = user_input.get(
@@ -189,35 +205,36 @@ class SettingsFlowMixin:
                     self._user_data[CONF_WIDTH_PIXELS] = int(user_input[CONF_WIDTH_PIXELS])
                 return await self.async_step_custom_line_width()
 
-            # Merge with data from previous steps and create entry
-            data = {
-                **self._user_data,
-                CONF_CODEPAGE: codepage or "",
-                CONF_LINE_WIDTH: int(line_width) if line_width else DEFAULT_LINE_WIDTH,
-                CONF_DEFAULT_ALIGN: user_input.get(CONF_DEFAULT_ALIGN, DEFAULT_ALIGN),
-                CONF_DEFAULT_CUT: user_input.get(CONF_DEFAULT_CUT, DEFAULT_CUT),
-            }
+            if not errors:
+                # Merge with data from previous steps and create entry
+                data = {
+                    **self._user_data,
+                    CONF_CODEPAGE: codepage or "",
+                    CONF_LINE_WIDTH: line_width_int,
+                    CONF_DEFAULT_ALIGN: user_input.get(CONF_DEFAULT_ALIGN, DEFAULT_ALIGN),
+                    CONF_DEFAULT_CUT: user_input.get(CONF_DEFAULT_CUT, DEFAULT_CUT),
+                }
 
-            if user_input.get(CONF_WIDTH_PIXELS):
-                data[CONF_WIDTH_PIXELS] = int(user_input[CONF_WIDTH_PIXELS])
+                if user_input.get(CONF_WIDTH_PIXELS):
+                    data[CONF_WIDTH_PIXELS] = int(user_input[CONF_WIDTH_PIXELS])
 
-            data[CONF_IMPL] = user_input.get(CONF_IMPL, IMPL_AUTO)
+                data[CONF_IMPL] = user_input.get(CONF_IMPL, IMPL_AUTO)
 
-            # Remove internal keys
-            data.pop("_printer_name", None)
+                # Remove internal keys
+                data.pop("_printer_name", None)
 
-            title = _make_entry_title(data, self._user_data)
+                title = _make_entry_title(data, self._user_data)
 
-            _LOGGER.debug(
-                "Creating config entry for %s with profile=%s codepage=%s",
-                title,
-                data.get(CONF_PROFILE),
-                data.get(CONF_CODEPAGE),
-            )
+                _LOGGER.debug(
+                    "Creating config entry for %s with profile=%s codepage=%s",
+                    title,
+                    data.get(CONF_PROFILE),
+                    data.get(CONF_CODEPAGE),
+                )
 
-            return self.async_create_entry(  # type: ignore[attr-defined,no-any-return]
-                title=title, data=data, description=_create_entry_description(data)
-            )
+                return self.async_create_entry(  # type: ignore[attr-defined,no-any-return]
+                    title=title, data=data, description=_create_entry_description(data)
+                )
 
         # Get profile-specific options
         profile = self._user_data.get(CONF_PROFILE, PROFILE_AUTO)
@@ -234,7 +251,6 @@ class SettingsFlowMixin:
         width_choices: dict[str, str] = {}
         for w in width_list:
             width_choices[str(w)] = f"{w} columns"
-        width_choices[OPTION_CUSTOM] = "Custom (enter columns)..."
 
         # Get cut modes for selected profile
         cut_modes = await self.hass.async_add_executor_job(get_profile_cut_modes, profile)
@@ -243,8 +259,18 @@ class SettingsFlowMixin:
         data_schema = vol.Schema(
             {
                 vol.Optional(CONF_CODEPAGE, default=""): vol.In(codepage_choices),
-                vol.Optional(CONF_LINE_WIDTH, default=str(DEFAULT_LINE_WIDTH)): vol.In(
-                    width_choices
+                # Combobox rather than vol.In: custom_value lets the user
+                # type a width directly instead of hunting for a
+                # "Custom..." choice that only opens a box on the next screen.
+                vol.Optional(CONF_LINE_WIDTH, default=str(DEFAULT_LINE_WIDTH)): SelectSelector(
+                    SelectSelectorConfig(
+                        options=[
+                            SelectOptionDict(value=v, label=label)
+                            for v, label in width_choices.items()
+                        ],
+                        custom_value=True,
+                        mode=SelectSelectorMode.DROPDOWN,
+                    )
                 ),
                 vol.Optional(CONF_DEFAULT_ALIGN, default=DEFAULT_ALIGN): vol.In(
                     ["left", "center", "right"]
@@ -257,7 +283,9 @@ class SettingsFlowMixin:
             }
         )
 
-        return self.async_show_form(step_id="codepage", data_schema=data_schema)  # type: ignore[attr-defined,no-any-return]
+        return self.async_show_form(  # type: ignore[attr-defined,no-any-return]
+            step_id="codepage", data_schema=data_schema, errors=errors
+        )
 
     async def async_step_custom_codepage(
         self, user_input: dict[str, Any] | None = None
@@ -334,8 +362,6 @@ class SettingsFlowMixin:
         if user_input is not None:
             custom_width = user_input.get("custom_line_width")
             _LOGGER.debug("Custom line width entered: %s", custom_width)
-
-            from .network_helpers import validate_custom_line_width  # noqa: PLC0415
 
             width_int, err_code = validate_custom_line_width(custom_width)
             if err_code:

--- a/custom_components/escpos_printer/strings.json
+++ b/custom_components/escpos_printer/strings.json
@@ -161,7 +161,7 @@
         },
         "data_description": {
           "codepage": "Character encoding/codepage for text. Choose 'Custom' to enter a codepage manually.",
-          "line_width": "Number of characters per line (columns). Choose 'Custom' to enter a value manually.",
+          "line_width": "Number of characters per line (columns). Pick a preset or type a custom number.",
           "width_pixels": "Overrides the profile's printable width for images. Leave empty to use the profile. Common values: 384 (58 mm), 576 (80 mm).",
           "impl": "ESC/POS command set used to print images. Auto follows the printer profile; override if images print garbled or fail.",
           "default_align": "Default text alignment for printing.",
@@ -372,7 +372,7 @@
           "timeout": "Connection timeout in seconds.",
           "profile": "Select your printer model. Changing this will reset encoding options.",
           "codepage": "Character encoding/codepage for text.",
-          "line_width": "Number of characters per line (columns).",
+          "line_width": "Number of characters per line (columns). Pick a preset or type a custom number.",
           "width_pixels": "Overrides the profile's printable width for images. Leave empty to use the profile. Common values: 384 (58 mm), 576 (80 mm).",
           "default_align": "Default text alignment for printing.",
           "default_cut": "Default paper cut mode after printing.",

--- a/custom_components/escpos_printer/translations/en.json
+++ b/custom_components/escpos_printer/translations/en.json
@@ -161,7 +161,7 @@
         },
         "data_description": {
           "codepage": "Character encoding/codepage for text. Choose 'Custom' to enter a codepage manually.",
-          "line_width": "Number of characters per line (columns). Choose 'Custom' to enter a value manually.",
+          "line_width": "Number of characters per line (columns). Pick a preset or type a custom number.",
           "width_pixels": "Overrides the profile's printable width for images. Leave empty to use the profile. Common values: 384 (58 mm), 576 (80 mm).",
           "impl": "ESC/POS command set used to print images. Auto follows the printer profile; override if images print garbled or fail.",
           "default_align": "Default text alignment for printing.",
@@ -372,7 +372,7 @@
           "timeout": "Connection timeout in seconds.",
           "profile": "Select your printer model. Changing this will reset encoding options.",
           "codepage": "Character encoding/codepage for text.",
-          "line_width": "Number of characters per line (columns).",
+          "line_width": "Number of characters per line (columns). Pick a preset or type a custom number.",
           "width_pixels": "Overrides the profile's printable width for images. Leave empty to use the profile. Common values: 384 (58 mm), 576 (80 mm).",
           "default_align": "Default text alignment for printing.",
           "default_cut": "Default paper cut mode after printing.",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -539,3 +539,76 @@ async def test_network_flow_reuses_preset_detected_result(hass):  # type: ignore
 
     assert result["type"] == "create_entry"
     assert result["data"][CONF_DETECTED_MODEL] == "TM-T20II"
+
+
+async def test_config_flow_typed_line_width_creates_entry_directly(hass):  # type: ignore[no-untyped-def]
+    """The width combobox accepts a typed value at setup — no second step."""
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK},
+        )
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {CONF_HOST: "1.2.3.4", CONF_PORT: 9100},
+        )
+
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
+            {
+                CONF_CODEPAGE: "",
+                CONF_LINE_WIDTH: "42",
+                CONF_DEFAULT_ALIGN: "left",
+                CONF_DEFAULT_CUT: "none",
+            },
+        )
+
+        assert result4["type"] == "create_entry"
+        assert result4["data"][CONF_LINE_WIDTH] == 42
+
+
+async def test_config_flow_typed_line_width_invalid_shows_error(hass):  # type: ignore[no-untyped-def]
+    """A non-numeric typed width re-shows the codepage form with an error."""
+    with (
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.escpos_printer._config_flow.network_steps.query_printer_id",
+            return_value=None,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_CONNECTION_TYPE: CONNECTION_TYPE_NETWORK},
+        )
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {CONF_HOST: "1.2.3.4", CONF_PORT: 9100},
+        )
+
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
+            {
+                CONF_CODEPAGE: "",
+                CONF_LINE_WIDTH: "wide",
+                CONF_DEFAULT_ALIGN: "left",
+                CONF_DEFAULT_CUT: "none",
+            },
+        )
+
+        assert result4["type"] == "form"
+        assert result4["step_id"] == "codepage"
+        assert result4["errors"] == {"base": "invalid_line_width"}

--- a/tests/test_options_flow_custom.py
+++ b/tests/test_options_flow_custom.py
@@ -347,3 +347,50 @@ async def test_options_flow_non_bt_entry_status_interval_below_60_accepted(hass)
         await hass.async_block_till_done()
     assert result["type"] == "create_entry"
     assert result["data"][CONF_STATUS_INTERVAL] == 30
+
+
+async def test_options_flow_typed_line_width_saves_directly(hass):  # type: ignore[no-untyped-def]
+    """The width combobox accepts a typed value — no second step needed."""
+    entry = await _setup_entry(hass)
+
+    result = await _open_settings(hass, entry)
+    with patch("custom_components.escpos_printer.async_setup_entry", return_value=True):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_PROFILE: "TM-T20",
+                CONF_CODEPAGE: "",
+                CONF_LINE_WIDTH: "42",
+                "default_align": "left",
+                "default_cut": "none",
+                "timeout": 4.0,
+                "keepalive": False,
+                "status_interval": 0,
+            },
+        )
+        await hass.async_block_till_done()
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_LINE_WIDTH] == 42
+
+
+async def test_options_flow_typed_line_width_invalid_shows_error(hass):  # type: ignore[no-untyped-def]
+    """A non-numeric typed width re-shows the settings form with an error."""
+    entry = await _setup_entry(hass)
+
+    result = await _open_settings(hass, entry)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_PROFILE: "TM-T20",
+            CONF_CODEPAGE: "",
+            CONF_LINE_WIDTH: "lots",
+            "default_align": "left",
+            "default_cut": "none",
+            "timeout": 4.0,
+            "keepalive": False,
+            "status_interval": 0,
+        },
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "settings"
+    assert result["errors"] == {"base": "invalid_line_width"}


### PR DESCRIPTION
## Problem

Selecting "Custom (enter columns)..." under **Characters per line** showed no box to type a value into. The entry box actually lived on a *second* screen that only appeared after pressing Submit — an affordance that reads as a broken form (reported against the setup flow's codepage/settings step).

## Fix

Replace the plain `vol.In` dropdown with HA's native `SelectSelector` combobox (`custom_value=True`) in both places the field appears:

- setup flow (`async_step_codepage` — shared by network/USB/Bluetooth/serial), and
- the options flow settings form.

You now pick a preset (e.g. "48 columns") or just type a number directly into the same field. Typed values are validated with the existing shared `validate_custom_line_width` bounds check (1–255); invalid input re-shows the form with the existing `invalid_line_width` error.

Backward compatibility: the `__custom__` sentinel still routes to the legacy two-step entry box, so nothing depending on that path breaks. Field descriptions updated to say "Pick a preset or type a custom number."

## Testing

- 4 new tests: typed width creates the entry directly (setup + options), invalid typed width errors on the same form (setup + options).
- All existing custom-line-width tests (sentinel two-step path) pass unchanged.
- Flow test files: 147 passed; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)