### PR TITLE
Add 13 printer models from issue-tracker and vendor-manual research

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,10 +92,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Epson TM-T70 and TM-T70II are recognized as compatible models (aliased
   to the bundled TM-T88V profile, whose 512px/180dpi/42-56-column class
-  and codepage table match both). Epson TM-m30 and TM-m30III are now
-  supported via a built-in `TM-m30III` profile carried from the upstream
-  escpos-printer-db printer database — newer than the one python-escpos
-  3.1 ships, so it isn't available there yet.
+  and codepage table match both). Epson TM-m30, TM-m30II, and TM-m30III
+  are now supported via a built-in `TM-m30III` profile carried from the
+  upstream escpos-printer-db printer database — newer than the one
+  python-escpos 3.1 ships, so it isn't available there yet. (The TM-m30II
+  TRG confirms an exact geometry and font match: 576 dots, 48/57/64
+  columns.)
+- Rongta RP80 and RP328 are recognized as compatible models, mapped to
+  the built-in `RP820` profile: RP328's vendor spec (72mm/203dpi = 576
+  dots, 48/64 columns) and the official RP80 command-set manual (same
+  font table and Epson-standard codepage layout as the hardware-verified
+  RP850P) both match the RP820 class.
 - The Bluetooth device picker now also recognizes printers by their cached
   Serial Port Profile (SPP) record, not just the imaging device class —
   cheap printers that don't advertise the imaging class show up in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   dots, 48/64 columns) and the official RP80 command-set manual (same
   font table and Epson-standard codepage layout as the hardware-verified
   RP850P) both match the RP820 class.
+- Bixolon SRP-350III (180dpi/512-dot class, aliased to TM-T88V) and its
+  203dpi sibling SRP-352III (576-dot class, aliased to TM-T20II) are
+  recognized as compatible models, per Bixolon's official user's manual.
+- Citizen CT-S801/CT-S851 and their II revisions are recognized as
+  compatible models (aliased to TM-T20II): Citizen's manuals confirm the
+  203dpi/576-dot default on 80mm paper, and its command reference
+  accepts the Epson-standard codepage numbers. Units memory-switched to
+  83mm/640-dot stock should recalibrate width.
 - Epson TM-m10 (58mm compact) is supported via a built-in profile with
   geometry from Epson's own technical reference (420 dots at 203dpi,
   35/42/46 columns — a class no bundled profile covers). Its codepage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Epson TM-T70 and TM-T70II are recognized as compatible models (aliased
+  to the bundled TM-T88V profile, whose 512px/180dpi/42-56-column class
+  and codepage table match both). Epson TM-m30 and TM-m30III are now
+  supported via a built-in `TM-m30III` profile carried from the upstream
+  escpos-printer-db printer database — newer than the one python-escpos
+  3.1 ships, so it isn't available there yet.
 - The Bluetooth device picker now also recognizes printers by their cached
   Serial Port Profile (SPP) record, not just the imaging device class —
   cheap printers that don't advertise the imaging class show up in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   dots, 48/64 columns) and the official RP80 command-set manual (same
   font table and Epson-standard codepage layout as the hardware-verified
   RP850P) both match the RP820 class.
+- Epson TM-m10 (58mm compact) is supported via a built-in profile with
+  geometry from Epson's own technical reference (420 dots at 203dpi,
+  35/42/46 columns — a class no bundled profile covers). Its codepage
+  table is borrowed from the TM-m30 family (Epson gates the per-model
+  table behind an NDA) — run the calibration wizard to verify encodings
+  on real hardware.
 - The Bluetooth device picker now also recognizes printers by their cached
   Serial Port Profile (SPP) record, not just the imaging device class —
   cheap printers that don't advertise the imaging class show up in the

