### PR TITLE
Add a ruff format gate to CI and reformat files that slipped past it

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -69,6 +69,12 @@ jobs:
       - name: Lint (ruff)
         run: ruff check .
 
+      # CI-L2: mirror the pre-commit ruff-format hook in CI. Without this
+      # gate, code merged without local hooks (GitHub web merges, cloud
+      # agents, forks) can land unformatted — as happened in #139.
+      - name: Format check (ruff)
+        run: ruff format --check .
+
       - name: Type check (mypy)
         run: mypy custom_components/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,8 +37,11 @@ repos:
         files: ^blueprints/.*\.md$
         pass_filenames: false
 
+  # Keep this rev in lockstep with the ruff pin in pyproject.toml — the
+  # CI format gate runs the pyproject-pinned ruff, so a version skew here
+  # can locally format code in a way CI then rejects.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.13
+    rev: v0.16.2
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/custom_components/escpos_printer/_config_flow/bluetooth_helpers.py
+++ b/custom_components/escpos_printer/_config_flow/bluetooth_helpers.py
@@ -169,7 +169,9 @@ def _build_bt_device_choices(
     Always offers a manual-entry fallback so users without bluez D-Bus
     access can still configure paired devices.
     """
-    candidates = [d for d in devices if _is_printer_candidate(d)] if printers_only else list(devices)
+    candidates = (
+        [d for d in devices if _is_printer_candidate(d)] if printers_only else list(devices)
+    )
     choices: dict[str, str] = {d["_choice_key"]: d["label"] for d in candidates}
     # Surface "Show all" only when the printer filter is on AND there's
     # something the user can't currently see (avoids redundant choice when no

--- a/custom_components/escpos_printer/_config_flow/bluetooth_steps.py
+++ b/custom_components/escpos_printer/_config_flow/bluetooth_steps.py
@@ -163,9 +163,7 @@ class BluetoothFlowMixin:
         # would yield zero entries we transparently disable it — handles
         # printers that advertise neither signal.
         printers_only = not self._show_all_bt_devices
-        if printers_only and not any(
-            _is_printer_candidate(d) for d in self._paired_bt_devices
-        ):
+        if printers_only and not any(_is_printer_candidate(d) for d in self._paired_bt_devices):
             printers_only = False
         device_choices = _build_bt_device_choices(
             self._paired_bt_devices, printers_only=printers_only

--- a/custom_components/escpos_printer/_config_flow/options_flow.py
+++ b/custom_components/escpos_printer/_config_flow/options_flow.py
@@ -334,8 +334,7 @@ class EscposOptionsFlowHandler(CalibrationFlowMixin, config_entries.OptionsFlowW
             vol.Optional(CONF_LINE_WIDTH, default=current_line_width_str): SelectSelector(
                 SelectSelectorConfig(
                     options=[
-                        SelectOptionDict(value=v, label=label)
-                        for v, label in width_choices.items()
+                        SelectOptionDict(value=v, label=label) for v, label in width_choices.items()
                     ],
                     custom_value=True,
                     mode=SelectSelectorMode.DROPDOWN,

--- a/custom_components/escpos_printer/bluez.py
+++ b/custom_components/escpos_printer/bluez.py
@@ -141,9 +141,7 @@ async def list_paired_bluetooth_devices() -> list[dict[str, Any]]:
         )
         uuids_var = device_props.get("UUIDs")
         uuids_value = getattr(uuids_var, "value", None) if uuids_var is not None else None
-        uuids = (
-            [str(u) for u in uuids_value] if isinstance(uuids_value, (list, tuple)) else []
-        )
+        uuids = [str(u) for u in uuids_value] if isinstance(uuids_value, (list, tuple)) else []
         devices.append(
             {
                 "mac": mac,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,13 @@ exclude_dirs = ["tests"]
 line-length = 100
 target-version = "py314"
 
+[tool.ruff.format]
+# ruff 0.16 formats Python code blocks inside Markdown by default. Our
+# .md files (plan docs, test designs, SECURITY.md) carry abridged and
+# pseudo-code snippets that shouldn't be reformatted — keep the
+# formatter (and the CI format gate) scoped to real code.
+exclude = ["*.md"]
+
 [tool.ruff.lint]
 select = [
     "E",      # pycodestyle errors

--- a/tests/test_config_flow_bluetooth.py
+++ b/tests/test_config_flow_bluetooth.py
@@ -493,8 +493,9 @@ class TestSppUuidDetection:
 
     def test_spp_uuid_matches_case_insensitively(self):
         assert has_spp_uuid(["00001101-0000-1000-8000-00805F9B34FB"])
-        assert has_spp_uuid(["0000110b-0000-1000-8000-00805f9b34fb",
-                             "00001101-0000-1000-8000-00805f9b34fb"])
+        assert has_spp_uuid(
+            ["0000110b-0000-1000-8000-00805f9b34fb", "00001101-0000-1000-8000-00805f9b34fb"]
+        )
 
     def test_non_spp_or_empty_lists_rejected(self):
         assert not has_spp_uuid(["0000110b-0000-1000-8000-00805f9b34fb"])  # A2DP sink
@@ -528,12 +529,8 @@ class TestSppUuidDetection:
             },
         }
         with (
-            patch.object(
-                bluez, "_connect_system_bus", AsyncMock(return_value=MagicMock())
-            ),
-            patch.object(
-                bluez, "_get_managed_objects", AsyncMock(return_value=managed)
-            ),
+            patch.object(bluez, "_connect_system_bus", AsyncMock(return_value=MagicMock())),
+            patch.object(bluez, "_get_managed_objects", AsyncMock(return_value=managed)),
         ):
             devices = await bluez.list_paired_bluetooth_devices()
 


### PR DESCRIPTION
## Root cause

`pre-commit run --all-files` locally reformats five bluetooth-related files on main. This is **not** formatter version drift between the hooks and the pin: both agree the files are unformatted. They landed that way because PR #139 was squash-merged on GitHub.com (committer `GitHub <noreply@github.com>`), so local pre-commit hooks never ran on the merged result — and CI runs `ruff check` but had no `ruff format --check` gate to catch it.

## Changes

- Reformat the five files (`bluetooth_helpers.py`, `bluetooth_steps.py`, `options_flow.py`, `bluez.py`, `test_config_flow_bluetooth.py`) — pure formatting, no behavior change; identical output under ruff 0.15 and 0.16.
- Add a `ruff format --check .` step to `validate.yml` next to the existing lint step (commented as CI-L2, mirroring the existing CI-L1 pattern of duplicating pre-commit gates in CI for hook-less commit paths).
- Bump pre-commit's `ruff-pre-commit` rev v0.15.13 → v0.16.2 to match the `ruff==0.16.2` pin in pyproject.toml, with a comment to keep them in lockstep.
- **Exclude `*.md` from `ruff format`** (`tool.ruff.format.exclude`): ruff 0.16 formats Python code blocks inside Markdown by default, which made the new gate fail on 10 doc files (SECURITY.md, plan docs, test designs) whose snippets are deliberately abridged pseudo-code. The formatter and gate stay scoped to real code.

## The initial CI failure on this PR

The first push failed its own format gate — on Markdown files. That exposed a second environment gap: the local venv still carried ruff **0.15.22** (which skips Markdown), stale from before the 0.16.2 bump, so the pre-push "196 files clean" verification wasn't run with the pinned version. After `uv sync --all-extras` → real 0.16.2: only Markdown differed; no Python file is formatted differently between the two versions.

## Verification (ruff 0.16.2, synced venv)

- `uv run ruff format --check .` — 196 files clean
- `uv run ruff check .` — pass; `uv run mypy custom_components/` — clean
- `pre-commit run ruff-format` / `ruff-check` `--all-files` at rev v0.16.2 — pass
- `uv run pytest -q` — 1319 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
