### PR TITLE
Fix Rongta RP820 codepages and redesign width calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- The encoding calibration step no longer offers ISO-8859-1 when no
+  printer profile is configured (or the configured name is unknown). In
+  those cases the printer runs python-escpos's default profile, which
+  cannot switch to ISO-8859-1: the sample line silently printed under the
+  previous line's codepage, looked correct on paper, and the stored
+  codepage then failed on every later print. Candidates are now filtered
+  against the profile the printer actually runs with.
 - The width-bars calibration step no longer reports "Printing the test
   page failed" on printers whose profile declares a pixel width.
   python-escpos refuses to send images wider than the profile's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   before draining the previous one could print the fragments out of
   order (seen on TM-T20II: TEST 1/3/2 labels shuffled, garbled pattern
   rows, and the trailing feed landing mid-page).
+- The width calibration step now asks the user to spot an intact
+  right-side border on the widest of several labeled boxes, instead of
+  comparing two bars' lengths by eye. The old length-comparison judgment
+  misread a real printer (512px vs. its true 576px, an 11% difference) on
+  faint thermal ink, storing a too-narrow width. Labels now print as a
+  separate text line above each box rather than baked into the image, and
+  the candidate widths gained a finer step (384, 512, 546, 576, 640, 832
+  — 546 covers the Epson 42-column-mode width class).
 - The "Characters per line" field in setup and options is now a combobox:
   pick a preset or type a custom number directly. Previously a
   "Custom (enter columns)..." choice promised an entry box that only
   appeared on a follow-up screen after submitting, which read as "no box
   to enter a value". The legacy two-step path still works.