--- a/custom_components/escpos_printer/capabilities/aliases.py
+++ b/custom_components/escpos_printer/capabilities/aliases.py
@@ -10,16 +10,27 @@ the fallback only when upstream can't represent it (e.g. non-standard
 codepage numbering).
 
 Researched-but-held models (deliberately absent — conflicting or
-unverified specs, or a widthless alias target): TM-m10, TM-m30II (Epson
-spec not yet checked), Rongta RP80/RP328, Zjiang ZJ-8220, Bixolon
-SRP-350III, PeriPage/MTP-3, Citizen CT-S801/851, generic Symcode/Bisofice.
-See the 2026-08-08 research in the PR discussion. GitHub-tracker evidence
-exhausted 2026-08-13 (escpos-printer-db, python-escpos, and escpos-php
-issue trackers all searched — zero new data surfaced for SRP-350III,
-RP80/RP328, CT-S801/851, ZJ-8220, or PeriPage/MTP-3); the next evidence
-source for these should be vendor manuals or FCC filings, not these
-trackers. RP328's community-suggested profile (escpos-php #1055 →
-RP326) is widthless, which confirms rather than resolves that hold.
+unverified specs, or a widthless alias target), status as of the
+2026-08-13 vendor-manual/FCC research pass (GitHub trackers were
+exhausted earlier the same day — escpos-printer-db, python-escpos, and
+escpos-php issues all searched):
+- Bixolon SRP-350III and Citizen CT-S801/851: still unresolved
+  (vendor-doc pass pending/incomplete).
+- Zjiang ZJ-8220: a real SKU (zjiang.com product id 34), likely generic
+  80mm/203dpi class, but no primary spec sheet or FCC filing found —
+  zjiang.com is unreachable to fetchers (TLS cert points at sister
+  domain cnfujun.com). Held at low confidence.
+- PeriPage A6-class: PERMANENTLY OUT OF SCOPE — not ESC/POS at all
+  (proprietary Bluetooth protocol; python-escpos #386 plus multiple
+  reverse-engineering projects, e.g. eliasweingaertner/peripage-A6-
+  bluetooth). Note "MTP-3" is a GOOJPRT model, not PeriPage — a
+  different, unverified device; don't conflate the two.
+- Symcode/Bisofice: CLOSED as unmappable — storefront brands over
+  mixed OEM hardware, no FCC identity of record; the generic profile
+  is the right answer for these.
+- Epson TM-m10: geometry confirmed from Epson's TRG (420 dots/203dpi,
+  Font A/B/C = 35/42/46 — matches no existing profile); needs its own
+  registered profile, pending codepage-table transcription.
 """
 
 from __future__ import annotations
@@ -67,14 +78,17 @@ ALIAS_MODELS: dict[str, str] = {
     # different 576px/203dpi class and are NOT covered by this alias.
     "Epson TM-T70": "TM-T88V",
     "Epson TM-T70II": "TM-T88V",
-    # Epson TM-m30: points at the custom "TM-m30III" profile (registered
-    # in custom_profiles.py, carried from an upstream escpos-printer-db
-    # merge) rather than a bundled profile. Epson's own TM-m30 spec
+    # Epson TM-m30/TM-m30II: point at the custom "TM-m30III" profile
+    # (registered in custom_profiles.py, carried from an upstream
+    # escpos-printer-db merge) rather than a bundled profile. Epson's own
+    # TM-m30 spec
     # (https://download4.epson.biz/sec_pubs/bs/html/m000943/en/chap10_1.html)
-    # confirms the same 80mm/72mm-printable/203dpi/576-dot class as the
-    # hardware-tested TM-m30III data. TM-m30II deliberately not aliased
-    # here -- its spec hasn't been checked yet.
+    # confirms the same 80mm/72mm-printable/203dpi/576-dot class, and the
+    # TM-m30II TRG (files.support.epson.com/pdf/pos/bulk/
+    # tm-m30ii_trg_en_reva.pdf pp.96-97) confirms an exact match on the
+    # full font triple too: 576 dots, Font A/B/C = 48/57/64 columns.
     "Epson TM-m30": "TM-m30III",
+    "Epson TM-m30II": "TM-m30III",
     # Xprinter: XP-58IIH 58mm/384dots (manuals.plus manual); XP-80C 80mm/576
     # (xprintertech.com); XP-N160II/XP-T80A 80mm/203dpi (vendor listings).
     "Xprinter XP-58IIH": "POS-5890",
@@ -114,6 +128,16 @@ ALIAS_MODELS: dict[str, str] = {
     # a real profile key, so it already appears in the dropdown and
     # resolves directly without going through the alias table.
     "Rongta RP850P": "RP820",
+    # Rongta RP80 and RP328: same class as the hardware-verified
+    # RP850P/RP820. RP328's vendor page states 72mm effective width @
+    # 203dpi (= 576 dots), Font A 12x24/48 cols, Font B 9x17/64 cols,
+    # ESC/POS emulation (rongtatech.com/rp328-bluetooth-thermal-receipt-
+    # printer_p20.html). The official Rongta "RP80 Command Set" manual is
+    # a command-set fingerprint match for RP820/RP850P: identical ESC ! n
+    # font table (12x24 / 9x17) and the same Epson-standard ESC t 0-47
+    # codepage table with the same reserved slots 11-14.
+    "Rongta RP80": "RP820",
+    "Rongta RP328": "RP820",
     # Misc verified 58mm/384dot ESC/POS clones.
     "HOIN HOP-E58": "POS-5890",
     "Goojprt PT-210": "POS-5890",

--- a/custom_components/escpos_printer/capabilities/aliases.py
+++ b/custom_components/escpos_printer/capabilities/aliases.py
@@ -28,9 +28,9 @@ escpos-php issues all searched):
 - Symcode/Bisofice: CLOSED as unmappable — storefront brands over
   mixed OEM hardware, no FCC identity of record; the generic profile
   is the right answer for these.
-- Epson TM-m10: geometry confirmed from Epson's TRG (420 dots/203dpi,
-  Font A/B/C = 35/42/46 — matches no existing profile); needs its own
-  registered profile, pending codepage-table transcription.
+(TM-m10 was resolved by this pass: TRG-confirmed geometry, registered
+as its own profile in custom_profiles.py with a borrowed-and-flagged
+codepage table.)
 """
 
 from __future__ import annotations

--- a/custom_components/escpos_printer/capabilities/aliases.py
+++ b/custom_components/escpos_printer/capabilities/aliases.py
@@ -14,8 +14,6 @@ unverified specs, or a widthless alias target), status as of the
 2026-08-13 vendor-manual/FCC research pass (GitHub trackers were
 exhausted earlier the same day — escpos-printer-db, python-escpos, and
 escpos-php issues all searched):
-- Bixolon SRP-350III and Citizen CT-S801/851: still unresolved
-  (vendor-doc pass pending/incomplete).
 - Zjiang ZJ-8220: a real SKU (zjiang.com product id 34), likely generic
   80mm/203dpi class, but no primary spec sheet or FCC filing found —
   zjiang.com is unreachable to fetchers (TLS cert points at sister
@@ -28,9 +26,10 @@ escpos-php issues all searched):
 - Symcode/Bisofice: CLOSED as unmappable — storefront brands over
   mixed OEM hardware, no FCC identity of record; the generic profile
   is the right answer for these.
