### PR TITLE
Let width calibration bars print past the profile's declared width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- The width-bars calibration step no longer reports "Printing the test
+  page failed" on printers whose profile declares a pixel width.
+  python-escpos refuses to send images wider than the profile's
+  `media.width.pixels`, so the bars beyond that width (640/832 on a
+  576-dot TM-T20II) raised an error that aborted the page. The width
+  bars now bypass that profile check for the duration of the send —
+  wider-than-true-width bars are the measurement (hardware clips them
+  to the same length), and the bypass also makes an under-declared
+  profile width detectable instead of silently "confirmed". Each bar
+  is additionally attempted independently, so a printer rejecting one
+  bar can't abort the rest; the step only errors if no bar prints.
 - Calibration test pages now print each page over a single printer
   connection instead of one connection per label/pattern. With the
   reconnect-per-operation model, printers that accept a new connection

--- a/custom_components/escpos_printer/_config_flow/calibration_steps.py
+++ b/custom_components/escpos_printer/_config_flow/calibration_steps.py
@@ -270,26 +270,50 @@ class CalibrationFlowMixin:
             step_id="calibrate_impl", data_schema=schema, errors=errors
         )
 
-    async def _print_width_bars(self, adapter: Any) -> None:
-        """Print one bar per candidate width, using the impl chosen so far."""
+    async def _print_width_bars(self, adapter: Any) -> bool:
+        """Print one bar per candidate width, using the impl chosen so far.
+
+        Bars wider than the printer's true width are the measurement —
+        the hardware clips them to the same length. That requires
+        ``ignore_profile_width``: python-escpos otherwise refuses any
+        image wider than the profile's declared ``media.width.pixels``
+        (``ImageWidthError``), which both broke the step on printers
+        with a declared width (seen on TM-T20II @ 576: bars 640/832
+        aborted the page) and made an under-declared profile width
+        impossible to detect. Each bar is still attempted independently
+        so a printer rejecting one bar can't abort the rest. Returns
+        True if at least one bar printed.
+        """
         impl = self._calib.get("impl") or getattr(adapter, "default_impl", None) or DEFAULT_IMPL
+        any_ok = False
         async with adapter.batch_connection(self.hass) as page:
             await self._print_step_header(
                 page, "CALIBRATE 2/4: WIDTH BARS", "First bar equal to bottom?"
             )
             for w in WIDTH_CANDIDATES:
-                # width=w beats a narrower profile/opts width in the image
-                # pipeline (process_image only ever downscales, never
-                # upscales), so each bar prints at its true pixel width
-                # instead of all four being clamped to the same width.
-                await page.print_image(
-                    image=width_bar_data_uri(w),
-                    impl=impl,
-                    width=w,
-                    feed=1,
-                    auto_resize=False,
-                )
-            await self._print_step_trailer(page, feed=4)
+                try:
+                    # width=w beats a narrower profile/opts width in the image
+                    # pipeline (process_image only ever downscales, never
+                    # upscales), so each bar prints at its true pixel width
+                    # instead of all four being clamped to the same width.
+                    await page.print_image(
+                        image=width_bar_data_uri(w),
+                        impl=impl,
+                        width=w,
+                        feed=1,
+                        auto_resize=False,
+                        ignore_profile_width=True,
+                    )
+                    any_ok = True
+                except Exception as err:
+                    _LOGGER.warning(
+                        "Calibration width bar %d failed to print: %s",
+                        w,
+                        sanitize_log_message(str(err)),
+                    )
+            if any_ok:
+                await self._print_step_trailer(page, feed=4)
+        return any_ok
 
     async def async_step_calibrate_width(
         self, user_input: dict[str, Any] | None = None
@@ -303,7 +327,8 @@ class CalibrationFlowMixin:
                     reason="printer_not_ready"
                 )
             try:
