### PR TITLE
Annotate deliberate subprocess use in extract_markdown_bash with nosec

### DIFF
--- a/scripts/extract_markdown_bash.py
+++ b/scripts/extract_markdown_bash.py
@@ -35,7 +35,10 @@ from collections.abc import Iterator
 from pathlib import Path
 import re
 import shutil
-import subprocess
+
+# Running shellcheck/bash on repo-owned markdown is this tool's entire
+# purpose; it never sees input from outside the repository.
+import subprocess  # nosec B404
 import sys
 import tempfile
 from typing import NamedTuple
@@ -80,7 +83,8 @@ def iter_bash_blocks(md_path: Path) -> Iterator[Block]:
 
 def shellcheck_block(block: Block) -> list[str]:
     """Return a list of ``shellcheck`` finding lines for *block*."""
-    if shutil.which("shellcheck") is None:
+    shellcheck = shutil.which("shellcheck")
+    if shellcheck is None:
         return [
             f"{block.path}:{block.line}: WARN — shellcheck not installed; "
             "install via `apk add shellcheck` (HA OS / Alpine) or your "
@@ -95,9 +99,12 @@ def shellcheck_block(block: Block) -> list[str]:
         fh.write(block.body)
         tmp = Path(fh.name)
     try:
-        proc = subprocess.run(
+        # Fixed argv over a repo-owned tempfile; nothing here is
+        # attacker-controlled (and shellcheck is an absolute path via
+        # shutil.which above).
+        proc = subprocess.run(  # nosec B603
             [
-                "shellcheck",
+                shellcheck,
                 # SC1091: source file paths we can't resolve at lint time.
                 # SC2155: declare/assign separation — opinionated, OK as-is.
                 "--exclude=SC1091,SC2155",
@@ -132,7 +139,10 @@ def smoke_exec_block(block: Block, iterations: int = 10) -> list[str]:
 
     failures: list[str] = []
     for i in range(1, iterations + 1):
-        proc = subprocess.run(
+        # Smoke-executing the repo's own fenced blocks is the feature —
+        # the SIGPIPE bug this catches only reproduces by running them.
+        # bash stays a PATH lookup on purpose (Alpine/macOS/CI differ).
+        proc = subprocess.run(  # nosec B603 B607
             ["bash", "-c", body],
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Problem

Five standing Bandit alerts in the Security tab, all on `scripts/extract_markdown_bash.py`:

- **B404** (import subprocess), **B603** ×2 (subprocess without shell-injection check), **B607** ×2 (partial executable path for `shellcheck`/`bash`).

They're low severity, so the `-ll` CI gate never fails on them — they just accumulate as open alerts.

## Why annotate rather than fix or skip

Running `shellcheck`/`bash` on the repo's own `blueprints/*.md` is this tool's entire purpose (it smoke-execs the password-generator pipeline to catch the SIGPIPE-141 regression), and it never sees input from outside the repository — anyone who can modify the markdown can modify CI itself, so there's no privilege boundary. The findings are by-design, not defects.

Per-line `# nosec <code>` with a stated why, instead of adding the codes to `[tool.bandit] skips`: a global skip would also silence subprocess findings in `custom_components/`, where shipped integration code spawning a process absolutely should alert. `scripts/` deliberately stays in Bandit's scan scope (it runs with elevated privileges in dependabot-auto-sync), so future scripts keep full scrutiny.

## Changes

- Targeted `# nosec B404` / `# nosec B603` / `# nosec B603 B607` on the three flagged sites, each with a justification comment.
- One real fix folded in: `shellcheck_block` now passes the `shutil.which("shellcheck")` result (already computed for the is-installed check) to `subprocess.run`, resolving that B607 legitimately with an absolute path. `bash` stays a PATH lookup on purpose — it lives in different places on Alpine (HA OS), macOS, and CI runners.

## Verification

- `bandit -c pyproject.toml -r custom_components/escpos_printer scripts -ll` (CI invocation): clean.
- Full-severity `bandit -r scripts`: "No issues identified", 5 findings specifically disabled by code, 0 blanket-nosec lines.
- `python scripts/extract_markdown_bash.py`: still passes (5 blocks in 4 files ok); ruff and pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)