-(TM-m10 was resolved by this pass: TRG-confirmed geometry, registered
-as its own profile in custom_profiles.py with a borrowed-and-flagged
-codepage table.)
+(Resolved by this pass: TM-m10 — TRG-confirmed geometry, registered as
+its own profile in custom_profiles.py with a borrowed-and-flagged
+codepage table; Bixolon SRP-350III/352III and Citizen CT-S801/851 —
+vendor-manual-confirmed geometry, aliased below.)
 """
 
 from __future__ import annotations
@@ -138,6 +137,28 @@ ALIAS_MODELS: dict[str, str] = {
     # codepage table with the same reserved slots 11-14.
     "Rongta RP80": "RP820",
     "Rongta RP328": "RP820",
+    # Bixolon SRP-350III: official user's manual v2.00 section 8-1 states
+    # 180dpi / 72mm printing width (= 512-dot class) with Font A/B
+    # defaults 42/56 -- exactly TM-T88V's geometry. Its 203dpi sibling
+    # SRP-352III (same manual) is the 576-dot class with Font A 48 --
+    # TM-T20II geometry. Bixolon documents Epson-standard ESC t numbering
+    # (0=437, 2=850, 16=1252) in its unified command manual; verify
+    # codepages via the calibration wizard on real hardware.
+    "Bixolon SRP-350III": "TM-T88V",
+    "Bixolon SRP-352III": "TM-T20II",
+    # Citizen CT-S801/CT-S851 (and II revisions): official user's manuals
+    # section 1.4 confirm 203dpi with the 80mm default = 576 dots (Font
+    # A/B/C 48/64/72). The 640-dot figure in the same table is the 83mm
+    # memory-switch paper option, not the default -- users running 83mm
+    # stock should recalibrate width. Citizen's shared command reference
+    # dual-maps WPC1252 at both 9 and 16, and accepts the Epson-standard
+    # 0/2/16/19 -- so TM-T20II's table works for the common codepages;
+    # exotic pages (e.g. CP857 at Citizen's 8 vs Epson's 13) may need a
+    # manual codepage override.
+    "Citizen CT-S801": "TM-T20II",
+    "Citizen CT-S801II": "TM-T20II",
+    "Citizen CT-S851": "TM-T20II",
+    "Citizen CT-S851II": "TM-T20II",
     # Misc verified 58mm/384dot ESC/POS clones.
     "HOIN HOP-E58": "POS-5890",
     "Goojprt PT-210": "POS-5890",

--- a/custom_components/escpos_printer/capabilities/aliases.py
+++ b/custom_components/escpos_printer/capabilities/aliases.py
@@ -10,10 +10,16 @@ the fallback only when upstream can't represent it (e.g. non-standard
 codepage numbering).
 
 Researched-but-held models (deliberately absent — conflicting or
-unverified specs, or a widthless alias target): TM-m10/m30, TM-T70/T70II,
-Rongta RP80/RP328, ZJ-8220, Bixolon SRP-350III, PeriPage/MTP-3, Citizen
-CT-S801/851, generic Symcode/Bisofice. See the 2026-08-08 research in the
-PR discussion.
+unverified specs, or a widthless alias target): TM-m10, TM-m30II (Epson
+spec not yet checked), Rongta RP80/RP328, Zjiang ZJ-8220, Bixolon
+SRP-350III, PeriPage/MTP-3, Citizen CT-S801/851, generic Symcode/Bisofice.
+See the 2026-08-08 research in the PR discussion. GitHub-tracker evidence
+exhausted 2026-08-13 (escpos-printer-db, python-escpos, and escpos-php
+issue trackers all searched — zero new data surfaced for SRP-350III,
+RP80/RP328, CT-S801/851, ZJ-8220, or PeriPage/MTP-3); the next evidence
+source for these should be vendor manuals or FCC filings, not these
+trackers. RP328's community-suggested profile (escpos-php #1055 →
+RP326) is widthless, which confirms rather than resolves that hold.
 """
 
 from __future__ import annotations