+- Rongta RP850P/RP820 printers (the network identity RP850P hardware
+  announces) now use a built-in `RP820` profile with the firmware's
+  real Epson-style codepage numbering, and are recognized as a
+  compatible model so discovered Rongta printers preselect it. They
+  were previously aliased to the bundled `NT-80-V-UL` profile, whose
+  codepage table used non-standard ESC t values that don't exist in
+  this firmware, garbling every calibration codepage except CP850.
+  The new profile declares the hardware-probed 48-column DIP (SW-5)
+  geometry — 576px raster width, 48/64 text columns — and documents
+  that the 42-column position switches the whole geometry to
+  512px/42/56; recalibrate after flipping the switch.
+- Every bundled profile's codepage table is now deduped at runtime: some
+  profiles map a codepage name to both a low index and a duplicate index
+  >= 48, and since python-escpos always emits the last-registered index,
+  affected printers got the >= 48 one — unreachable on clone firmware's
+  0-47 ESC t table, garbling that codepage. Only the >= 48 duplicate is
+  dropped (never the low one), so this only ever affects codepage names
+  that had a working low-index duplicate to fall back to; the surviving
+  index isn't guaranteed to be Epson's own standard number for that
+  codepage (e.g. `NT-80-V-UL`'s CP864 dedupes to 28, in-range but not
+  Epson's 37) — only that it now falls inside the range clone firmware
+  actually implements. Codepage names that only ever had a single index
+  >= 48 are unaffected and remain unverified on clone hardware. This
+  fixes garbled non-CP850 codepages on every model aliased to `NT-80-V-UL`
+  (Xprinter XP-80C/XP-N160II/XP-T80A, Sunmi T2) and `POS-5890`/`NT-5890K`
+  (Zjiang ZJ-5890/ZJ-5890K/POS-5890K/ZJ-5802, Xprinter XP-58IIH, HOIN
+  HOP-E58, Goojprt PT-210, Netum NT-1809DD). `NT-80-V-UL`'s Font A/B
+  column counts (previously 12/9, actually glyph dot widths mistakenly
+  entered as columns) are also corrected to 48/64, fixing implausible
+  line-width options on the same models. All three fixes mirror
+  corrections already reported upstream to escpos-printer-db.
 
 ### Added
 
@@ -67,9 +106,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   the matching printer profile when one is known. Discovered entries are
   additionally tracked by MAC address, so a DHCP lease change updates the
   existing entry's host in place instead of offering a duplicate.
-- "Rongta RP820" is recognized as a compatible model (the network identity
-  RP850P hardware announces), so discovered Rongta printers preselect the
-  matching 80mm profile.
 - Network printer entries are now titled by their detected model (e.g.
   "TM-T20II (192.168.1.50:9100)") instead of the bare address. Manual
   renames are still never overwritten when a lease change or reconfigure

--- a/custom_components/escpos_printer/_config_flow/calibration.py
+++ b/custom_components/escpos_printer/_config_flow/calibration.py
@@ -17,7 +17,11 @@ WIDTH_CANDIDATES: tuple[int, ...] = (384, 512, 546, 576, 640, 832)
 IMPL_CANDIDATES: tuple[str, ...] = ("bitImageRaster", "bitImageColumn", "graphics")
 # Capability order, broadest encoding first: the wizard stores the first
 # checked candidate in this order, so ties resolve to the most capable.
-CODEPAGE_CANDIDATES: tuple[str, ...] = ("CP858", "CP1252", "CP850", "ISO_8859-1", "CP437")
+# These are the four most-supported Western codepages across the real
+# printer profiles in escpos-printer-db (CP437 97%, CP1252 82%, CP858
+# 80%, CP850 77% of bundled profiles). ISO_8859-1 was dropped: no
+# bundled profile exposes it, so the profile filter removed it anyway.
+CODEPAGE_CANDIDATES: tuple[str, ...] = ("CP858", "CP1252", "CP850", "CP437")
 CODEPAGE_SAMPLE = "café ñ ü é ß ° €"
 
 _ISSUES_URL = "https://github.com/cognitivegears/ha-escpos-thermal-printer/issues/new"

--- a/custom_components/escpos_printer/_config_flow/calibration.py
+++ b/custom_components/escpos_printer/_config_flow/calibration.py
@@ -11,9 +11,9 @@ import base64
 import io
 from urllib.parse import quote
 
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw
 
-WIDTH_CANDIDATES: tuple[int, ...] = (384, 512, 576, 640, 832)
+WIDTH_CANDIDATES: tuple[int, ...] = (384, 512, 546, 576, 640, 832)
 IMPL_CANDIDATES: tuple[str, ...] = ("bitImageRaster", "bitImageColumn", "graphics")
 # Capability order, broadest encoding first: the wizard stores the first
 # checked candidate in this order, so ties resolve to the most capable.
@@ -41,22 +41,23 @@ def checkerboard_data_uri() -> str:
 
 
 def width_bar_data_uri(width_px: int) -> str:
-    """Outlined rectangle exactly width_px wide, labeled at the LEFT edge.
+    """Outlined rectangle exactly width_px wide, for right-border detection.
 
     An outline (3px border) rather than a solid fill draws a fraction of
     the ink a filled bar would -- kinder to the print head, which matters
-    on battery-powered (Bluetooth) printers -- while keeping the same
-    length-comparison semantics: the right-edge border still clips at the
-    true printable width, so bars at or beyond that width still end up
-    identical length.
+    on battery-powered (Bluetooth) printers. No label inside the box (the
+    candidate width is printed as a text line above it, see
+    ``_print_width_bars``): the judgment this box exists for is "does the
+    right-side border print intact?", not a length comparison between two
+    near-equal bars -- comparing 512 vs 576 (an 11% difference) by eye on
+    faint thermal ink proved unreliable on real hardware. A too-wide box
+    loses its
+    border on both clip firmware (truncated) and wrap firmware (shed into
+    garbled fragments on the next line) -- either way, no intact border.
     """
-    img = Image.new("1", (width_px, 44), 1)
+    img = Image.new("1", (width_px, 24), 1)
     draw = ImageDraw.Draw(img)
-    draw.rectangle((0, 0, width_px - 1, 43), outline=0, width=3)
-    # PIL's bitmap default font is ~11px (~1.4mm at 203dpi) — unreadable
-    # on paper. Pillow >=10.1 ships a scalable default; 30px is ~3.8mm.
-    font = ImageFont.load_default(size=30)
-    draw.text((8, 6), str(width_px), fill=0, font=font)
+    draw.rectangle((0, 0, width_px - 1, 23), outline=0, width=3)
     return _png_data_uri(img)
 
 

--- a/custom_components/escpos_printer/_config_flow/calibration_steps.py
+++ b/custom_components/escpos_printer/_config_flow/calibration_steps.py
@@ -67,11 +67,11 @@ _IMPL_LABELS = {
 _ACTION_CHOICES = {"continue": "Continue", "reprint": "Reprint the test page"}
 _RULER_ACTION_CHOICES = _ACTION_CHOICES | {"skip": "Skip this step"}
 _CONFIRM_ACTION_CHOICES = {"start": "Start calibration", "cancel": "Cancel"}
-# Derived from WIDTH_CANDIDATES so the bar numbers/labels can't drift out
-# of sync with what _print_width_bars actually prints.
-_WIDTH_CHOICES: dict[str, str] = {
-    str(w): f"Bar {i} ({w})" for i, w in enumerate(WIDTH_CANDIDATES, start=1)
-} | {"none": "Not sure / bars unclear"}
+# Derived from WIDTH_CANDIDATES so the choices can't drift out of sync
+# with what _print_width_bars actually prints.
+_WIDTH_CHOICES: dict[str, str] = {str(w): f"{w} px" for w in WIDTH_CANDIDATES} | {
+    "none": "None had an intact right edge"
+}
 _CODEPAGE_ACTION_CHOICES = {
     "continue": "Continue",
     "reprint": "Reprint the test lines",
@@ -277,43 +277,49 @@ class CalibrationFlowMixin:
         )
 
     async def _print_width_bars(self, adapter: Any) -> bool:
-        """Print one bar per candidate width, using the impl chosen so far.
+        """Print a labeled box per candidate width, using the impl chosen so far.
 
-        Bars wider than the printer's true width are the measurement —
-        the hardware clips them to the same length. That requires
-        ``ignore_profile_width``: python-escpos otherwise refuses any
-        image wider than the profile's declared ``media.width.pixels``
-        (``ImageWidthError``), which both broke the step on printers
-        with a declared width (seen on TM-T20II @ 576: bars 640/832
-        aborted the page) and made an under-declared profile width
-        impossible to detect. Each bar is still attempted independently
-        so a printer rejecting one bar can't abort the rest. Returns
-        True if at least one bar printed.
+        Boxes wider than the printer's true width are the measurement —
+        the hardware either clips or wraps them, losing the right-side
+        border either way. That requires ``ignore_profile_width``:
+        python-escpos otherwise refuses any image wider than the
+        profile's declared ``media.width.pixels`` (``ImageWidthError``),
+        which both broke the step on printers with a declared width
+        (seen on TM-T20II @ 576: bars 640/832 aborted the page) and made
+        an under-declared profile width impossible to detect. The width
+        number is a separate text line above each box (not baked into
+        the image) so the reader's only job is spotting an intact border,
+        not reading two things at once. Each candidate is still attempted
+        independently so a printer rejecting one can't abort the rest.
+        Returns True if at least one candidate printed.
         """
         impl = self._calib.get("impl") or getattr(adapter, "default_impl", None) or DEFAULT_IMPL
         any_ok = False
         async with adapter.batch_connection(self.hass) as page:
             await self._print_step_header(
-                page, "CALIBRATE 2/4: WIDTH BARS", "First bar equal to bottom?"
+                page, "CALIBRATE 2/4: WIDTH BOXES", "Widest box with right edge?"
             )
             for w in WIDTH_CANDIDATES:
                 try:
+                    await page.print_text(text=f"{w}:\n", feed=0)
                     # width=w beats a narrower profile/opts width in the image
                     # pipeline (process_image only ever downscales, never
-                    # upscales), so each bar prints at its true pixel width
-                    # instead of all four being clamped to the same width.
+                    # upscales), so each box prints at its true pixel width
+                    # instead of all of them being clamped to the same width.
+                    # feed=2 (vs. the usual 1) keeps each label+box grouped
+                    # and visibly separated from the next one.
                     await page.print_image(
                         image=width_bar_data_uri(w),
                         impl=impl,
                         width=w,
-                        feed=1,
+                        feed=2,
                         auto_resize=False,
                         ignore_profile_width=True,
                     )
                     any_ok = True
                 except Exception as err:
                     _LOGGER.warning(
-                        "Calibration width bar %d failed to print: %s",
+                        "Calibration width box %d failed to print: %s",
                         w,
                         sanitize_log_message(str(err)),
                     )

--- a/custom_components/escpos_printer/_config_flow/calibration_steps.py
+++ b/custom_components/escpos_printer/_config_flow/calibration_steps.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.selector import (
 )
 import voluptuous as vol
 
-from ..capabilities import get_profile_codepages
+from ..capabilities import get_profile_codepages, resolve_profile_name
 from ..const import (
     CONF_CODEPAGE,
     CONF_DETECTED_MODEL,
@@ -427,21 +427,27 @@ class CalibrationFlowMixin:
         )
 
     async def _get_codepage_candidates(self) -> tuple[str, ...]:
-        """Codepage candidates the configured profile can actually switch to.
+        """Codepage candidates the *active* escpos profile can switch to.
 
-        ``get_profile_codepages`` already falls back to the common
-        codepage list (a superset of every candidate here) when no
-        profile is configured or the profile's own list is unknown, so
-        intersecting is enough -- no separate "no profile" branch needed.
+        With no profile configured (or an unresolvable name), the printer
+        object runs python-escpos's **default** profile, so candidates are
+        filtered against that -- NOT the static ``COMMON_CODEPAGES`` list
+        ``get_profile_codepages`` returns for those cases. That list
+        includes ISO_8859-1, which the default profile cannot switch to:
+        ``charcode()`` fails (silently, by design), the sample prints
+        under the *previous* line's codepage, looks correct on paper, and
+        the stored codepage then silently fails on every later print.
         Deliberately NO fallback to the full candidate tuple when the
-        intersection is empty: that fallback is exactly the
-        false-verification bug (a candidate printing under a codepage the
-        profile can't switch to) this narrowing exists to prevent.
+        intersection is empty either, for the same reason: every printed
+        line must be one the active profile can genuinely switch to.
         """
         profile = self.config_entry.options.get(
             CONF_PROFILE, self.config_entry.data.get(CONF_PROFILE)
         )
-        profile_codepages = await self.hass.async_add_executor_job(get_profile_codepages, profile)
+        resolved = await self.hass.async_add_executor_job(resolve_profile_name, profile)
+        profile_codepages = await self.hass.async_add_executor_job(
+            get_profile_codepages, resolved or "default"
+        )
         return tuple(cp for cp in CODEPAGE_CANDIDATES if cp in profile_codepages)
 
     async def _print_codepage_candidates(

--- a/custom_components/escpos_printer/capabilities/__init__.py
+++ b/custom_components/escpos_printer/capabilities/__init__.py
@@ -21,6 +21,7 @@ from .constants import (
     PROFILE_AUTO,
     PROFILE_CUSTOM,
 )
+from .custom_profiles import register_custom_profiles
 from .features import (
     get_profile_cut_modes,
     get_profile_features,
@@ -38,6 +39,16 @@ from .profiles import (
     resolve_profile_name,
 )
 from .suggestions import suggest_profile
+
+# Register hardware-verified profiles that aren't in escpos-printer-db yet.
+# Runs at import time (rather than lazily on first capabilities lookup) so
+# it's guaranteed to happen before *every* consumer: this package is always
+# imported by the integration's top-level ``__init__.py`` before
+# ``async_setup_entry`` runs, and before ``printer/base_adapter.py`` (which
+# calls ``escpos.capabilities.get_profile()`` directly, bypassing our own
+# loader) can be reached -- Python always finishes initializing a parent
+# package before any of its submodules execute.
+register_custom_profiles()
 
 __all__ = [
     "COMMON_CODEPAGES",
@@ -64,6 +75,7 @@ __all__ = [
     "pick_impl",
     "profile_declares_no_images",
     "profile_supports_feature",
+    "register_custom_profiles",
     "resolve_alias",
     "resolve_profile_name",
     "suggest_profile",

--- a/custom_components/escpos_printer/capabilities/aliases.py
+++ b/custom_components/escpos_printer/capabilities/aliases.py
@@ -1,9 +1,13 @@
-"""Clone/equivalent-model aliases onto bundled escpos-printer-db profiles.
+"""Clone/equivalent-model aliases onto known printer profiles.
 
 Aliases route rebadged or near-equivalent hardware to an existing
-bundled profile. They only ever improve defaults (width, codepages) —
-they never gate behavior. Genuinely new hardware belongs upstream in
-escpos-printer-db, not here.
+profile — almost always a bundled escpos-printer-db one, but occasionally
+an integration-registered profile (see custom_profiles.py) when no bundled
+profile's codepage table matches the hardware. They only ever improve
+defaults (width, codepages) — they never gate behavior. Genuinely new
+hardware belongs upstream in escpos-printer-db first; a custom profile is
+the fallback only when upstream can't represent it (e.g. non-standard
+codepage numbering).
 
 Researched-but-held models (deliberately absent — conflicting or
 unverified specs, or a widthless alias target): TM-m10/m30, TM-T70/T70II,
@@ -55,18 +59,38 @@ ALIAS_MODELS: dict[str, str] = {
     "Xprinter XP-N160II": "NT-80-V-UL",
     "Xprinter XP-T80A": "NT-80-V-UL",
     # Rongta RP850P: hardware-verified on a real unit (self-test: 640-dot
-    # head, GD207_v1.16 firmware). Raster width follows the DIP column-mode
-    # switch (SW-5): 576 dots in 48-column mode (the default this alias
-    # assumes), 512 dots in 42-column/TM-T88-compat mode — recalibrate or
-    # set a width override after changing the switch. Over-width raster
-    # WRAPS onto extra lines rather than clipping on this firmware. NOT
-    # aliased to RP326 because that bundled profile declares no pixel width.
-    "Rongta RP850P": "NT-80-V-UL",
-    # "RP820" is the DHCP hostname (Rongta_RP820) that RP850P hardware
+    # head, GD207_v1.16 firmware). Raster width AND text columns follow
+    # the DIP column-mode switch (SW-5): 576 dots / 48 columns in the
+    # 48-column position, 512 dots / 42 columns in the 42-column position
+    # (both modes probed on hardware 2026-08-13) — recalibrate after
+    # flipping the switch. Over-width raster WRAPS onto extra lines rather
+    # than clipping on this firmware. NOT aliased to RP326 because that
+    # bundled profile declares no pixel width.
+    #
+    # Points at the custom "RP820" profile (registered in
+    # custom_profiles.py), not a bundled escpos-printer-db profile.
+    # It was previously aliased to NT-80-V-UL, but that profile's
+    # codePages table sent ESC t 52/71/53 for CP437/CP1252/CP858, values
+    # that don't exist in this firmware's 0-47 table, so every codepage
+    # but CP850 printed garbage on real hardware -- the firmware actually
+    # follows Epson's standard numbering (0/2/16/19 for the same four
+    # codepages, hardware-verified 2026-08-13 via the HA calibration
+    # wizard). custom_profiles.py now dedupes NT-80-V-UL's >=48 duplicate
+    # indices at runtime too, so it *also* sends 0/2/16/19 for these four.
+    # RP820 still earns its own profile: NT-80-V-UL's ~31 codepage names
+    # that only ever had a single index >= 48 (e.g. CP1250, CP775) remain
+    # unreachable on clone firmware, while RP820's full Epson table (copied
+    # from TM-T20II) covers them at their real low indices; RP820 also
+    # carries hardware-verified per-DIP-mode geometry (576px/48 cols in
+    # the 48-column SW-5 position, 512px/42 cols in the 42-column one)
+    # and graphics=False that NT-80-V-UL has no data for.
+    #
+    # "RP820" is also the DHCP hostname (Rongta_RP820) that RP850P hardware
     # announces on the network — observed on the hardware-verified unit
-    # above, so it inherits the same alias target. Covers DHCP-discovery
-    # identity, and any actual RP820 units sharing that network firmware.
-    "Rongta RP820": "NT-80-V-UL",
+    # above. No separate "Rongta RP820" alias entry is needed: RP820 is now
+    # a real profile key, so it already appears in the dropdown and
+    # resolves directly without going through the alias table.
+    "Rongta RP850P": "RP820",
     # Misc verified 58mm/384dot ESC/POS clones.
     "HOIN HOP-E58": "POS-5890",
     "Goojprt PT-210": "POS-5890",

--- a/custom_components/escpos_printer/capabilities/custom_profiles.py
+++ b/custom_components/escpos_printer/capabilities/custom_profiles.py
@@ -1,0 +1,164 @@
+"""Register/patch printer profiles that escpos-printer-db gets wrong or lacks.
+
+Unlike ``aliases.py`` (which points a display name at an *existing* bundled
+profile), this module either builds a genuinely new profile dict (RP820) or
+corrects data in place (the clone-firmware codePages dedupe below, and
+NT-80-V-UL's font columns) inside
+``escpos.capabilities.CAPABILITIES["profiles"]`` so the fix applies
+everywhere: the config-flow dropdown, the calibration codepage filter, and
+the printer constructors (all of which resolve profile names through that
+dict, either via our own loader or directly through
+``escpos.capabilities.get_profile()``).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+# Clone firmware (the whole reason these profiles get aliased to) only ever
+# implements the standard Epson 0-47 ESC t table; indices at or above this
+# are Epson's *extended* table, absent on clones.
+_CLONE_TABLE_LIMIT = 48
+
+
+def _dedupe_clone_codepages(profiles: dict[str, Any]) -> None:
+    """Drop unreachable-on-clones duplicate codePages indices, in place.
+
+    Several bundled profiles map one codepage name to two indices: a
+    standard one and a duplicate >= 48 (escpos-printer-db's data entry
+    bug, also reported upstream). ``BaseProfile.get_code_pages()`` inverts
+    the dict last-wins, so python-escpos always emits whichever index
+    comes last in iteration order -- on affected profiles that's the >=48
+    duplicate, which doesn't exist in clone firmware's 0-47 table and
+    garbles that codepage.
+
+    Rule: for a name with multiple indices, drop the ones >= 48 *only if*
+    a < 48 index also exists for that name. This is NOT the same as
+    "lowest index always wins" -- some profiles (e.g. CT-S651) legitimately
+    put their real, working index at 16 while a stale/inactive duplicate
+    sits at 9; unconditionally keeping the lowest would regress those.
+    Restricting the drop to the >=48 range only touches indices clone
+    firmware can't reach anyway. "Unknown" placeholder entries are left
+    untouched -- they're filtered out downstream (codepages.py) regardless
+    of which index survives, so deduping them buys nothing and would make
+    profiles with no *real* affected codepage (e.g. CT-S651) look changed.
+    """
+    for profile in profiles.values():
+        code_pages: dict[str, str] = profile.get("codePages", {})
+        indices_by_name: dict[str, list[int]] = {}
+        for index_str, name in code_pages.items():
+            if name == "Unknown":
+                continue
+            indices_by_name.setdefault(name, []).append(int(index_str))
+        for indices in indices_by_name.values():
+            low = [i for i in indices if i < _CLONE_TABLE_LIMIT]
+            high = [i for i in indices if i >= _CLONE_TABLE_LIMIT]
+            if low and high:
+                for index in high:
+                    del code_pages[str(index)]
+
+
+def _patch_nt80vul_fonts(profiles: dict[str, Any]) -> None:
+    """Correct NT-80-V-UL's font column counts, in place.
+
+    fonts.columns holds glyph DOT widths (12, 9) mistakenly entered as
+    column counts -- implausible for this 576px/80mm profile. Correct
+    values: 576/12 = 48, 576/9 = 64 (also reported upstream to
+    escpos-printer-db; drop this patch once the bundled DB ships fixed
+    data). Guarded so a second call is a no-op.
+    """
+    profile = profiles.get("NT-80-V-UL")
+    if profile is None:
+        return
+    fonts = profile.get("fonts", {})
+    if fonts.get("0", {}).get("columns") == 12:
+        fonts["0"]["columns"] = 48
+    if fonts.get("1", {}).get("columns") == 9:
+        fonts["1"]["columns"] = 64
+
+
+def register_custom_profiles() -> None:
+    """Insert/patch our custom profiles in escpos's profile registry.
+
+    Idempotent: the codePages/font patches no-op once already applied, and
+    registering RP820 is a no-op once already registered rather than
+    rebinding a fresh dict -- escpos's ``get_profile_class`` caches the
+    profile *class* keyed by name on first lookup, built from whichever
+    dict was registered at that time, so a later call replacing the dict
+    would leave the cached class pointing at stale data. All patching runs
+    inside one broad try/except: a malformed bundled profile (e.g. a
+    non-numeric codePages key) must not crash integration import, mirroring
+    ``loader._get_capabilities()``'s fallback philosophy.
+    """
+    try:
+        from escpos.capabilities import CAPABILITIES  # noqa: PLC0415
+
+        profiles: dict[str, Any] = CAPABILITIES["profiles"]
+
+        _dedupe_clone_codepages(profiles)
+        _patch_nt80vul_fonts(profiles)
+
+        if "RP820" in profiles:
+            return  # already registered; CLASS_CACHE pins the first dict, don't rebind it
+
+        template = profiles.get("TM-T20II")
+        if template is None:
+            # Degraded python-escpos install (e.g. its BrokenDefault
+            # fallback, which only has "default") -- nothing to copy from.
+            _LOGGER.warning("TM-T20II profile not found, skipping RP820 registration")
+            return
+
+        # RP820: the Rongta RP850P announces itself on the network as
+        # "RP820" (DHCP hostname Rongta_RP820, firmware GD207_v1.16). It
+        # was previously aliased to the bundled NT-80-V-UL profile; even
+        # after the codePages dedupe above, NT-80-V-UL still can't fully
+        # replace this profile -- about 31 of its codepage names (CP1250,
+        # CP1253, CP720, CP775, ...) only ever had a single index >= 48,
+        # so they stay unreachable on clone firmware, whereas RP820's full
+        # Epson table (copied from TM-T20II) covers them at their real
+        # low indices. RP820 also carries hardware measurements NT-80-V-UL
+        # doesn't have: per-DIP-mode geometry (below) and graphics=False.
+        # This profile is a deep copy of the bundled TM-T20II profile
+        # (same codePages/encodings) with media/fonts/features overridden
+        # to match those measurements.
+        #
+        # Hardware-verified 2026-08-13 on a real RP850P unit: BOTH
+        # geometries exist and follow the SW-5 column-mode DIP switch --
+        # 48-column position: 576px raster / 48 text columns; 42-column
+        # position: 512px raster / 42 text columns (each confirmed by a
+        # fine-grained right-edge probe plus a text-column ruler in the
+        # respective mode). All four calibration codepages
+        # (CP858/CP1252/CP850/CP437) render correctly,
+        # bitImageRaster/bitImageColumn print cleanly, graphics (GS ( L)
+        # does not.
+        rp820 = copy.deepcopy(template)
+        rp820["name"] = "RP820"
+        rp820["vendor"] = "Rongta"
+        rp820["notes"] = (
+            "Hardware-verified via the HA calibration wizard on a Rongta RP850P "
+            "unit (firmware GD207_v1.16, which announces DHCP hostname "
+            "Rongta_RP820). Defaults describe the 48-column SW-5 DIP position "
+            "(576px/48 cols); the 42-column position is 512px/42 cols -- "
+            "recalibrate after flipping the switch."
+        )
+        rp820["media"] = {"dpi": 203, "width": {"mm": 72, "pixels": 576}}
+        rp820["features"] = {**rp820["features"], "graphics": False}
+        # Defaults are the 48-column SW-5 position. media/fonts happen to
+        # be value-identical to the TM-T20II template today, but they are
+        # kept as explicit assignments on purpose: these numbers are our
+        # own hardware measurements, not inheritances, and pinning them
+        # means an upstream edit to TM-T20II's geometry can't silently
+        # change RP820's. The 42-column position is 512px raster with
+        # Font A 42 / Font B 56; users who flip SW-5 should recalibrate
+        # (a calibration override wins over the profile default anyway).
+        rp820["fonts"] = {
+            "0": {"name": "Font A", "columns": 48},
+            "1": {"name": "Font B", "columns": 64},
+        }
+        profiles["RP820"] = rp820
+    except Exception:  # mirror loader._get_capabilities's broad fallback
+        _LOGGER.warning("Failed to register/patch custom printer profiles", exc_info=True)

--- a/custom_components/escpos_printer/capabilities/line_widths.py
+++ b/custom_components/escpos_printer/capabilities/line_widths.py
@@ -9,10 +9,13 @@ from .loader import _get_capabilities
 
 _LOGGER = logging.getLogger(__name__)
 
-# A receipt printer never has fewer than 16 characters per line. Guards
-# against upstream escpos-printer-db data bugs like NT-80-V-UL, whose
-# fonts.columns values (9, 12) are actually font DOT widths mistakenly
-# encoded as column counts (correct values: 48 and 64 on that profile).
+# A receipt printer never has fewer than 16 characters per line. General
+# defensive floor against upstream escpos-printer-db data bugs where
+# fonts.columns holds a font's glyph DOT width instead of a column count
+# (implausibly small for any receipt printer) -- e.g. NT-80-V-UL shipped
+# 9/12 instead of 48/64 this way; that specific case is now corrected at
+# runtime (see custom_profiles.py), but this floor stays as a safety net
+# for any other profile with the same class of bug.
 _MIN_PLAUSIBLE_COLUMNS = 16
 
 

--- a/custom_components/escpos_printer/strings.json
+++ b/custom_components/escpos_printer/strings.json
@@ -402,9 +402,9 @@
       },
       "calibrate_width": {
         "title": "Calibrate: paper width",
-        "description": "Your printer just printed five numbered bars. Bars wider than your printer's true width get cut off at the same length. Counting from the top, pick the first bar that is the SAME length as the bottom bar. If the bars look like staircases rather than clean solid blocks, choose Not sure — your printer wraps rather than clips.",
+        "description": "Your printer just printed a labeled box for each candidate width. A box that's too wide for your printer loses its right-side border — either cut off or wrapped into garbled fragments. Pick the WIDEST box whose right-side border printed as a clean, unbroken line. If none of the boxes has an intact right border, choose \"None had an intact right edge\".",
         "data": {
-          "first_equal": "First bar equal to the bottom bar",
+          "first_equal": "Widest box with an intact right border",
           "action": "Action"
         }
       },

--- a/custom_components/escpos_printer/translations/en.json
+++ b/custom_components/escpos_printer/translations/en.json
@@ -402,9 +402,9 @@
       },
       "calibrate_width": {
         "title": "Calibrate: paper width",
-        "description": "Your printer just printed five numbered bars. Bars wider than your printer's true width get cut off at the same length. Counting from the top, pick the first bar that is the SAME length as the bottom bar. If the bars look like staircases rather than clean solid blocks, choose Not sure — your printer wraps rather than clips.",
+        "description": "Your printer just printed a labeled box for each candidate width. A box that's too wide for your printer loses its right-side border — either cut off or wrapped into garbled fragments. Pick the WIDEST box whose right-side border printed as a clean, unbroken line. If none of the boxes has an intact right border, choose \"None had an intact right edge\".",
         "data": {
-          "first_equal": "First bar equal to the bottom bar",
+          "first_equal": "Widest box with an intact right border",
           "action": "Action"
         }
       },

--- a/docs/calibration.md
+++ b/docs/calibration.md
@@ -57,17 +57,18 @@ characters-per-line step.
 
 ### 2. Paper width (skipped if no pattern printed cleanly in step 1)
 
-The printer prints five numbered bars at 384, 512, 576, 640, and 832
-pixels wide, each labeled at its left edge. Bars wider than your printer's
-true printable width get clipped to the same length as the widest bar
-that fits — so several bars at the bottom of the page will look
-identical. If the bars look like staircases rather than clean solid
-blocks, your printer wraps rather than clips — choose "Not sure" instead.
+The printer prints six outlined boxes at 384, 512, 546, 576, 640, and
+832 pixels wide, each with its width printed as a text line above it. A
+box that fits your printer's true printable width prints complete,
+including its **right-side vertical border**. A box that's too wide
+loses that border — clipped off on some printers, shed onto the next
+line as stray fragments on printers that wrap instead of clipping.
+Either way the reading is the same: no intact right edge.
 
-Counting from the top, pick the **first bar that's the same length as the
-bottom bar**. That bar's labeled width is your printer's true printable
-width. If you can't tell, choose "Not sure / bars unclear" to leave the
-paper width unmeasured.
+Pick the **widest box whose right-side border printed**. That box's
+labeled width is your printer's true printable width. If none of the
+boxes show an intact right edge, choose "None had an intact right edge"
+to leave the paper width unmeasured.
 
 ### 3. Characters per line
 
@@ -155,7 +156,11 @@ must be connected and the config entry loaded):
   ```
 
   If both prints come out the same length, your printer's printable width
-  is 576px; if the 640px print is visibly longer, it's 640px.
+  is 576px; if the 640px print is visibly longer, it's 640px. Length
+  differences this small are easy to misjudge on faint thermal ink — if
+  in doubt, use a test image with a strong border on its right edge and
+  check whether that edge printed instead (the wizard's width step, which
+  you can re-run at any time, works exactly this way).
 
 See [Configuration reference](configuration.md) for setting these values
 by hand, and [Images guide](images.md) for the image-implementation

--- a/tests/test_calibration_flow.py
+++ b/tests/test_calibration_flow.py
@@ -752,7 +752,7 @@ async def test_codepage_candidates_narrowed_to_profile_using_real_capabilities_d
 
 
 async def test_codepage_step_skipped_when_profile_supports_none_of_the_candidates(hass):  # type: ignore[no-untyped-def]
-    """AF-240's real codepage list (OXHOO-EUROPEAN) excludes all five candidates.
+    """AF-240's real codepage list (OXHOO-EUROPEAN) excludes every candidate.
 
     No fallback to the full candidate list here -- that fallback IS the
     false-verification bug (printing a line under a codepage the printer

--- a/tests/test_calibration_flow.py
+++ b/tests/test_calibration_flow.py
@@ -269,18 +269,24 @@ async def test_impl_continue_stores_choice_and_advances_to_width(hass):  # type:
     assert result2["type"] == "form"
     assert result2["step_id"] == "calibrate_width"
 
-    # 3 impl-step prints already happened; width step adds 5 more (one per bar).
-    assert adapter.print_image.await_count == 3 + 5
+    # 3 impl-step prints already happened; width step adds 6 more (one per box).
+    assert adapter.print_image.await_count == 3 + 6
     width_calls = adapter.print_image.await_args_list[3:]
-    assert len(width_calls) == 5
+    assert len(width_calls) == 6
     assert all(call.kwargs["impl"] == "bitImageColumn" for call in width_calls)
-    # Each bar must request its own pixel width -- otherwise process_image
-    # clamps every bar to the profile/opts width and they all print
+    # Each box must request its own pixel width -- otherwise process_image
+    # clamps every box to the profile/opts width and they all print
     # identical length, making the step unable to measure anything wider.
-    assert [call.kwargs["width"] for call in width_calls] == [384, 512, 576, 640, 832]
+    assert [call.kwargs["width"] for call in width_calls] == [384, 512, 546, 576, 640, 832]
     # ...and bypass python-escpos's profile-width refusal, or bars wider
     # than the declared profile width can never reach the printer.
     assert all(call.kwargs["ignore_profile_width"] for call in width_calls)
+    # The label moved out of the box raster into a text line above it --
+    # without these, the user gets six unlabeled boxes and no way to map
+    # "the widest intact one" back to a pixel width.
+    label_texts = [call.kwargs["text"] for call in adapter.print_text.await_args_list]
+    for w in (384, 512, 546, 576, 640, 832):
+        assert f"{w}:\n" in label_texts
 
 
 async def test_impl_partial_candidate_failure_is_tolerated(hass):  # type: ignore[no-untyped-def]
@@ -343,7 +349,7 @@ async def test_width_bars_prefer_calib_impl_then_adapter_default(hass):  # type:
     flow._calib["impl"] = "graphics"
     await flow._print_width_bars(adapter)
     assert all(
-        call.kwargs["impl"] == "graphics" for call in adapter.print_image.await_args_list[-5:]
+        call.kwargs["impl"] == "graphics" for call in adapter.print_image.await_args_list[-6:]
     )
 
     # No stored impl -- falls back to adapter.default_impl, not the
@@ -351,23 +357,24 @@ async def test_width_bars_prefer_calib_impl_then_adapter_default(hass):  # type:
     del flow._calib["impl"]
     await flow._print_width_bars(adapter)
     assert all(
-        call.kwargs["impl"] == "bitImageColumn" for call in adapter.print_image.await_args_list[-5:]
+        call.kwargs["impl"] == "bitImageColumn" for call in adapter.print_image.await_args_list[-6:]
     )
 
 
-async def test_width_partial_bar_failure_is_tolerated(hass):  # type: ignore[no-untyped-def]
-    """Bars wider than the profile's declared width failing doesn't fail the step.
+async def test_width_partial_box_failure_is_tolerated(hass):  # type: ignore[no-untyped-def]
+    """Boxes wider than the profile's declared width failing doesn't fail the step.
 
     python-escpos raises ImageWidthError for any image wider than the
     profile's media.width.pixels, so on a printer with a declared width
-    (e.g. TM-T20II @ 576) the 640/832 bars can never be sent. The bars
+    (e.g. TM-T20II @ 576) the 640/832 boxes can never be sent. The boxes
     that did print are still a valid measurement (seen on TM-T20II:
-    3 bars on paper + a spurious "print failed" banner).
+    4 boxes on paper + a spurious "print failed" banner).
     """
     entry, adapter = _make_entry(hass)
-    # 3 impl-step prints succeed; width bars 384/512/576 succeed, 640/832
-    # exceed the profile width and raise.
+    # 3 impl-step prints succeed; width boxes 384/512/546/576 succeed,
+    # 640/832 exceed the profile width and raise.
     adapter.print_image.side_effect = [None] * 3 + [
+        None,
         None,
         None,
         None,
@@ -383,14 +390,14 @@ async def test_width_partial_bar_failure_is_tolerated(hass):  # type: ignore[no-
     assert result2["type"] == "form"
     assert result2["step_id"] == "calibrate_width"
     assert result2.get("errors") in (None, {})
-    # All five bars were attempted -- a failing bar must not abort the rest.
-    assert adapter.print_image.await_count == 3 + 5
+    # All six candidates were attempted -- a failing one must not abort the rest.
+    assert adapter.print_image.await_count == 3 + 6
 
 
-async def test_width_all_bars_failing_shows_print_error(hass):  # type: ignore[no-untyped-def]
-    """If every bar fails to print, the form re-shows a print-failure error."""
+async def test_width_all_boxes_failing_shows_print_error(hass):  # type: ignore[no-untyped-def]
+    """If every box fails to print, the form re-shows a print-failure error."""
     entry, adapter = _make_entry(hass)
-    adapter.print_image.side_effect = [None] * 3 + [RuntimeError("boom")] * 5
+    adapter.print_image.side_effect = [None] * 3 + [RuntimeError("boom")] * 6
     result = await _open_calibrate(hass, entry)
 
     result2 = await hass.config_entries.options.async_configure(

--- a/tests/test_calibration_flow.py
+++ b/tests/test_calibration_flow.py
@@ -598,6 +598,14 @@ async def test_ruler_low_value_rejected_by_schema(hass):  # type: ignore[no-unty
         )
 
 
+# With no profile configured (or an unresolvable name), the printer object
+# runs escpos's *default* profile, so calibration filters candidates against
+# it. ISO_8859-1 is in COMMON_CODEPAGES but NOT in the default profile: it
+# must not print, or it renders under the previous line's codepage and
+# verifies falsely (then silently fails on every later print once stored).
+DEFAULT_PROFILE_CANDIDATES = ("CP858", "CP1252", "CP850", "CP437")
+
+
 async def test_codepage_step_prints_one_line_per_candidate_with_encoding(hass, monkeypatch):  # type: ignore[no-untyped-def]
     """The codepage step prints one line per candidate, tagged with its encoding."""
     entry, adapter = _make_entry(hass)
@@ -613,7 +621,7 @@ async def test_codepage_step_prints_one_line_per_candidate_with_encoding(hass, m
         for call in adapter.print_text.await_args_list
         if call.kwargs.get("encoding") is not None
     ]
-    assert encodings == list(CODEPAGE_CANDIDATES)
+    assert encodings == list(DEFAULT_PROFILE_CANDIDATES)
     texts = [
         call.kwargs["text"]
         for call in adapter.print_text.await_args_list
@@ -625,6 +633,23 @@ async def test_codepage_step_prints_one_line_per_candidate_with_encoding(hass, m
     # Every feed=0 sample line needs its own newline, or unflushed lines
     # merge/drop on real hardware (same class as the impl-label bug).
     assert all(text.endswith("\n") for text in texts)
+
+
+async def test_codepage_unresolvable_profile_filters_against_default(hass, monkeypatch):  # type: ignore[no-untyped-def]
+    """An unknown profile name degrades to escpos's default profile at connect
+    time, so candidates must be filtered against the default profile too --
+    same false-verification hole as the no-profile case."""
+    entry, adapter = _make_entry(hass, data_extra={CONF_PROFILE: "NoSuchModel9000"})
+
+    result = await _advance_to_codepage(hass, entry)
+
+    assert result["step_id"] == "calibrate_codepage"
+    encodings = [
+        call.kwargs["encoding"]
+        for call in adapter.print_text.await_args_list
+        if call.kwargs.get("encoding") is not None
+    ]
+    assert encodings == list(DEFAULT_PROFILE_CANDIDATES)
 
 
 async def test_codepage_reprint_reprints(hass, monkeypatch):  # type: ignore[no-untyped-def]
@@ -640,7 +665,7 @@ async def test_codepage_reprint_reprints(hass, monkeypatch):  # type: ignore[no-
     assert result2["type"] == "form"
     assert result2["step_id"] == "calibrate_codepage"
     # header + one line per candidate (the trailing separator is a page feed)
-    assert adapter.print_text.await_count == before + len(CODEPAGE_CANDIDATES) + 1
+    assert adapter.print_text.await_count == before + len(DEFAULT_PROFILE_CANDIDATES) + 1
 
 
 async def test_codepage_continue_stores_first_in_candidate_order(hass, monkeypatch):  # type: ignore[no-untyped-def]
@@ -689,7 +714,7 @@ async def test_codepage_choice_labels_carry_own_expected_rendering(hass, monkeyp
 
     assert result["type"] == "form"
     labels = result["data_schema"].schema["codepages_match"].options
-    assert labels["CP437"] == "Line 5: CP437 — café ñ ü é ß ° ?"
+    assert labels["CP437"] == "Line 4: CP437 — café ñ ü é ß ° ?"
     assert labels["CP858"] == "Line 1: CP858 — café ñ ü é ß ° €"
 
 

--- a/tests/test_calibration_helpers.py
+++ b/tests/test_calibration_helpers.py
@@ -30,30 +30,28 @@ def test_checkerboard_dimensions() -> None:
     assert img.size == (192, 48)
 
 
-def test_width_candidates_include_832() -> None:
-    """The fifth bar (832px) covers wider 100mm/112mm heads."""
-    assert WIDTH_CANDIDATES == (384, 512, 576, 640, 832)
+def test_width_candidates_include_832_and_546() -> None:
+    """832px covers wider 100mm/112mm heads; 546px is the Epson 42-column
+    mode class (e.g. TM-T20II in 42-col mode)."""
+    assert WIDTH_CANDIDATES == (384, 512, 546, 576, 640, 832)
 
 
-def test_width_bar_outline_exact_width_and_label_at_left() -> None:
+def test_width_bar_outline_exact_width_with_intact_right_border() -> None:
     for width in WIDTH_CANDIDATES:
         img = _decode_data_uri(width_bar_data_uri(width)).convert("L")
-        assert img.size == (width, 44)
-        # The border is still black at the far right edge -- clipping
-        # there is what a too-narrow printer's bars still detect.
-        assert img.getpixel((width - 1, 22)) < 64
-        # Interior (away from the border and the label) is mostly white
-        # now -- a fraction of the ink (and print-head heat) a solid
-        # filled bar would use.
-        assert img.getpixel((width // 2, 22)) > 192
-        # The label must be READABLE on paper, not just present: the old
-        # ~11px bitmap default font printed at ~1.4mm and regressing to it
-        # leaves only ~50 dark pixels in this crop. A 30px scalable font
-        # leaves several hundred. Cropped from x=4 (inside the 3px border)
-        # so the border's own edge can't satisfy the assertion.
-        label = img.crop((4, 4, 110, 40))
-        dark = sum(count for value, count in enumerate(label.histogram()) if value < 64)
-        assert dark > 150, f"label too small/faint for {width}px bar ({dark} dark px)"
+        assert img.size == (width, 24)
+        # The whole point of the box: an intact right-side border at
+        # x=width-1 is the signal the calibration step asks the user to
+        # look for, so if the printer reproduced the box at full width,
+        # this column must be black top to bottom (not just one pixel).
+        right_edge = [img.getpixel((width - 1, y)) for y in range(24)]
+        assert all(v < 64 for v in right_edge), f"right border not intact at {width}px"
+        # Interior (away from the border) is mostly white -- a fraction of
+        # the ink (and print-head heat) a solid filled bar would use.
+        assert img.getpixel((width // 2, 12)) > 192
+        # No baked-in label -- the width number now prints as a separate
+        # text line above the box (see _print_width_bars).
+        assert img.getpixel((8, 8)) > 192
 
 
 def test_ruler_layout() -> None:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -266,10 +266,26 @@ class TestGetProfileLineWidths:
         assert result == [42, 56]
 
     def test_bogus_font_columns_fall_back_to_common(self):
-        """NT-80-V-UL's upstream data bug encodes font DOT widths (9, 12) as
-        column counts on a 576px printer -- both are implausibly small for
-        any receipt printer, so the result must fall back to common widths."""
-        result = get_profile_line_widths("NT-80-V-UL")
+        """A profile whose fonts.columns holds font DOT widths instead of
+        column counts (both implausibly small for any receipt printer)
+        falls back to common widths. (Real-world instance of this bug,
+        NT-80-V-UL, is now corrected at runtime -- see
+        test_custom_profiles.py -- so this uses synthetic data instead.)"""
+        mock_data = {
+            "profiles": {
+                "bogus": {
+                    "fonts": {
+                        "0": {"columns": 9},
+                        "1": {"columns": 12},
+                    }
+                }
+            },
+        }
+        with patch(
+            "custom_components.escpos_printer.capabilities.line_widths._get_capabilities",
+            return_value=mock_data,
+        ):
+            result = get_profile_line_widths("bogus")
         assert result == COMMON_LINE_WIDTHS
 
     def test_mixed_bogus_and_plausible_keeps_only_plausible(self):

--- a/tests/test_config_flow_dhcp.py
+++ b/tests/test_config_flow_dhcp.py
@@ -526,10 +526,10 @@ async def test_dhcp_discovery_rongta_clone_overrides_epson_emulation(hass):
     flow = hass.config_entries.flow.async_progress()[0]
     assert flow["context"]["title_placeholders"] == {"name": "RP820 (192.168.10.158)"}
 
-    # The overridden identity ("RP820") resolves through the alias table
-    # to the 80mm clone profile -- not to the emulated TM-T88III.
+    # The overridden identity ("RP820") resolves directly to the custom
+    # RP820 profile -- not to the emulated TM-T88III.
     defaults = result["data_schema"]({"host": "192.168.10.158"})
-    assert defaults["profile"] == "NT-80-V-UL"
+    assert defaults["profile"] == "RP820"
 
     with patch(
         "custom_components.escpos_printer._config_flow.network_steps._can_connect",

--- a/tests/test_custom_profiles.py
+++ b/tests/test_custom_profiles.py
@@ -1,0 +1,127 @@
+"""Tests for the RP820 custom profile (custom_profiles.py)."""
+
+from __future__ import annotations
+
+import escpos.capabilities
+
+from custom_components.escpos_printer._config_flow.calibration import CODEPAGE_CANDIDATES
+from custom_components.escpos_printer.capabilities.aliases import normalize_model, resolve_alias
+from custom_components.escpos_printer.capabilities.codepages import get_profile_codepages
+from custom_components.escpos_printer.capabilities.custom_profiles import (
+    register_custom_profiles,
+)
+from custom_components.escpos_printer.capabilities.line_widths import get_profile_line_widths
+from custom_components.escpos_printer.capabilities.loader import _get_capabilities
+from custom_components.escpos_printer.capabilities.profiles import get_profile_choices
+
+
+def test_registers_rp820_in_escpos_capabilities() -> None:
+    register_custom_profiles()
+    profile = escpos.capabilities.get_profile("RP820")
+    assert profile.profile_data["codePages"]["0"] == "CP437"
+    assert profile.profile_data["codePages"]["2"] == "CP850"
+    assert profile.profile_data["codePages"]["16"] == "CP1252"
+    assert profile.profile_data["codePages"]["19"] == "CP858"
+    assert profile.profile_data["media"]["width"]["pixels"] == 576
+    assert profile.profile_data["features"]["graphics"] is False
+    assert profile.profile_data["fonts"]["0"]["columns"] == 48
+
+
+def test_registration_is_idempotent() -> None:
+    """A second call must not rebind the dict escpos's CLASS_CACHE already
+    built a profile class from -- otherwise get_profile("RP820") would
+    return stale data out of sync with the registered dict."""
+    register_custom_profiles()
+    register_custom_profiles()
+    profile = escpos.capabilities.get_profile("RP820")
+    assert profile.profile_data is escpos.capabilities.CAPABILITIES["profiles"]["RP820"]
+
+
+def test_rp820_profile_present_in_our_capabilities_loader() -> None:
+    profiles = _get_capabilities()["profiles"]
+    assert "RP820" in profiles
+
+
+def test_rp850p_alias_resolves_to_rp820() -> None:
+    assert resolve_alias("Rongta RP850P") == "RP820"
+    assert resolve_alias("RP850P") == "RP820"
+
+
+def test_calibration_codepage_candidates_for_rp820() -> None:
+    profile_codepages = get_profile_codepages("RP820")
+    candidates = tuple(cp for cp in CODEPAGE_CANDIDATES if cp in profile_codepages)
+    assert candidates == ("CP858", "CP1252", "CP850", "CP437")
+
+
+def test_dropdown_lists_rp820_exactly_once_without_compatible_suffix() -> None:
+    choices = get_profile_choices()
+    display_names = [display for _key, display in choices]
+    assert display_names.count("Rongta RP820") == 1
+    assert "Rongta RP820 (compatible)" not in display_names
+
+
+# =============================================================================
+# Bundled-profile runtime patches (escpos-printer-db data bugs, also
+# reported upstream)
+# =============================================================================
+
+
+def test_nt80vul_codepages_deduped() -> None:
+    register_custom_profiles()
+    code_pages = escpos.capabilities.get_profile("NT-80-V-UL").get_code_pages()
+    assert code_pages["CP437"] == "0"
+    assert code_pages["CP1252"] == "16"
+    assert code_pages["CP858"] == "19"
+    assert code_pages["CP850"] == "2"
+
+
+def test_pos5890_codepages_deduped() -> None:
+    register_custom_profiles()
+    code_pages = escpos.capabilities.get_profile("POS-5890").get_code_pages()
+    assert code_pages["CP437"] == "0"
+    assert code_pages["CP1252"] == "16"
+    assert code_pages["CP858"] == "19"
+
+
+def test_nt5890k_codepages_deduped() -> None:
+    register_custom_profiles()
+    code_pages = escpos.capabilities.get_profile("NT-5890K").get_code_pages()
+    assert code_pages["CP437"] == "0"
+    assert code_pages["CP1252"] == "16"
+    assert code_pages["CP858"] == "19"
+
+
+def test_ct_s651_codepages_unchanged_by_dedupe() -> None:
+    """CT-S651 has real low-index duplicates (CP1252 at 9 and 16, CP852 at
+    6 and 18, CP866 at 7 and 17) with no >=48 entry -- the dedupe rule
+    must be a strict no-op here. This is the regression guard for the
+    "lowest index always wins" mistake: that rule would have deleted the
+    working low duplicate (9/6/7) on this profile."""
+    before = dict(escpos.capabilities.CAPABILITIES["profiles"]["CT-S651"]["codePages"])
+    register_custom_profiles()
+    after = dict(escpos.capabilities.CAPABILITIES["profiles"]["CT-S651"]["codePages"])
+    assert after == before
+
+
+def test_nt80vul_font_columns_corrected() -> None:
+    register_custom_profiles()
+    profile_data = escpos.capabilities.get_profile("NT-80-V-UL").profile_data
+    assert profile_data["fonts"]["0"]["columns"] == 48
+    assert profile_data["fonts"]["1"]["columns"] == 64
+
+
+def test_nt80vul_patch_is_idempotent() -> None:
+    register_custom_profiles()
+    first = dict(escpos.capabilities.CAPABILITIES["profiles"]["NT-80-V-UL"])
+    register_custom_profiles()
+    second = dict(escpos.capabilities.CAPABILITIES["profiles"]["NT-80-V-UL"])
+    assert first == second
+
+
+def test_aliased_model_through_nt80vul_gets_corrected_line_widths() -> None:
+    """Xprinter XP-80C routes through NT-80-V-UL; its columns should now
+    reflect the corrected profile data (48, 64), not the plausibility-filter
+    fallback to common widths."""
+    register_custom_profiles()
+    alias_key = normalize_model("Xprinter XP-80C")
+    assert get_profile_line_widths(alias_key) == [48, 64]

--- a/tests/test_profile_aliases.py
+++ b/tests/test_profile_aliases.py
@@ -27,11 +27,14 @@ def test_normalize_model() -> None:
     assert normalize_model("ZJ_5890-K") == "zj5890k"
 
 
-def test_every_alias_target_exists_in_bundled_db() -> None:
+def test_every_alias_target_exists_in_bundled_or_registered_profiles() -> None:
+    """Alias targets are almost always bundled escpos-printer-db profiles,
+    but may be an integration-registered custom profile (e.g. RP820) --
+    _get_capabilities() reflects both once custom_profiles has run."""
     profiles = _get_capabilities()["profiles"]
     for alias, target in PROFILE_ALIASES.items():
         assert alias == normalize_model(alias), f"alias key {alias!r} must be pre-normalized"
-        assert target in profiles, f"alias {alias!r} -> {target!r} not in bundled DB"
+        assert target in profiles, f"alias {alias!r} -> {target!r} not in a known profile"
 
 
 def test_every_alias_target_declares_a_pixel_width() -> None:
@@ -168,4 +171,25 @@ async def test_setup_entry_resolves_alias_to_target_profile(hass) -> None:  # ty
 
     adapter = entry.runtime_data.adapter
     assert adapter._config.profile == "NT-80-V-UL"
+    assert adapter.get_profile_pixel_width() == 576
+
+
+async def test_setup_entry_resolves_rp850p_alias_to_custom_rp820_profile(hass) -> None:  # type: ignore[no-untyped-def]
+    """The RP850P alias now targets the custom RP820 profile (not a bundled
+    escpos-printer-db profile) -- confirm it resolves the same way at
+    connect time as any other alias."""
+    alias_key = normalize_model("Rongta RP850P")  # -> RP820, 576px
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="1.2.3.4:9100",
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: 9100, CONF_PROFILE: alias_key},
+        unique_id="1.2.3.4:9100",
+    )
+    entry.add_to_hass(hass)
+    with patch("escpos.printer.Network"):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    adapter = entry.runtime_data.adapter
+    assert adapter._config.profile == "RP820"
     assert adapter.get_profile_pixel_width() == 576


### PR DESCRIPTION
## Root cause

On a Rongta RP850P (announces itself as RP820), every calibration codepage except CP850 printed garbage even though the printer's self-test lists all of them. Several escpos-printer-db profiles map one codepage name to **two** ESC t indices — a standard one and a duplicate at ≥48 (e.g. NT-80-V-UL: CP437 at 0/50/52, CP1252 at 16/71, CP858 at 19/53) — and python-escpos's `get_code_pages()` dict inversion is last-wins, so it always emits the ≥48 duplicate. Clone firmware only implements the standard 0–47 table, so those codepages garble. CP850 has no duplicate, which is exactly why it was the one clean line.

## Changes

- **`RP820` custom profile**, registered into python-escpos's capabilities at startup: Epson-standard codepage table (copied from TM-T20II) plus hardware-verified geometry — 576 px raster / 48+64 columns in the 48-column SW-5 DIP position (512 px / 42+56 in the 42-column position, documented), `graphics: false`. "Rongta RP850P" now aliases to it.
- **Runtime dedupe of duplicate ≥48 codepage indices across all bundled profiles** — dropped only when a <48 twin exists. Plain lowest-wins would regress profiles like CT-S651 whose *standard* index is the high one; a CT-S651-unchanged test guards the rule. Also fixes: Xprinter XP-80C/XP-N160II/XP-T80A, Sunmi T2, Zjiang ZJ-5890/ZJ-5890K/POS-5890K/ZJ-5802, Xprinter XP-58IIH, HOIN HOP-E58, Goojprt PT-210, Netum NT-1809DD.
- **NT-80-V-UL font columns corrected** 12/9 → 48/64 (glyph dot widths mistakenly entered as column counts). Both data patches mirror corrections reported upstream to escpos-printer-db and carry comments to drop them once fixed data ships.
- **Width calibration step redesigned**: right-edge-border detection ("widest box whose right-side border printed") replaces the length comparison, which misread 512-vs-576 on real hardware — on wrap-firmware printers every over-width bar prints its main rows at head width, and an 11% length difference is easy to misjudge on thermal ink. Labels moved out of the raster to text lines above each box; candidates now (384, 512, 546, 576, 640, 832); wizard strings and docs updated in lockstep.

- **Encoding-step candidate filtering fixed for the generic/auto profile**: with no profile configured (or an unknown name), the printer runs python-escpos's *default* profile, but candidates were filtered against the static `COMMON_CODEPAGES` list — so ISO-8859-1 could print under the previous line's codepage, look correct, get stored, and then silently fail on every later print. Candidates now filter against the profile the printer actually runs with.

## Hardware verification

All four calibration codepages (CP858/CP1252/CP850/CP437), both SW-5 geometries, and the border-detection probe method were verified on a physical RP850P (firmware GD207_v1.16). The 546 candidate (only non-multiple-of-8) was byte-verified to pad with blank dots, keeping its right border intact.

## Testing

- `uv run pytest -q` → 1333 passed
- `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy custom_components/` → all clean
- New tests: RP820 registration/idempotency (CLASS_CACHE identity), per-profile dedupe outcomes incl. the CT-S651 no-op guard, right-border pixel property of the width boxes, width-step label printing, end-to-end alias→profile resolution at entry setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)