-                await self._print_width_bars(adapter)
+                if not await self._print_width_bars(adapter):
+                    errors["base"] = "calibration_print_failed"
             except Exception as err:
                 _LOGGER.warning("Calibration width step failed: %s", sanitize_log_message(str(err)))
                 errors["base"] = "calibration_print_failed"

--- a/custom_components/escpos_printer/printer/base_adapter.py
+++ b/custom_components/escpos_printer/printer/base_adapter.py
@@ -27,6 +27,7 @@ from .image_operations import (
     ImageStats,
     _print_prepared_under_lock,
     prepare_image_for_print,
+    profile_width_bypass,
 )
 from .image_processor import FALLBACK_PROFILE_WIDTH
 from .mapping_utils import cleanup_cut, map_align, map_cut, map_multiplier, map_underline
@@ -795,12 +796,18 @@ class _BatchPage:
         dither: str = "floyd-steinberg",
         auto_resize: bool = False,
         feed: int | None = 0,
+        ignore_profile_width: bool = False,
     ) -> None:
         """Print an image on the held connection (mirrors ``adapter.print_image``).
 
         Image prep runs while the lock is held — callers pass small
         generated data URIs (calibration patterns), not slow camera or
         URL sources.
+
+        ``ignore_profile_width`` swaps in a width-unlocked profile for
+        the send so python-escpos doesn't refuse images wider than the
+        profile's declared width — calibration's width bars are wider
+        on purpose (hardware clipping is the measurement).
         """
         prepared = await prepare_image_for_print(
             self._adapter,
@@ -811,7 +818,11 @@ class _BatchPage:
             dither=dither,
             auto_resize=auto_resize,
         )
-        await _print_prepared_under_lock(self._hass, self._printer, prepared)
+        if ignore_profile_width:
+            with profile_width_bypass(self._printer):
+                await _print_prepared_under_lock(self._hass, self._printer, prepared)
+        else:
+            await _print_prepared_under_lock(self._hass, self._printer, prepared)
         await self._adapter._apply_cut_and_feed(self._hass, self._printer, "none", feed)
 
     async def feed(self, lines: int) -> None:

--- a/custom_components/escpos_printer/printer/image_operations.py
+++ b/custom_components/escpos_printer/printer/image_operations.py
@@ -41,6 +41,8 @@ from .image_processor import (
 from .mapping_utils import cleanup_cut, map_align
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from homeassistant.core import Context, HomeAssistant
     from PIL import Image
 
@@ -430,6 +432,48 @@ async def _process_bytes(
             raise HomeAssistantError(_describe_undecodable(raw, content_type)) from exc
 
     return await hass.async_add_executor_job(_go)
+
+
+class _WidthUnlockedProfile:
+    """Proxy of a python-escpos profile with ``media.width`` removed.
+
+    ``Escpos.image()`` raises ``ImageWidthError`` for images wider than
+    ``profile_data["media"]["width"]["pixels"]`` — and deliberately
+    prints anyway on ``KeyError`` (the "unknown width" path generic
+    profiles take). Dropping just that key opts out of the refusal while
+    delegating every other attribute (``get_font``, ``supports``, …) to
+    the real profile, so ``set()`` and text encoding keep working.
+    """
+
+    def __init__(self, profile: Any) -> None:
+        self._profile = profile
+        data = dict(getattr(profile, "profile_data", {}) or {})
+        media = dict(data.get("media", {}))
+        media.pop("width", None)
+        data["media"] = media
+        self.profile_data = data
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._profile, name)
+
+
+@contextlib.contextmanager
+def profile_width_bypass(printer: Any) -> Iterator[None]:
+    """Temporarily hide the profile's pixel width from ``printer``.
+
+    Calibration sends bars *deliberately* wider than the profile width
+    so the hardware's own clipping can be measured — including when the
+    configured profile under-declares the true width, which is exactly
+    the misconfiguration the width step exists to catch. Callers hold
+    the adapter lock, so no other operation can observe the swapped
+    profile.
+    """
+    original = printer.profile
+    printer.profile = _WidthUnlockedProfile(original)
+    try:
+        yield
+    finally:
+        printer.profile = original
 
 
 # Cache of ``printer.image`` supported kwarg names, keyed by printer class.

--- a/tests/test_calibration_flow.py
+++ b/tests/test_calibration_flow.py
@@ -276,6 +276,9 @@ async def test_impl_continue_stores_choice_and_advances_to_width(hass):  # type:
     # clamps every bar to the profile/opts width and they all print
     # identical length, making the step unable to measure anything wider.
     assert [call.kwargs["width"] for call in width_calls] == [384, 512, 576, 640, 832]
+    # ...and bypass python-escpos's profile-width refusal, or bars wider
+    # than the declared profile width can never reach the printer.
+    assert all(call.kwargs["ignore_profile_width"] for call in width_calls)
 
 
 async def test_impl_partial_candidate_failure_is_tolerated(hass):  # type: ignore[no-untyped-def]
@@ -348,6 +351,53 @@ async def test_width_bars_prefer_calib_impl_then_adapter_default(hass):  # type:
     assert all(
         call.kwargs["impl"] == "bitImageColumn" for call in adapter.print_image.await_args_list[-5:]
     )
+
+
+async def test_width_partial_bar_failure_is_tolerated(hass):  # type: ignore[no-untyped-def]
+    """Bars wider than the profile's declared width failing doesn't fail the step.
+
+    python-escpos raises ImageWidthError for any image wider than the
+    profile's media.width.pixels, so on a printer with a declared width
+    (e.g. TM-T20II @ 576) the 640/832 bars can never be sent. The bars
+    that did print are still a valid measurement (seen on TM-T20II:
+    3 bars on paper + a spurious "print failed" banner).
+    """
+    entry, adapter = _make_entry(hass)
+    # 3 impl-step prints succeed; width bars 384/512/576 succeed, 640/832
+    # exceed the profile width and raise.
+    adapter.print_image.side_effect = [None] * 3 + [
+        None,
+        None,
+        None,
+        RuntimeError("640 > 576"),
+        RuntimeError("832 > 576"),
+    ]
+    result = await _open_calibrate(hass, entry)
+
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"impls_clean": ["bitImageRaster"], "action": "continue"}
+    )
+
+    assert result2["type"] == "form"
+    assert result2["step_id"] == "calibrate_width"
+    assert result2.get("errors") in (None, {})
+    # All five bars were attempted -- a failing bar must not abort the rest.
+    assert adapter.print_image.await_count == 3 + 5
+
+
+async def test_width_all_bars_failing_shows_print_error(hass):  # type: ignore[no-untyped-def]
+    """If every bar fails to print, the form re-shows a print-failure error."""
+    entry, adapter = _make_entry(hass)
+    adapter.print_image.side_effect = [None] * 3 + [RuntimeError("boom")] * 5
+    result = await _open_calibrate(hass, entry)
+
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"impls_clean": ["bitImageRaster"], "action": "continue"}
+    )
+
+    assert result2["type"] == "form"
+    assert result2["step_id"] == "calibrate_width"
+    assert result2["errors"]["base"] == "calibration_print_failed"
 
 
 async def test_width_continue_with_bar_stores_pixels_then_advances_to_ruler(hass):  # type: ignore[no-untyped-def]

--- a/tests/test_profile_width_bypass.py
+++ b/tests/test_profile_width_bypass.py
@@ -13,11 +13,18 @@ fails here instead of on paper.
 
 from __future__ import annotations
 
+import base64
+import io
+from unittest.mock import patch
+
 from escpos.exceptions import ImageWidthError
 from escpos.printer import Dummy
+from homeassistant.const import CONF_HOST, CONF_PORT
 from PIL import Image
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.escpos_printer.const import DOMAIN
 from custom_components.escpos_printer.printer.image_operations import (
     profile_width_bypass,
 )