@@ -52,6 +58,23 @@ ALIAS_MODELS: dict[str, str] = {
     # Epson TM-T88 successors: same 80mm/512dots/180dpi lineage as TM-T88V.
     "Epson TM-T88VI": "TM-T88V",
     "Epson TM-T88VII": "TM-T88V",
+    # Epson TM-T70/TM-T70II ANK (alphanumeric) models: upstream
+    # escpos-printer-db profiles for both match TM-T88V's class exactly
+    # (512px/180dpi, Font A/B 42/56 columns, codepage indices agree at
+    # every index both tables define -- T70's table is a subset of
+    # TM-T88V's, T70II's is nearly identical). ANK only -- the
+    # TM-T70-SA/TM-T70II-SA/TM-T70II-CH regional variants are a
+    # different 576px/203dpi class and are NOT covered by this alias.
+    "Epson TM-T70": "TM-T88V",
+    "Epson TM-T70II": "TM-T88V",
+    # Epson TM-m30: points at the custom "TM-m30III" profile (registered
+    # in custom_profiles.py, carried from an upstream escpos-printer-db
+    # merge) rather than a bundled profile. Epson's own TM-m30 spec
+    # (https://download4.epson.biz/sec_pubs/bs/html/m000943/en/chap10_1.html)
+    # confirms the same 80mm/72mm-printable/203dpi/576-dot class as the
+    # hardware-tested TM-m30III data. TM-m30II deliberately not aliased
+    # here -- its spec hasn't been checked yet.
+    "Epson TM-m30": "TM-m30III",
     # Xprinter: XP-58IIH 58mm/384dots (manuals.plus manual); XP-80C 80mm/576
     # (xprintertech.com); XP-N160II/XP-T80A 80mm/203dpi (vendor listings).
     "Xprinter XP-58IIH": "POS-5890",

--- a/custom_components/escpos_printer/capabilities/custom_profiles.py
+++ b/custom_components/escpos_printer/capabilities/custom_profiles.py
@@ -1,9 +1,9 @@
 """Register/patch printer profiles that escpos-printer-db gets wrong or lacks.
 
 Unlike ``aliases.py`` (which points a display name at an *existing* bundled
-profile), this module either builds a genuinely new profile dict (RP820) or
-corrects data in place (the clone-firmware codePages dedupe below, and
-NT-80-V-UL's font columns) inside
+profile), this module either builds genuinely new profile dicts (RP820,
+TM-m30III) or corrects data in place (the clone-firmware codePages dedupe
+below, and NT-80-V-UL's font columns) inside
 ``escpos.capabilities.CAPABILITIES["profiles"]`` so the fix applies
 everywhere: the config-flow dropdown, the calibration codepage filter, and
 the printer constructors (all of which resolve profile names through that
@@ -81,18 +81,175 @@ def _patch_nt80vul_fonts(profiles: dict[str, Any]) -> None:
         fonts["1"]["columns"] = 64
 
 
+def _register_rp820(profiles: dict[str, Any]) -> None:
+    """Register the RP820 profile, a deep copy of TM-T20II with overrides.
+
+    Idempotent: a no-op once already registered rather than rebinding a
+    fresh dict -- escpos's ``get_profile_class`` caches the profile
+    *class* keyed by name on first lookup, built from whichever dict was
+    registered at that time, so a later call replacing the dict would
+    leave the cached class pointing at stale data.
+    """
+    if "RP820" in profiles:
+        return  # already registered; CLASS_CACHE pins the first dict, don't rebind it
+
+    template = profiles.get("TM-T20II")
+    if template is None:
+        # Degraded python-escpos install (e.g. its BrokenDefault
+        # fallback, which only has "default") -- nothing to copy from.
+        _LOGGER.warning("TM-T20II profile not found, skipping RP820 registration")
+        return
+
+    # RP820: the Rongta RP850P announces itself on the network as
+    # "RP820" (DHCP hostname Rongta_RP820, firmware GD207_v1.16). It
+    # was previously aliased to the bundled NT-80-V-UL profile; even
+    # after the codePages dedupe above, NT-80-V-UL still can't fully
+    # replace this profile -- about 31 of its codepage names (CP1250,
+    # CP1253, CP720, CP775, ...) only ever had a single index >= 48,
+    # so they stay unreachable on clone firmware, whereas RP820's full
+    # Epson table (copied from TM-T20II) covers them at their real
+    # low indices. RP820 also carries hardware measurements NT-80-V-UL
+    # doesn't have: per-DIP-mode geometry (below) and graphics=False.
+    # This profile is a deep copy of the bundled TM-T20II profile
+    # (same codePages/encodings) with media/fonts/features overridden
+    # to match those measurements.
+    #
+    # Hardware-verified 2026-08-13 on a real RP850P unit: BOTH
+    # geometries exist and follow the SW-5 column-mode DIP switch --
+    # 48-column position: 576px raster / 48 text columns; 42-column
+    # position: 512px raster / 42 text columns (each confirmed by a
+    # fine-grained right-edge probe plus a text-column ruler in the
+    # respective mode). All four calibration codepages
+    # (CP858/CP1252/CP850/CP437) render correctly,
+    # bitImageRaster/bitImageColumn print cleanly, graphics (GS ( L)
+    # does not.
+    rp820 = copy.deepcopy(template)
+    rp820["name"] = "RP820"
+    rp820["vendor"] = "Rongta"
+    rp820["notes"] = (
+        "Hardware-verified via the HA calibration wizard on a Rongta RP850P "
+        "unit (firmware GD207_v1.16, which announces DHCP hostname "
+        "Rongta_RP820). Defaults describe the 48-column SW-5 DIP position "
+        "(576px/48 cols); the 42-column position is 512px/42 cols -- "
+        "recalibrate after flipping the switch."
+    )
+    rp820["media"] = {"dpi": 203, "width": {"mm": 72, "pixels": 576}}
+    rp820["features"] = {**rp820["features"], "graphics": False}
+    # Defaults are the 48-column SW-5 position. media/fonts happen to
+    # be value-identical to the TM-T20II template today, but they are
+    # kept as explicit assignments on purpose: these numbers are our
+    # own hardware measurements, not inheritances, and pinning them
+    # means an upstream edit to TM-T20II's geometry can't silently
+    # change RP820's. The 42-column position is 512px raster with
+    # Font A 42 / Font B 56; users who flip SW-5 should recalibrate
+    # (a calibration override wins over the profile default anyway).
+    rp820["fonts"] = {
+        "0": {"name": "Font A", "columns": 48},
+        "1": {"name": "Font B", "columns": 64},
+    }
+    profiles["RP820"] = rp820
+
+
+def _register_tm_m30iii(profiles: dict[str, Any]) -> None:
+    """Register the Epson TM-m30III profile, verbatim from escpos-printer-db.
+
+    Data carried from escpos-printer-db PR #93 (merged upstream,
+    hardware-tested there) since it's absent from python-escpos 3.1's
+    vendored database -- drop this once a python-escpos release ships it.
+    The upstream YAML declares ``inherits: default`` for features/colors
+    (no override), so those two keys are copied from the bundled
+    "default" profile to match; everything else (fonts, media, codePages)
+    is this printer's own data, transcribed as-is. Notably codePages
+    index 19 is "Unknown", not CP858 -- unlike every other 80mm/576px
+    profile in the bundled DB, which is why this is a standalone profile
+    rather than an alias to one of them.
+
+    Idempotent: a no-op once already registered, same reasoning as RP820.
+    """
+    if "TM-m30III" in profiles:
+        return
+
+    default = profiles.get("default")
+    if default is None:
+        _LOGGER.warning("default profile not found, skipping TM-m30III registration")
+        return
+
+    profiles["TM-m30III"] = {
+        "name": "TM-m30III",
+        "vendor": "Epson",
+        "notes": (
+            "Epson TM-m30III profile, carried from escpos-printer-db "
+            "(PR #93). Tested with a TM-m30III (112) (SKU C31CK50112), "
+            "the standard model, black, EU, without WiFi/Bluetooth "
+            "support, using 80mm paper."
+        ),
+        "features": default["features"],
+        "colors": default["colors"],
+        "fonts": {
+            "0": {"name": "Font A", "columns": 48},
+            "1": {"name": "Font B", "columns": 57},
+            "2": {"name": "Font C", "columns": 64},
+        },
+        "media": {"dpi": 203, "width": {"mm": 80, "pixels": 576}},
+        "codePages": {
+            "0": "CP437",
+            "1": "CP932",
+            "2": "CP850",
+            "3": "CP860",
+            "4": "CP863",
+            "5": "CP865",
+            "11": "Unknown",
+            "12": "Unknown",
+            "13": "CP857",
+            "14": "CP737",
+            "15": "ISO_8859-7",
+            "16": "CP1252",
+            "17": "CP866",
+            "18": "CP852",
+            "19": "Unknown",
+            "20": "Unknown",
+            "21": "CP874",
+            "26": "Unknown",
+            "30": "TCVN-3-1",
+            "31": "TCVN-3-2",
+            "32": "Unknown",
+            "33": "CP775",
+            "34": "CP855",
+            "35": "CP861",
+            "36": "CP862",
+            "37": "CP864",
+            "38": "CP869",
+            "39": "ISO_8859-2",
+            "40": "ISO_8859-15",
+            "41": "Unknown",
+            "42": "CP774",
+            "43": "CP772",
+            "44": "CP1125",
+            "45": "CP1250",
+            "46": "CP1251",
+            "47": "CP1253",
+            "48": "CP1254",
+            "49": "CP1255",
+            "50": "CP1256",
+            "51": "CP1257",
+            "52": "CP1258",
+            "53": "RK1048",
+            "255": "Unknown",
+        },
+    }
+
+
 def register_custom_profiles() -> None:
     """Insert/patch our custom profiles in escpos's profile registry.
 
     Idempotent: the codePages/font patches no-op once already applied, and
