### PR TITLE
Replace calibration ruler slider with a number box and explicit skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- The calibration wizard's "characters per line" step now uses a typed
+  number box (16–96) instead of a 0–96 slider, and skipping is an
+  explicit "Skip this step" action instead of the magic value 0. The
+  user is transcribing a count they just read off the paper, so a
+  slider was the wrong control, and its 0 default made the skip
+  convention easy to trigger by accident. Continuing with the count
+  left empty now asks for a value or an explicit skip.
+
 ### Fixed
 
 - The width-bars calibration step no longer reports "Printing the test

--- a/custom_components/escpos_printer/_config_flow/calibration_steps.py
+++ b/custom_components/escpos_printer/_config_flow/calibration_steps.py
@@ -21,6 +21,11 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components.persistent_notification import async_create as pn_create
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+)
 import voluptuous as vol
 
 from ..capabilities import get_profile_codepages
@@ -60,6 +65,7 @@ _IMPL_LABELS = {
     "graphics": "Pattern 3 (Graphics)",
 }
 _ACTION_CHOICES = {"continue": "Continue", "reprint": "Reprint the test page"}
+_RULER_ACTION_CHOICES = _ACTION_CHOICES | {"skip": "Skip this step"}
 _CONFIRM_ACTION_CHOICES = {"start": "Start calibration", "cancel": "Cancel"}
 # Derived from WIDTH_CANDIDATES so the bar numbers/labels can't drift out
 # of sync with what _print_width_bars actually prints.
@@ -378,20 +384,30 @@ class CalibrationFlowMixin:
                 _LOGGER.warning("Calibration ruler step failed: %s", sanitize_log_message(str(err)))
                 errors["base"] = "calibration_print_failed"
         else:
-            marker = user_input.get("last_marker", 0)
-            if 1 <= marker <= 15:
-                errors["base"] = "line_width_out_of_range"
+            if user_input.get("action") == "skip":
+                return await self.async_step_calibrate_codepage()
+            marker = user_input.get("last_marker")
+            if marker is None:
+                # "Continue" with an empty count is ambiguous -- make the
+                # user either type what they measured or skip explicitly.
+                errors["base"] = "line_width_missing"
             else:
-                if marker:
-                    self._calib["line_width"] = marker
+                self._calib["line_width"] = marker
                 return await self.async_step_calibrate_codepage()
 
         schema = vol.Schema(
             {
-                vol.Required("last_marker", default=0): vol.All(
-                    vol.Coerce(int), vol.Range(min=0, max=96)
+                # BOX mode: the user transcribes a count they just read off
+                # the paper -- a typed number field, not a slider. 16 is the
+                # narrowest plausible printer width; "don't know" is the
+                # explicit skip action, not a magic 0.
+                vol.Optional("last_marker"): vol.All(
+                    NumberSelector(
+                        NumberSelectorConfig(min=16, max=96, step=1, mode=NumberSelectorMode.BOX)
+                    ),
+                    vol.Coerce(int),
                 ),
-                vol.Required("action", default="continue"): vol.In(_ACTION_CHOICES),
+                vol.Required("action", default="continue"): vol.In(_RULER_ACTION_CHOICES),
             }
         )
         if user_input is not None:

--- a/custom_components/escpos_printer/strings.json
+++ b/custom_components/escpos_printer/strings.json
@@ -332,7 +332,7 @@
       "invalid_profile": "Invalid printer profile name.",
       "invalid_codepage": "Invalid codepage/encoding.",
       "invalid_line_width": "Invalid line width. Must be a positive number.",
-      "line_width_out_of_range": "Enter the marker number you can read (16–96), or 0 to skip.",
+      "line_width_missing": "Enter the character count from the first line (16–96), or choose \"Skip this step\".",
       "bt_status_interval_too_low": "Status check interval must be 0 (disabled) or at least 60 seconds for Bluetooth printers.",
       "calibration_print_failed": "Printing the test page failed. Check the printer and try again."
     },
@@ -410,9 +410,9 @@
       },
       "calibrate_ruler": {
         "title": "Calibrate: characters per line",
-        "description": "Your printer just printed a ruler line of dots with the numbers 10, 20, 30... embedded in it, followed by one or two leftover lines you can ignore. Look at the FIRST printed line only: find the last complete number on it, then add 1 for every dot printed after that number. Example: if the line ends with \"40..\", enter 42. Enter 0 if you're not sure.",
+        "description": "Your printer just printed a ruler line of dots with the numbers 10, 20, 30... embedded in it, followed by one or two leftover lines you can ignore. Look at the FIRST printed line only: find the last complete number on it, then add 1 for every dot printed after that number. Example: if the line ends with \"40..\", enter 42. If you're not sure, choose \"Skip this step\".",
         "data": {
-          "last_marker": "Characters on the first line (0 = don't know / skip)",
+          "last_marker": "Characters on the first line",
           "action": "Action"
         }
       },