@@ -36,8 +43,8 @@ def test_dummy_profile_still_refuses_wide_images_without_bypass():
 def test_bypass_sends_wider_than_profile_image(impl):
     """Inside the bypass, every impl accepts a wider-than-profile image.
 
-    ``set()`` runs too — the first image slice calls it, and it reads
-    ``profile.get_font()``; the proxy must delegate everything except
+    ``set()`` runs too — the first image slice calls it, and it may read
+    other profile attributes; the proxy must delegate everything except
     the width key.
     """
     printer = Dummy(profile="TM-T20II")
@@ -49,9 +56,85 @@ def test_bypass_sends_wider_than_profile_image(impl):
     assert len(printer.output) > 0
 
 
+def test_bypass_profile_delegates_other_attributes():
+    """Only ``media.width`` is hidden; everything else reaches the real profile."""
+    printer = Dummy(profile="TM-T20II")
+    with profile_width_bypass(printer):
+        assert "width" not in printer.profile.profile_data["media"]
+        # Attribute lookups (``set()`` uses ``get_font``) must delegate.
+        assert printer.profile.get_font("a") == 0
+        assert printer.profile.name == "TM-T20II"
+
+
 def test_bypass_restores_profile_on_error():
+    # try/except instead of pytest.raises: CodeQL doesn't model
+    # pytest.raises' exception suppression and flags the trailing
+    # assert as unreachable.
     printer = Dummy(profile="TM-T20II")
     original = printer.profile
-    with pytest.raises(RuntimeError), profile_width_bypass(printer):
-        raise RuntimeError("boom")
+    try:
+        with profile_width_bypass(printer):
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
     assert printer.profile is original
+
+
+# ---------------------------------------------------------------------------
+# Batch-page integration: the ignore_profile_width flag end to end.
+# ---------------------------------------------------------------------------
+
+
+def _bar_data_uri(width: int) -> str:
+    img = Image.new("1", (width, 20), 1)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+
+
+async def _setup_entry(hass) -> MockConfigEntry:  # type: ignore[no-untyped-def]
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="1.2.3.4:9100",
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: 9100},
+        unique_id="1.2.3.4:9100",
+    )
+    entry.add_to_hass(hass)
+    with patch("escpos.printer.Network"):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+async def test_batch_page_print_image_bypasses_profile_width(hass):  # type: ignore[no-untyped-def]
+    """ignore_profile_width=True sends a wider-than-profile image and restores the profile."""
+    entry = await _setup_entry(hass)
+    adapter = entry.runtime_data.adapter
+
+    fake_printer = Dummy(profile="TM-T20II")
+    original = fake_printer.profile
+    with patch.object(adapter, "_connect", return_value=fake_printer):
+        async with adapter.batch_connection(hass) as page:
+            await page.print_image(
+                image=_bar_data_uri(640),
+                width=640,
+                feed=1,
+                ignore_profile_width=True,
+            )
+
+    assert fake_printer.profile is original
+    assert len(fake_printer.output) > 0
+
+
+async def test_batch_page_print_image_guarded_by_default(hass):  # type: ignore[no-untyped-def]
+    """Without the flag, python-escpos's profile-width refusal still applies."""
+    entry = await _setup_entry(hass)
+    adapter = entry.runtime_data.adapter
+
+    fake_printer = Dummy(profile="TM-T20II")
+    with (
+        patch.object(adapter, "_connect", return_value=fake_printer),
+        pytest.raises(ImageWidthError),
+    ):
+        async with adapter.batch_connection(hass) as page:
+            await page.print_image(image=_bar_data_uri(640), width=640, feed=1)