-    registering RP820 is a no-op once already registered rather than
-    rebinding a fresh dict -- escpos's ``get_profile_class`` caches the
-    profile *class* keyed by name on first lookup, built from whichever
-    dict was registered at that time, so a later call replacing the dict
-    would leave the cached class pointing at stale data. All patching runs
-    inside one broad try/except: a malformed bundled profile (e.g. a
-    non-numeric codePages key) must not crash integration import, mirroring
-    ``loader._get_capabilities()``'s fallback philosophy.
+    each registration helper below is a no-op once its profile already
+    exists -- see each helper's docstring for why (in short: escpos's
+    ``get_profile_class`` CLASS_CACHE pins the first dict it saw for a
+    name). All patching runs inside one broad try/except: a malformed
+    bundled profile (e.g. a non-numeric codePages key) must not crash
+    integration import, mirroring ``loader._get_capabilities()``'s
+    fallback philosophy.
     """
     try:
         from escpos.capabilities import CAPABILITIES  # noqa: PLC0415
@@ -101,64 +258,7 @@ def register_custom_profiles() -> None:
 
         _dedupe_clone_codepages(profiles)
         _patch_nt80vul_fonts(profiles)
-
-        if "RP820" in profiles:
-            return  # already registered; CLASS_CACHE pins the first dict, don't rebind it
-
-        template = profiles.get("TM-T20II")
-        if template is None:
-            # Degraded python-escpos install (e.g. its BrokenDefault
-            # fallback, which only has "default") -- nothing to copy from.
-            _LOGGER.warning("TM-T20II profile not found, skipping RP820 registration")
-            return
-
-        # RP820: the Rongta RP850P announces itself on the network as
-        # "RP820" (DHCP hostname Rongta_RP820, firmware GD207_v1.16). It
-        # was previously aliased to the bundled NT-80-V-UL profile; even
-        # after the codePages dedupe above, NT-80-V-UL still can't fully
-        # replace this profile -- about 31 of its codepage names (CP1250,
-        # CP1253, CP720, CP775, ...) only ever had a single index >= 48,
-        # so they stay unreachable on clone firmware, whereas RP820's full
-        # Epson table (copied from TM-T20II) covers them at their real
-        # low indices. RP820 also carries hardware measurements NT-80-V-UL
-        # doesn't have: per-DIP-mode geometry (below) and graphics=False.
-        # This profile is a deep copy of the bundled TM-T20II profile
-        # (same codePages/encodings) with media/fonts/features overridden
-        # to match those measurements.
-        #
-        # Hardware-verified 2026-08-13 on a real RP850P unit: BOTH
-        # geometries exist and follow the SW-5 column-mode DIP switch --
-        # 48-column position: 576px raster / 48 text columns; 42-column
-        # position: 512px raster / 42 text columns (each confirmed by a
-        # fine-grained right-edge probe plus a text-column ruler in the
-        # respective mode). All four calibration codepages
-        # (CP858/CP1252/CP850/CP437) render correctly,
-        # bitImageRaster/bitImageColumn print cleanly, graphics (GS ( L)
-        # does not.
-        rp820 = copy.deepcopy(template)
-        rp820["name"] = "RP820"
-        rp820["vendor"] = "Rongta"
-        rp820["notes"] = (
-            "Hardware-verified via the HA calibration wizard on a Rongta RP850P "
-            "unit (firmware GD207_v1.16, which announces DHCP hostname "
-            "Rongta_RP820). Defaults describe the 48-column SW-5 DIP position "
-            "(576px/48 cols); the 42-column position is 512px/42 cols -- "
-            "recalibrate after flipping the switch."
-        )
-        rp820["media"] = {"dpi": 203, "width": {"mm": 72, "pixels": 576}}
-        rp820["features"] = {**rp820["features"], "graphics": False}
-        # Defaults are the 48-column SW-5 position. media/fonts happen to
-        # be value-identical to the TM-T20II template today, but they are
-        # kept as explicit assignments on purpose: these numbers are our
-        # own hardware measurements, not inheritances, and pinning them
-        # means an upstream edit to TM-T20II's geometry can't silently
-        # change RP820's. The 42-column position is 512px raster with
-        # Font A 42 / Font B 56; users who flip SW-5 should recalibrate
-        # (a calibration override wins over the profile default anyway).
-        rp820["fonts"] = {
-            "0": {"name": "Font A", "columns": 48},
-            "1": {"name": "Font B", "columns": 64},
-        }
-        profiles["RP820"] = rp820
+        _register_rp820(profiles)
+        _register_tm_m30iii(profiles)
     except Exception:  # mirror loader._get_capabilities's broad fallback
         _LOGGER.warning("Failed to register/patch custom printer profiles", exc_info=True)

--- a/custom_components/escpos_printer/capabilities/custom_profiles.py
+++ b/custom_components/escpos_printer/capabilities/custom_profiles.py
@@ -239,6 +239,58 @@ def _register_tm_m30iii(profiles: dict[str, Any]) -> None:
     }
 
 
+def _register_tm_m10(profiles: dict[str, Any]) -> None:
+    """Register the Epson TM-m10 (58mm compact) profile.
+
+    Geometry is grade-A from Epson's own TRG
+    (files.support.epson.com/pdf/pos/bulk/tm-m10_trg_en_revg.pdf,
+    pp.98-99): 203dpi, 52.5mm printable width = 420 dots, Font A 12x24 ->
+    35 columns, Font B 10x24 -> 42, Font C 9x17 -> 46. No bundled profile
+    matches this class (420 dots and a 35-column Font A exist nowhere
+    else), which is why it needs its own profile.
+
+    The codePages table is ASSUMED, not confirmed: Epson gates the
+    per-model ESC t enumeration behind an NDA "Product Specifications"
+    document, and the public charcode reference site was shut down in
+    2024. The TRG does state "selectable from 43 pages including user
+    defined page" with PC437 as the power-on default -- the TM-m30III
+    table registered above has exactly 43 entries, so the m30-family
+    table is borrowed here as the closest same-generation sibling. The
+    calibration wizard verifies the pages that matter on real hardware.
+
+    Idempotent: a no-op once already registered, same reasoning as RP820.
+    """
+    if "TM-m10" in profiles:
+        return
+
+    m30iii = profiles.get("TM-m30III")
+    if m30iii is None:
+        _LOGGER.warning("TM-m30III profile not found, skipping TM-m10 registration")
+        return
+
+    profiles["TM-m10"] = {
+        "name": "TM-m10",
+        "vendor": "Epson",
+        "notes": (
+            "Epson TM-m10 58mm compact printer. Geometry from Epson's TRG "
+            "(Rev G, doc M00092306): 203dpi, 52.5mm printable = 420 dots, "
+            "fonts 35/42/46 columns. Codepage table borrowed from the "
+            "TM-m30III profile (the per-model table is NDA-gated; the TRG "
+            "confirms 43 selectable pages with PC437 default, matching "
+            "that table's shape) -- verify via the calibration wizard."
+        ),
+        "features": m30iii["features"],
+        "colors": m30iii["colors"],
+        "fonts": {
+            "0": {"name": "Font A", "columns": 35},
+            "1": {"name": "Font B", "columns": 42},
+            "2": {"name": "Font C", "columns": 46},
+        },
+        "media": {"dpi": 203, "width": {"mm": 52.5, "pixels": 420}},
+        "codePages": dict(m30iii["codePages"]),
+    }
+
+
 def register_custom_profiles() -> None:
     """Insert/patch our custom profiles in escpos's profile registry.
 