--- a/custom_components/escpos_printer/translations/en.json
+++ b/custom_components/escpos_printer/translations/en.json
@@ -332,7 +332,7 @@
       "invalid_profile": "Invalid printer profile name.",
       "invalid_codepage": "Invalid codepage/encoding.",
       "invalid_line_width": "Invalid line width. Must be a positive number.",
-      "line_width_out_of_range": "Enter the marker number you can read (16–96), or 0 to skip.",
+      "line_width_missing": "Enter the character count from the first line (16–96), or choose \"Skip this step\".",
       "bt_status_interval_too_low": "Status check interval must be 0 (disabled) or at least 60 seconds for Bluetooth printers.",
       "calibration_print_failed": "Printing the test page failed. Check the printer and try again."
     },
@@ -410,9 +410,9 @@
       },
       "calibrate_ruler": {
         "title": "Calibrate: characters per line",
-        "description": "Your printer just printed a ruler line of dots with the numbers 10, 20, 30... embedded in it, followed by one or two leftover lines you can ignore. Look at the FIRST printed line only: find the last complete number on it, then add 1 for every dot printed after that number. Example: if the line ends with \"40..\", enter 42. Enter 0 if you're not sure.",
+        "description": "Your printer just printed a ruler line of dots with the numbers 10, 20, 30... embedded in it, followed by one or two leftover lines you can ignore. Look at the FIRST printed line only: find the last complete number on it, then add 1 for every dot printed after that number. Example: if the line ends with \"40..\", enter 42. If you're not sure, choose \"Skip this step\".",
         "data": {
-          "last_marker": "Characters on the first line (0 = don't know / skip)",
+          "last_marker": "Characters on the first line",
           "action": "Action"
         }
       },

--- a/tests/test_calibration_flow.py
+++ b/tests/test_calibration_flow.py
@@ -9,7 +9,9 @@ from unittest.mock import AsyncMock, MagicMock
 from homeassistant.components import persistent_notification as pn
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PORT
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+import voluptuous as vol
 
 from custom_components.escpos_printer._config_flow.calibration import CODEPAGE_CANDIDATES
 from custom_components.escpos_printer.capabilities.loader import _get_capabilities
@@ -470,12 +472,15 @@ async def _advance_to_ruler(hass, entry):  # type: ignore[no-untyped-def]
     )
 
 
-async def _advance_to_codepage(hass, entry, *, last_marker: int = 0):  # type: ignore[no-untyped-def]
+async def _advance_to_codepage(hass, entry, *, last_marker: int | None = None):  # type: ignore[no-untyped-def]
     """Hop through impl + width + ruler to land on the codepage step."""
     result = await _advance_to_ruler(hass, entry)