--- a/tests/test_profile_width_bypass.py
+++ b/tests/test_profile_width_bypass.py
@@ -1,0 +1,57 @@
+"""Tests for the calibration-only profile-width bypass.
+
+python-escpos raises ``ImageWidthError`` for any image wider than the
+profile's declared ``media.width.pixels`` — deliberately printing anyway
+when the key is missing. The width-bars calibration step *intends* to
+send wider-than-profile bars so hardware clipping can be measured, so it
+swaps in a proxy profile with the width key removed for the duration of
+the send. These tests run against the real python-escpos ``Dummy``
+printer (TM-T20II profile, 576 px) so a library upgrade that moves the
+width check or reads other profile attributes during ``image()``/``set()``
+fails here instead of on paper.
+"""
+
+from __future__ import annotations
+
+from escpos.exceptions import ImageWidthError
+from escpos.printer import Dummy
+from PIL import Image
+import pytest
+
+from custom_components.escpos_printer.printer.image_operations import (
+    profile_width_bypass,
+)
+
+WIDE = Image.new("1", (640, 44), 1)
+
+
+def test_dummy_profile_still_refuses_wide_images_without_bypass():
+    """Baseline: the guard this bypass exists for is still in the library."""
+    printer = Dummy(profile="TM-T20II")
+    with pytest.raises(ImageWidthError):
+        printer.image(WIDE, impl="bitImageRaster")
+
+
+@pytest.mark.parametrize("impl", ["bitImageRaster", "bitImageColumn", "graphics"])
+def test_bypass_sends_wider_than_profile_image(impl):
+    """Inside the bypass, every impl accepts a wider-than-profile image.
+
+    ``set()`` runs too — the first image slice calls it, and it reads
+    ``profile.get_font()``; the proxy must delegate everything except
+    the width key.
+    """
+    printer = Dummy(profile="TM-T20II")
+    original = printer.profile
+    with profile_width_bypass(printer):
+        printer.set(align="left", normal_textsize=True)
+        printer.image(WIDE, impl=impl)
+    assert printer.profile is original
+    assert len(printer.output) > 0
+
+
+def test_bypass_restores_profile_on_error():
+    printer = Dummy(profile="TM-T20II")
+    original = printer.profile
+    with pytest.raises(RuntimeError), profile_width_bypass(printer):
+        raise RuntimeError("boom")
+    assert printer.profile is original


### PR DESCRIPTION
## Problem

On printers whose profile declares a pixel width (e.g. TM-T20II @ 576), the width-bars calibration step printed only the first three bars and showed "Printing the test page failed."

Root cause: python-escpos's `Escpos.image()` raises `ImageWidthError` for any image wider than the profile's `media.width.pixels` — before a single byte reaches the printer. The 640/832 bars were refused client-side, and `_print_width_bars` had no per-bar error handling (unlike the impl and codepage steps), so the exception aborted the rest of the page and surfaced the error banner.

This also meant an *under-declared* profile width could never be detected — exactly the misconfiguration the width step exists to catch: bars wider than the wrong profile value were refused, and the wizard "confirmed" the wrong width.

## Fix

- **`profile_width_bypass()`** (image_operations.py): temporarily swaps `printer.profile` for a proxy whose `profile_data` lacks `media.width`, taking python-escpos's deliberate `KeyError` → "print anyway" path. Everything else (`get_font`, `supports`, …) delegates to the real profile so `set()` and text encoding keep working. Restored in `finally`; the adapter lock means nothing else can observe the swap.
- **`_BatchPage.print_image`** gained `ignore_profile_width` (default off); only `_print_width_bars` passes it. Wider-than-true-width bars are the measurement — hardware clips them to the same length.
- **Per-bar try/except** in `_print_width_bars`, matching the impl/codepage steps: a printer rejecting one bar can't abort the rest; the step errors only if no bar prints.

## Tests

- New `tests/test_profile_width_bypass.py` runs against the real python-escpos `Dummy` printer with the actual TM-T20II profile: asserts the library still refuses 640px without the bypass (so a library upgrade that moves the check fails here instead of on paper), that all three impls accept it inside the bypass, and that the profile is restored even on error.
- Flow tests: every width-bar call requests the bypass; partial bar failure is tolerated (no error banner, all five bars attempted); all-bars-failing still shows the error.

Verified: full suite 1315 passed, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)