@@ -260,5 +312,6 @@ def register_custom_profiles() -> None:
         _patch_nt80vul_fonts(profiles)
         _register_rp820(profiles)
         _register_tm_m30iii(profiles)
+        _register_tm_m10(profiles)
     except Exception:  # mirror loader._get_capabilities's broad fallback
         _LOGGER.warning("Failed to register/patch custom printer profiles", exc_info=True)

--- a/tests/test_custom_profiles.py
+++ b/tests/test_custom_profiles.py
@@ -163,6 +163,27 @@ def test_calibration_codepage_candidates_for_tm_m30iii() -> None:
     assert candidates == ("CP1252", "CP850", "CP437")
 
 
+def test_registers_tm_m10_in_escpos_capabilities() -> None:
+    """TRG-confirmed geometry; codepage table borrowed from TM-m30III."""
+    register_custom_profiles()
+    profile = escpos.capabilities.get_profile("TM-m10")
+    assert profile.profile_data["media"]["width"]["pixels"] == 420
+    assert profile.profile_data["fonts"]["0"]["columns"] == 35
+    assert profile.profile_data["fonts"]["1"]["columns"] == 42
+    assert profile.profile_data["fonts"]["2"]["columns"] == 46
+    m30iii = escpos.capabilities.CAPABILITIES["profiles"]["TM-m30III"]
+    assert profile.profile_data["codePages"] == m30iii["codePages"]
+    # ...but a distinct dict: patching one table must not mutate the other.
+    assert profile.profile_data["codePages"] is not m30iii["codePages"]
+
+
+def test_tm_m10_registration_is_idempotent() -> None:
+    register_custom_profiles()
+    register_custom_profiles()
+    profile = escpos.capabilities.get_profile("TM-m10")
+    assert profile.profile_data is escpos.capabilities.CAPABILITIES["profiles"]["TM-m10"]
+
+
 def test_epson_tm_t70_aliases_resolve_to_tm_t88v() -> None:
     assert resolve_alias("Epson TM-T70") == "TM-T88V"
     assert resolve_alias("Epson TM-T70II") == "TM-T88V"