-    return await hass.config_entries.options.async_configure(
-        result["flow_id"], {"last_marker": last_marker, "action": "continue"}
+    payload = (
+        {"action": "skip"}
+        if last_marker is None
+        else {"last_marker": last_marker, "action": "continue"}
     )
+    return await hass.config_entries.options.async_configure(result["flow_id"], payload)
 
 
 async def test_ruler_step_prints_once_and_shows_form(hass):  # type: ignore[no-untyped-def]
@@ -505,7 +510,7 @@ async def test_ruler_reprint_reprints_and_reshows_same_step(hass):  # type: igno
     before = adapter.print_text.await_count
 
     result2 = await hass.config_entries.options.async_configure(
-        result["flow_id"], {"last_marker": 0, "action": "reprint"}
+        result["flow_id"], {"action": "reprint"}
     )
 
     assert result2["type"] == "form"
@@ -545,14 +550,14 @@ async def test_ruler_marker_stores_line_width_and_advances_to_codepage(hass):  #
     assert flow._calib["line_width"] == 48
 
 
-async def test_ruler_zero_skips_storing_and_advances(hass):  # type: ignore[no-untyped-def]
-    """0 (don't know / skip) leaves line_width unset but still advances."""
+async def test_ruler_skip_action_skips_storing_and_advances(hass):  # type: ignore[no-untyped-def]
+    """The explicit skip action leaves line_width unset but still advances."""
     entry, _adapter = _make_entry(hass)
     result = await _advance_to_ruler(hass, entry)
     flow = hass.config_entries.options._progress[result["flow_id"]]
 
     result2 = await hass.config_entries.options.async_configure(
-        result["flow_id"], {"last_marker": 0, "action": "continue"}
+        result["flow_id"], {"action": "skip"}
     )
 
     assert result2["type"] == "form"
@@ -560,22 +565,30 @@ async def test_ruler_zero_skips_storing_and_advances(hass):  # type: ignore[no-u
     assert "line_width" not in flow._calib
 
 
-async def test_ruler_low_value_shows_line_width_out_of_range_error(hass):  # type: ignore[no-untyped-def]
-    """1-15 is a positive number the user DID enter -- reject it with its own error key.
-
-    ``invalid_line_width`` ("Must be a positive number") is wrong here:
-    8 IS a positive number, it's just below the wizard's usable range.
-    """
+async def test_ruler_continue_without_marker_shows_missing_error(hass):  # type: ignore[no-untyped-def]
+    """Continue with an empty count is ambiguous -- demand a value or an explicit skip."""
     entry, _adapter = _make_entry(hass)
     result = await _advance_to_ruler(hass, entry)
 
     result2 = await hass.config_entries.options.async_configure(
-        result["flow_id"], {"last_marker": 8, "action": "continue"}
+        result["flow_id"], {"action": "continue"}
     )
 
     assert result2["type"] == "form"
     assert result2["step_id"] == "calibrate_ruler"
-    assert result2["errors"]["base"] == "line_width_out_of_range"
+    assert result2["errors"]["base"] == "line_width_missing"
+
+
+async def test_ruler_low_value_rejected_by_schema(hass):  # type: ignore[no-untyped-def]
+    """1-15 is below the narrowest plausible printer width -- the
+    NumberSelector's min=16 rejects it at schema level."""
+    entry, _adapter = _make_entry(hass)
+    result = await _advance_to_ruler(hass, entry)
+
+    with pytest.raises(vol.Invalid):
+        await hass.config_entries.options.async_configure(
+            result["flow_id"], {"last_marker": 8, "action": "continue"}
+        )
 
 
 async def test_codepage_step_prints_one_line_per_candidate_with_encoding(hass, monkeypatch):  # type: ignore[no-untyped-def]
@@ -719,7 +732,7 @@ async def test_codepage_step_skipped_when_profile_supports_none_of_the_candidate
     prints_before = adapter.print_text.await_count
 
     result2 = await hass.config_entries.options.async_configure(
-        result["flow_id"], {"last_marker": 0, "action": "continue"}
+        result["flow_id"], {"action": "skip"}
     )
 
     assert result2["type"] == "form"
@@ -836,7 +849,7 @@ async def test_save_with_nothing_measured_creates_no_notification(hass):  # type
         result["flow_id"], {"impls_clean": [], "action": "continue"}
     )
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], {"last_marker": 0, "action": "continue"}
+        result["flow_id"], {"action": "skip"}
     )
     assert result["step_id"] == "calibrate_codepage"
     result = await hass.config_entries.options.async_configure(


### PR DESCRIPTION
## What

The calibration wizard's "characters per line" step (3/4) rendered its input as a 0–96 slider. That was an accident of `vol.Range(min, max)` — the HA frontend auto-renders bounded voluptuous numbers as sliders — not a deliberate choice, and it was the wrong control: the user has just counted an exact number off the printed ruler and wants to type it, not drag to it.

## Changes

- **`last_marker` is now a BOX-mode `NumberSelector`** bounded to 16–96 (the plausible printer-width range), rendering as a typed number field — consistent with the custom line width entry added in #141.
- **Skipping is an explicit "Skip this step" action**, matching the codepage step (4/4), instead of the magic value 0. The number field now only ever holds a real measurement.
- **Continue with an empty count shows a `line_width_missing` error** ("enter the count or choose Skip") instead of silently skipping — choosing Continue with nothing entered is ambiguous.
- Values 1–15 are now rejected at schema level by the selector's `min=16` (previously a backend check with its own error key, now removed along with its `line_width_out_of_range` string).
- Updated step description/labels in `strings.json` + `translations/en.json`, tests, and CHANGELOG.

## Testing

- `uv run pytest -q` — 1319 passed
- `uv run ruff check .` / `uv run mypy custom_components/` — clean
- Ruler-step tests updated: skip action leaves `line_width` unset, empty-count Continue errors, 1–15 raises at schema level, reprint still preserves an entered count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)