--- a/tests/test_custom_profiles.py
+++ b/tests/test_custom_profiles.py
@@ -8,6 +8,9 @@ from custom_components.escpos_printer._config_flow.calibration import CODEPAGE_C
 from custom_components.escpos_printer.capabilities.aliases import normalize_model, resolve_alias
 from custom_components.escpos_printer.capabilities.codepages import get_profile_codepages
 from custom_components.escpos_printer.capabilities.custom_profiles import (
+    _register_rp820,
+    _register_tm_m10,
+    _register_tm_m30iii,
     register_custom_profiles,
 )
 from custom_components.escpos_printer.capabilities.line_widths import get_profile_line_widths
@@ -175,6 +178,17 @@ def test_registers_tm_m10_in_escpos_capabilities() -> None:
     assert profile.profile_data["codePages"] == m30iii["codePages"]
     # ...but a distinct dict: patching one table must not mutate the other.
     assert profile.profile_data["codePages"] is not m30iii["codePages"]
+
+
+def test_registration_helpers_skip_when_template_profile_missing() -> None:
+    """A degraded escpos database (e.g. its BrokenDefault fallback, which
+    only carries "default") leaves each helper nothing to copy from --
+    they must warn and skip, never raise or register partial data."""
+    profiles: dict = {}
+    _register_rp820(profiles)
+    _register_tm_m30iii(profiles)
+    _register_tm_m10(profiles)
+    assert profiles == {}
 
 
 def test_tm_m10_registration_is_idempotent() -> None:

--- a/tests/test_custom_profiles.py
+++ b/tests/test_custom_profiles.py
@@ -1,4 +1,4 @@
-"""Tests for the RP820 custom profile (custom_profiles.py)."""
+"""Tests for the RP820/TM-m30III custom profiles (custom_profiles.py)."""
 
 from __future__ import annotations
 
@@ -125,3 +125,48 @@ def test_aliased_model_through_nt80vul_gets_corrected_line_widths() -> None:
     register_custom_profiles()
     alias_key = normalize_model("Xprinter XP-80C")
     assert get_profile_line_widths(alias_key) == [48, 64]
+
+
+# =============================================================================
+# Epson TM-T70/TM-T70II/TM-m30 support (upstream escpos-printer-db merges
+# newer than python-escpos 3.1's bundled database)
+# =============================================================================
+
+
+def test_registers_tm_m30iii_in_escpos_capabilities() -> None:
+    register_custom_profiles()
+    profile = escpos.capabilities.get_profile("TM-m30III")
+    assert profile.profile_data["media"]["width"]["pixels"] == 576
+    assert profile.profile_data["fonts"]["0"]["columns"] == 48
+    assert profile.profile_data["fonts"]["1"]["columns"] == 57
+    assert profile.profile_data["fonts"]["2"]["columns"] == 64
+    assert profile.profile_data["codePages"]["0"] == "CP437"
+    assert profile.profile_data["codePages"]["2"] == "CP850"
+    assert profile.profile_data["codePages"]["16"] == "CP1252"
+    # The honesty property that makes this a standalone profile rather
+    # than an alias to another 80mm/576px bundled profile: index 19 is
+    # NOT CP858 here, unlike TM-T20II/NT-80-V-UL/POS-5890/etc.
+    assert profile.profile_data["codePages"].get("19") != "CP858"
+
+
+def test_tm_m30iii_registration_is_idempotent() -> None:
+    register_custom_profiles()
+    register_custom_profiles()
+    profile = escpos.capabilities.get_profile("TM-m30III")
+    assert profile.profile_data is escpos.capabilities.CAPABILITIES["profiles"]["TM-m30III"]
+
+
+def test_calibration_codepage_candidates_for_tm_m30iii() -> None:
+    """No CP858 candidate -- TM-m30III's index 19 is Unknown, not CP858."""
+    profile_codepages = get_profile_codepages("TM-m30III")
+    candidates = tuple(cp for cp in CODEPAGE_CANDIDATES if cp in profile_codepages)
+    assert candidates == ("CP1252", "CP850", "CP437")
+
+
+def test_epson_tm_t70_aliases_resolve_to_tm_t88v() -> None:
+    assert resolve_alias("Epson TM-T70") == "TM-T88V"
+    assert resolve_alias("Epson TM-T70II") == "TM-T88V"
+
+
+def test_epson_tm_m30_alias_resolves_to_tm_m30iii() -> None:
+    assert resolve_alias("Epson TM-m30") == "TM-m30III"

--- a/tests/test_profile_aliases.py
+++ b/tests/test_profile_aliases.py
@@ -92,6 +92,9 @@ def test_resolve_alias() -> None:
     assert resolve_alias("Epson TM-T70") == "TM-T88V"
     assert resolve_alias("Epson TM-T70II") == "TM-T88V"
     assert resolve_alias("Epson TM-m30") == "TM-m30III"
+    assert resolve_alias("Epson TM-m30II") == "TM-m30III"
+    assert resolve_alias("Rongta RP80") == "RP820"
+    assert resolve_alias("Rongta RP328") == "RP820"
     assert resolve_alias("nonsense-model") is None
 
 

--- a/tests/test_profile_aliases.py
+++ b/tests/test_profile_aliases.py
@@ -89,6 +89,9 @@ def test_resolve_alias() -> None:
     assert resolve_alias("CT-S601II") == "CT-S651"
     assert resolve_alias("Citizen CT-S601II") == "CT-S651"
     assert resolve_alias("Epson TM-T20III") == "TM-T20II"
+    assert resolve_alias("Epson TM-T70") == "TM-T88V"
+    assert resolve_alias("Epson TM-T70II") == "TM-T88V"
+    assert resolve_alias("Epson TM-m30") == "TM-m30III"
     assert resolve_alias("nonsense-model") is None
 
 

--- a/tests/test_profile_aliases.py
+++ b/tests/test_profile_aliases.py
@@ -95,6 +95,10 @@ def test_resolve_alias() -> None:
     assert resolve_alias("Epson TM-m30II") == "TM-m30III"
     assert resolve_alias("Rongta RP80") == "RP820"
     assert resolve_alias("Rongta RP328") == "RP820"
+    assert resolve_alias("Bixolon SRP-350III") == "TM-T88V"
+    assert resolve_alias("Bixolon SRP-352III") == "TM-T20II"
+    assert resolve_alias("Citizen CT-S801") == "TM-T20II"
+    assert resolve_alias("Citizen CT-S851II") == "TM-T20II"
     assert resolve_alias("nonsense-model") is None
 
 


### PR DESCRIPTION
## Summary

A research pass across the escpos-printer-db / python-escpos / escpos-php issue trackers, vendor manuals, and FCC filings, resolving most of the long-held-back compatibility list. Every mapping below is backed by a cited primary source; evidence notes live as comments in `aliases.py` / `custom_profiles.py`.

### New models supported

| Model | Mapping | Evidence |
|---|---|---|
| Epson TM-T70, TM-T70II (ANK) | alias → TM-T88V | upstream escpos-printer-db profiles (vendor-doc-cited); verified identical 512px/180dpi/42-56-col class, codepage indices agree |
| Epson TM-m30, TM-m30II, TM-m30III | new built-in `TM-m30III` profile (verbatim from upstream, hardware-tested there) | 576px/203dpi, fonts 48/57/64; index 19 is *not* CP858, so a TM-T20II alias would misdeclare it. TM-m30II TRG confirms an exact geometry+font match |
| Epson TM-m10 | new built-in `TM-m10` profile | Epson TRG: 420 dots/203dpi, fonts 35/42/46 — a class nothing bundled covers. Codepage table borrowed from TM-m30III and flagged as assumed (Epson NDA-gates the per-model table); the calibration wizard verifies it on hardware |
| Rongta RP80, RP328 | alias → RP820 (built-in) | RP328 vendor spec (72mm/203dpi = 576 dots, 48/64 cols); RP80 command-set manual is a fingerprint match for the hardware-verified RP850P |
| Bixolon SRP-350III | alias → TM-T88V | official manual: 180dpi/72mm = 512-dot class, fonts 42/56 exactly |
| Bixolon SRP-352III | alias → TM-T20II | same manual: the 203dpi/576-dot sibling |
| Citizen CT-S801, CT-S801II, CT-S851, CT-S851II | alias → TM-T20II | official manuals: 203dpi, 576-dot default on 80mm (the 640-dot figure is the 83mm memory-switch option, noted); Citizen's command reference accepts Epson-standard codepage numbers |

### Closed as unresolvable (documented in `aliases.py`)

- **PeriPage A6-class**: permanently out of scope — proprietary Bluetooth protocol, not ESC/POS (python-escpos #386 + multiple reverse-engineering projects). "MTP-3" is actually a GOOJPRT model, a different unverified device.
- **Symcode/Bisofice**: storefront brands over mixed OEM hardware, no FCC identity — cannot map by name; the generic profile is correct.
- **Zjiang ZJ-8220**: confirmed a real SKU but still held — no primary spec reachable.

### Why custom profiles instead of aliases for the TM-m10/m30III

python-escpos 3.1 (still the latest release, Dec 2023) vendors an escpos-printer-db snapshot that predates these upstream merges, so the data is carried via the integration's runtime profile registration (established in #147) with comments to drop it when a newer python-escpos ships.

## Testing

- `uv run pytest -q` → 1341 passed
- `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy custom_components/` → all clean
- New tests: TM-m30III and TM-m10 registration (data fidelity, idempotency, distinct codepage dicts), calibration candidate filtering for TM-m30III (no CP858), and alias resolution for all new models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)