### PR TITLE
Add HA action targets to print services and cut 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-08-15
+
+### Added
+
+- Print services can now be targeted by entity, area, floor, or label — in
+  addition to device — via Home Assistant's standard `target:` block, and
+  now appear in the entity/device "Add to… → Create as a new action"
+  picker. `calibration_print` is included. Existing `device_id` and
+  `broadcast` fields keep working unchanged; no migration is needed.
+
+### Changed
+
+- A legacy `device_id` in `data:` combined with a picker target (entity,
+  area, floor, or label) unions the two — every printer either resolves to
+  gets printed. Automations created in the UI before 1.2.0 stored
+  `device_id` inside `data:` rather than the newer `target:` block, so
+  their editor now shows an empty target picker; the call still works
+  unchanged.
+
+### Deprecated
+
+- The implicit broadcast-when-no-target fallback (omitting both a target
+  and `broadcast`) is deprecated; it will be removed in 2.0.0. Select a
+  target or set `broadcast: true` instead.
+
 ## [1.1.0] - 2026-08-14
 
 ### Added
@@ -1583,7 +1608,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 Earlier releases: see git history.
 
-[Unreleased]: https://github.com/cognitivegears/ha-escpos-thermal-printer/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/cognitivegears/ha-escpos-thermal-printer/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/cognitivegears/ha-escpos-thermal-printer/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/cognitivegears/ha-escpos-thermal-printer/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/cognitivegears/ha-escpos-thermal-printer/compare/v0.8.0...v1.0.0
 [0.8.0]: https://github.com/cognitivegears/ha-escpos-thermal-printer/compare/v0.7.4...v0.8.0

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ data:
   cut: partial
 ```
 
-To print to every configured printer at once, set `broadcast: true` in `data`. (Omitting the target entirely also broadcasts, kept for backward compatibility, but logs a warning when more than one printer is configured.)
+Since 1.2.0 the print services use Home Assistant's standard target picker, so you can also target entities, areas, floors, or labels — and the services appear in the entity/device "Add to… → Create as a new action" pickers. The `device_id` form above (and `device_id` passed directly in `data:`) keeps working unchanged; existing automations need no migration.
+
+To print to every configured printer at once, set `broadcast: true` in `data`. (Omitting the target entirely also broadcasts, kept for backward compatibility, but logs a warning when more than one printer is configured — this implicit fallback is deprecated and will be removed in 2.0.0.)
 
 ### Print a Bordered Header
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,10 +15,32 @@ Everything needed already exists: `adapter.feed()` / `adapter.cut()`
 three `ButtonEntity` subclasses reusing `build_device_info()`, plus `"button"`
 in `PLATFORMS`, icons, and strings. Beep as a fourth button is optional.
 
-### 2. Cash drawer service
+### 2. Cash drawer service — and the drawer-kick port as a "geek port"
 
-`open_cash_drawer` (python-escpos `cashdraw`, pin 2/5) plus a matching device
-action. The one classic POS capability entirely absent from the integration.
+**Core functionality**: `open_cash_drawer` (python-escpos `cashdraw`, pin 2/5)
+plus a matching device action, and optionally a button entity alongside the
+planned Feed/Cut/Calibration buttons (item 1). The one classic POS capability
+entirely absent from the integration.
+
+**Investigation: general-purpose I/O.** The drawer-kick connector (RJ11/RJ12)
+is electrically more than a cash-drawer plug, which makes it interesting as a
+cheap "geek port" for HA users without a drawer:
+
+- *Output*: `ESC p m t1 t2` fires a timed 24 V pulse on pin 2 or pin 5 with
+  configurable on/off duration — enough to drive a relay module, door strike,
+  or buzzer. Pulse-only, not level-hold, so it maps to an HA momentary
+  switch/button rather than a real GPIO line.
+- *Input*: the real-time status query `DLE EOT n=1` reports the drawer
+  kick-out connector pin 3 level, giving one readable sense line — a
+  binary_sensor for a door contact or any dry-contact switch, piggybacking on
+  the same poll loop as the existing paper sensor.
+
+Open questions for the investigation: which transports support the status
+read (network + USB likely, Bluetooth/serial to verify), per-model behavior of
+pulse timing limits, how to present this in the UI without confusing
+cash-drawer users (probably an "advanced" config option that renames the
+entities), and safety copy warning that pin voltage is 12/24 V solenoid drive,
+not logic-level.
 
 ### 3. Text styling: `invert`, `density`, `font` on `print_text` / `print_message`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,6 +84,13 @@ cannot re-fire.
 - **`_last_error_errno` in the Online sensor's attributes**: already tracked
   by the adapters and exposed in diagnostics, just not on the entity.
 
+## Planned for 2.0.0 (breaking)
+
+- **Remove the implicit broadcast-when-no-target fallback**: service calls
+  will require an explicit target (`device_id` or an entity/area/floor/label
+  target) or `broadcast: true`. Deprecated since 1.2.0; a warning has been
+  logged for this case since multi-printer support was added.
+
 ## Considered and rejected
 
 | Idea | Why not |

--- a/custom_components/escpos_printer/const.py
+++ b/custom_components/escpos_printer/const.py
@@ -4,6 +4,13 @@ from typing import Any
 
 DOMAIN = "escpos_printer"
 
+# HA target-picker keys (populated by a service's `target:` block in
+# services.yaml, merged into call.data by HA core before the schema/handler
+# runs). Shared by services/schemas.py (accept + broadcast-mutex) and
+# services/target_resolution.py (dispatch to async_extract_config_entry_ids)
+# so the four keys are defined in exactly one place.
+TARGET_PICKER_KEYS = ("entity_id", "area_id", "floor_id", "label_id")
+
 # Configuration keys
 CONF_HOST = "host"
 CONF_PORT = "port"

--- a/custom_components/escpos_printer/manifest.json
+++ b/custom_components/escpos_printer/manifest.json
@@ -119,5 +119,5 @@
       "description": "*pos*"
     }
   ],
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/custom_components/escpos_printer/services.yaml
+++ b/custom_components/escpos_printer/services.yaml
@@ -5,8 +5,6 @@ print_text_utf8:
     entity:
       domain: notify
       integration: escpos_printer
-    device:
-      integration: escpos_printer
   fields:
     broadcast:
       name: Broadcast
@@ -114,8 +112,6 @@ print_text:
   target:
     entity:
       domain: notify
-      integration: escpos_printer
-    device:
       integration: escpos_printer
   fields:
     broadcast:
@@ -234,8 +230,6 @@ print_qr:
     entity:
       domain: notify
       integration: escpos_printer
-    device:
-      integration: escpos_printer
   fields:
     broadcast:
       name: Broadcast
@@ -317,8 +311,6 @@ print_image:
   target:
     entity:
       domain: notify
-      integration: escpos_printer
-    device:
       integration: escpos_printer
   fields:
     broadcast:
@@ -517,8 +509,6 @@ print_image_url:
     entity:
       domain: notify
       integration: escpos_printer
-    device:
-      integration: escpos_printer
   fields:
     broadcast:
       name: Broadcast
@@ -715,8 +705,6 @@ print_image_path:
     entity:
       domain: notify
       integration: escpos_printer
-    device:
-      integration: escpos_printer
   fields:
     broadcast:
       name: Broadcast
@@ -910,8 +898,6 @@ print_camera_snapshot:
   target:
     entity:
       domain: notify
-      integration: escpos_printer
-    device:
       integration: escpos_printer
   fields:
     broadcast:
@@ -1107,8 +1093,6 @@ print_image_entity:
   target:
     entity:
       domain: notify
-      integration: escpos_printer
-    device:
       integration: escpos_printer
   fields:
     broadcast:
@@ -1445,8 +1429,6 @@ calibration_print:
     entity:
       domain: notify
       integration: escpos_printer
-    device:
-      integration: escpos_printer
   fields:
     broadcast:
       name: Broadcast
@@ -1485,8 +1467,6 @@ print_barcode:
   target:
     entity:
       domain: notify
-      integration: escpos_printer
-    device:
       integration: escpos_printer
   fields:
     broadcast:
@@ -1644,8 +1624,6 @@ feed:
     entity:
       domain: notify
       integration: escpos_printer
-    device:
-      integration: escpos_printer
   fields:
     broadcast:
       name: Broadcast
@@ -1675,8 +1653,6 @@ cut:
   target:
     entity:
       domain: notify
-      integration: escpos_printer
-    device:
       integration: escpos_printer
   fields:
     broadcast:
@@ -1715,8 +1691,6 @@ beep:
   target:
     entity:
       domain: notify
-      integration: escpos_printer
-    device:
       integration: escpos_printer
   fields:
     broadcast:
@@ -2016,8 +1990,6 @@ print_box:
     entity:
       domain: notify
       integration: escpos_printer
-    device:
-      integration: escpos_printer
   fields:
     broadcast:
       name: Broadcast
@@ -2116,8 +2088,6 @@ print_table:
   target:
     entity:
       domain: notify
-      integration: escpos_printer
-    device:
       integration: escpos_printer
   fields:
     broadcast:
@@ -2225,8 +2195,6 @@ print_text_image:
   target:
     entity:
       domain: notify
-      integration: escpos_printer
-    device:
       integration: escpos_printer
   fields:
     broadcast:
@@ -2430,8 +2398,6 @@ print_separator:
     entity:
       domain: notify
       integration: escpos_printer
-    device:
-      integration: escpos_printer
   fields:
     broadcast:
       name: Broadcast
@@ -2498,8 +2464,6 @@ print_kvtable:
   target:
     entity:
       domain: notify
-      integration: escpos_printer
-    device:
       integration: escpos_printer
   fields:
     broadcast:

--- a/custom_components/escpos_printer/services.yaml
+++ b/custom_components/escpos_printer/services.yaml
@@ -1,22 +1,21 @@
 print_text_utf8:
   name: Print Text (UTF-8)
-  description: Print UTF-8 text with automatic transcoding to printer codepage. Select one or more printer devices as the target.
+  description: Print UTF-8 text with automatic transcoding to printer codepage. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers)
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -111,23 +110,22 @@ print_text_utf8:
 
 print_text:
   name: Print Text (Raw Encoding)
-  description: Print text to the ESC/POS printer using raw encoding. Select one or more printer devices as the target.
+  description: Print text to the ESC/POS printer using raw encoding. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers)
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -231,23 +229,22 @@ print_text:
 
 print_qr:
   name: Print QR Code
-  description: Print a QR code. Select one or more printer devices as the target.
+  description: Print a QR code. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers)
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -316,23 +313,22 @@ print_image:
     renders it before the service call is dispatched — but the field itself
     is a plain string, not evaluated server-side. For a friendlier UI, prefer
     the focused services (Print Image from URL, from Path, Camera Snapshot,
-    Image Entity) — see docs/images.md.
+    Image Entity) — see docs/images.md. If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers).
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -516,23 +512,22 @@ print_image_url:
   name: Print Image from URL
   description: >
     Print an image fetched from an HTTP(S) URL. SSRF-aware — private,
-    loopback, and link-local addresses are refused.
+    loopback, and link-local addresses are refused. If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers).
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -715,23 +710,22 @@ print_image_path:
     Print an image from a local file path. The path must lie inside one
     of Home Assistant's allowlist_external_dirs (typically /config or
     /media — add directories under homeassistant -> allowlist_external_dirs
-    in configuration.yaml if needed).
+    in configuration.yaml if needed). If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers).
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -912,23 +906,22 @@ print_camera_snapshot:
   name: Print Camera Snapshot
   description: >
     Print a live snapshot from a camera entity. Convenience wrapper around
-    print_image with a camera-entity selector for a friendlier UI.
+    print_image with a camera-entity selector for a friendlier UI. If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers).
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -1110,23 +1103,22 @@ print_image_entity:
   name: Print Image Entity
   description: >
     Print the current frame from an HA image entity (weather radar, ML
-    overlay, generated chart, etc).
+    overlay, generated chart, etc). If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers).
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -1447,23 +1439,23 @@ calibration_print:
     Print a calibration sheet — a pixel ruler plus a threshold sweep
     strip — for tuning image dither/threshold settings (not the printer
     calibration wizard — see the Calibration docs page). Burns ~10 cm
-    of paper.
+    of paper. If no target is selected, prints to every configured
+    printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Printer device.
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -1489,23 +1481,22 @@ calibration_print:
 
 print_barcode:
   name: Print Barcode
-  description: Print a barcode. Select one or more printer devices as the target.
+  description: Print a barcode. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers)
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -1648,23 +1639,22 @@ print_barcode:
 
 feed:
   name: Feed Paper
-  description: Feed the paper a number of lines. Select one or more printer devices as the target.
+  description: Feed the paper a number of lines. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers)
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -1681,23 +1671,22 @@ feed:
 
 cut:
   name: Cut Paper
-  description: Cut the paper. Select one or more printer devices as the target.
+  description: Cut the paper. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers)
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -1722,23 +1711,22 @@ cut:
 
 beep:
   name: Beep
-  description: Trigger the printer buzzer (if supported). Select one or more printer devices as the target.
+  description: Trigger the printer buzzer (if supported). Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers)
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -2021,23 +2009,24 @@ print_message:
 
 print_box:
   name: Print Box
-  description: Print text wrapped in a printable border (single/double/ASCII glyphs).
+  description: >-
+    Print text wrapped in a printable border (single/double/ASCII glyphs).
+    If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers).
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -2121,23 +2110,24 @@ print_box:
 
 print_table:
   name: Print Table
-  description: Print a multi-column table (receipt-style) with optional borders and header.
+  description: >-
+    Print a multi-column table (receipt-style) with optional borders and
+    header. If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers).
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -2231,23 +2221,22 @@ print_text_image:
     and arbitrary point size. The rendered image is printed through the
     same dither/threshold pipeline as print_image. Use this when you need
     bigger or styled text than the printer's built-in 32-column font can
-    produce.
+    produce. If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers).
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -2436,23 +2425,22 @@ print_separator:
   description: >
     Print a single decorative rule built by repeating one character to
     fill the printer's line width. Examples — "-" for a single rule,
-    "=" for a heavy rule, "*" or "_" for decorative bars.
+    "=" for a heavy rule, "*" or "_" for decorative bars. If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers).
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}
@@ -2506,23 +2494,22 @@ print_kvtable:
   description: >
     Print a two-column label/value table — receipt totals, sensor
     readings, ingredient lists. Labels left-aligned, values per
-    "value_align" (default right).
+    "value_align" (default right). If no target is selected, prints to every configured printer (deprecated fallback).
+  target:
+    entity:
+      domain: notify
+      integration: escpos_printer
+    device:
+      integration: escpos_printer
   fields:
-    device_id:
-      name: Device
-      description: Select one or more printer devices (if omitted, broadcasts to all printers).
-      required: false
-      selector:
-        device:
-          integration: escpos_printer
     broadcast:
       name: Broadcast
       description: >
         Explicitly print to every configured printer. Mutually exclusive
-        with device_id. Omitting both device_id and broadcast also targets
-        all printers (kept for backward compatibility), but logs a warning
-        when more than one printer is configured — set broadcast: true to
-        make the intent explicit and silence it.
+        with any target (device, entity, area, floor, or label). Omitting
+        both a target and broadcast also prints to all printers, but that
+        implicit fallback is deprecated and will be removed in 2.0.0 —
+        select a target or set broadcast: true.
       default: false
       selector:
         boolean: {}

--- a/custom_components/escpos_printer/services/_handler_utils.py
+++ b/custom_components/escpos_printer/services/_handler_utils.py
@@ -59,8 +59,9 @@ async def _for_each_target(
     (with any ``translation_key`` / ``status`` context) propagates
     untouched; other exceptions are sanitised via :func:`_wrap_unexpected`.
 
-    Multiple targets (an explicit ``device_id`` list, or a broadcast to
-    every configured printer): each target is attempted even if an
+    Multiple targets (an explicit ``device_id`` list, a target-picker
+    selection of entities/areas/floors/labels, or a broadcast to every
+    configured printer): each target is attempted even if an
     earlier one fails, so one offline printer doesn't silently skip the
     rest. Failures are collected and reported together afterwards, named
     by printer, with a count of how many succeeded — partial success is

--- a/custom_components/escpos_printer/services/schemas.py
+++ b/custom_components/escpos_printer/services/schemas.py
@@ -87,6 +87,7 @@ from ..const import (
     DITHER_MODES,
     IMPL_MODES,
     ROTATION_VALUES,
+    TARGET_PICKER_KEYS,
 )
 from ..security import (
     IMAGE_CHUNK_DELAY_MAX,
@@ -120,33 +121,51 @@ from ..security import (
 # `selector: device:` and `selector: device: multiple: true` UI shapes.
 _DEVICE_ID = vol.Any(cv.string, [cv.string])
 
-# Explicit opt-in to broadcast to every loaded printer. Omitting both
-# `device_id` and `broadcast` still broadcasts (backward compatible —
-# see `target_resolution._async_get_target_entries`), but that implicit
-# form logs a warning; `broadcast: true` is the silent, explicit way to
-# say the same thing.
+# `entity_id`/`area_id`/`floor_id`/`label_id` accept str or [str] to match
+# the shapes HA's target picker sends. These are never in services.yaml as
+# explicit `fields:` entries — they come from the `target:` block declared
+# on each service, which HA core merges into `call.data` before schema
+# validation runs (the frontend's device/entity/area/floor/label picker
+# resolves to one or more of these keys under the hood). Without accepting
+# them here, the PREVENT_EXTRA schemas below would reject any call made
+# through the "create as a new action" target picker.
+_ANY_ID = vol.Any(cv.string, [cv.string])
+
+# Explicit opt-in to broadcast to every loaded printer. Omitting
+# `device_id`/the target-picker keys and `broadcast` still broadcasts
+# (backward compatible — see `target_resolution._async_get_target_entries`),
+# but that implicit form logs a warning; `broadcast: true` is the silent,
+# explicit way to say the same thing.
 _TARGET_FIELDS: dict[Any, Any] = {
     vol.Optional("device_id"): _DEVICE_ID,
+    **{vol.Optional(key): _ANY_ID for key in TARGET_PICKER_KEYS},
     vol.Optional("broadcast", default=False): cv.boolean,
 }
 
+_TARGET_KEYS = ("device_id", *TARGET_PICKER_KEYS)
 
-def _reject_broadcast_with_device_id(value: dict[Any, Any]) -> dict[Any, Any]:
-    """Reject `broadcast: true` combined with an explicit `device_id`.
+
+def _reject_broadcast_with_target(value: dict[Any, Any]) -> dict[Any, Any]:
+    """Reject `broadcast: true` combined with an explicit target.
 
     Voluptuous validates each key independently, so this cross-field rule
     can't live inside ``_TARGET_FIELDS`` itself — every schema below runs
     it as a second pass (via :func:`_with_target_validation`) over the
-    already-coerced dict.
+    already-coerced dict. ``device_id`` and the target-picker keys
+    (``entity_id``/``area_id``/``floor_id``/``label_id``) are all mutually
+    exclusive with ``broadcast`` for the same reason: they all pick a
+    non-broadcast target.
     """
-    if value.get("broadcast") and value.get("device_id"):
-        raise vol.Invalid("'broadcast' and 'device_id' are mutually exclusive")
+    if value.get("broadcast") and any(value.get(k) for k in _TARGET_KEYS):
+        raise vol.Invalid(
+            "'broadcast' and a target (device/entity/area/floor/label) are mutually exclusive"
+        )
     return value
 
 
 def _with_target_validation(schema_dict: dict[Any, Any]) -> vol.All:
-    """Wrap a global-service schema dict with the broadcast/device_id mutex check."""
-    return vol.All(vol.Schema(schema_dict), _reject_broadcast_with_device_id)
+    """Wrap a global-service schema dict with the broadcast/target mutex check."""
+    return vol.All(vol.Schema(schema_dict), _reject_broadcast_with_target)
 
 
 # Alignment / underline / cut / size enums shared across services.

--- a/custom_components/escpos_printer/services/target_resolution.py
+++ b/custom_components/escpos_printer/services/target_resolution.py
@@ -8,11 +8,12 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.service import async_extract_config_entry_ids
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
 
-from ..const import DOMAIN
+from ..const import DOMAIN, TARGET_PICKER_KEYS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,13 +21,14 @@ _LOGGER = logging.getLogger(__name__)
 def _all_loaded_entries_for_broadcast(
     call: ServiceCall, *, broadcast: bool, warn_implicit_broadcast: bool = True
 ) -> list[ConfigEntry]:
-    """Resolve the "no device_id" target list: every loaded printer.
+    """Resolve the "no target" list: every loaded printer.
 
     ``broadcast: true`` is the explicit, silent form of this. Omitting both
-    ``device_id`` and ``broadcast`` is kept for backward compatibility, but
-    warns once per call (unless there's only one printer, which is
-    unambiguous) so a caller who meant to target one printer notices
-    instead of silently printing to every printer.
+    a target (``device_id`` or a picker key) and ``broadcast`` is kept for
+    backward compatibility, but warns once per call (unless there's only
+    one printer, which is unambiguous) so a caller who meant to target one
+    printer notices instead of silently printing to every printer. This
+    implicit fallback is deprecated and will be removed in 2.0.0.
 
     ``warn_implicit_broadcast=False`` skips that warning for callers that
     require exactly one target and will raise their own, more specific
@@ -46,9 +48,10 @@ def _all_loaded_entries_for_broadcast(
         )
     if not broadcast and warn_implicit_broadcast and len(all_entries) > 1:
         _LOGGER.warning(
-            "escpos_printer.%s: no device_id specified — printing to all %d configured "
-            "printers. Set broadcast: true to make this explicit, or device_id to target "
-            "one printer.",
+            "escpos_printer.%s: no target specified — printing to all %d configured "
+            "printers. This implicit broadcast fallback is deprecated and will be "
+            "removed in 2.0.0; select a target (device, entity, area, floor, or "
+            "label) or set broadcast: true.",
             call.service,
             len(all_entries),
         )
@@ -80,11 +83,21 @@ async def _async_get_target_entries(
     """
     hass = call.hass
 
+    # entity_id/area_id/floor_id/label_id come from a service's `target:`
+    # block in services.yaml -- HA core merges the picker's selection into
+    # call.data before the schema/handler ever runs (see
+    # schemas._TARGET_FIELDS). Treat [] / None as absent, same as device_id
+    # below. When any is present, delegate everything -- including
+    # device_id, if it's also present -- to HA's target-expansion helper
+    # instead of the manual device_id loop.
+    if any(call.data.get(key) for key in TARGET_PICKER_KEYS):
+        return await _async_get_target_entries_from_targets(call)
+
     # Get device_id from service call data
     device_ids = call.data.get("device_id")
-    # `broadcast` and `device_id` are mutually exclusive at the schema layer
-    # (see schemas._reject_broadcast_with_device_id), so if device_id_list
-    # ends up non-empty below, broadcast is guaranteed False.
+    # `broadcast` and any target key are mutually exclusive at the schema
+    # layer (see schemas._reject_broadcast_with_target), so if
+    # device_id_list ends up non-empty below, broadcast is guaranteed False.
     broadcast = call.data.get("broadcast", False)
 
     # Normalize to a list
@@ -145,6 +158,59 @@ async def _async_get_target_entries(
         loaded_entry
         for loaded_entry in hass.config_entries.async_loaded_entries(DOMAIN)
         if loaded_entry.entry_id in target_entry_ids
+    ]
+
+    if not target_entries:
+        raise ServiceValidationError(
+            "No valid ESC/POS printer targets found. Please select a printer device.",
+            translation_domain=DOMAIN,
+            translation_key="no_target_found",
+        )
+
+    return target_entries
+
+
+async def _async_get_target_entries_from_targets(call: ServiceCall) -> list[ConfigEntry]:
+    """Resolve entity_id/area_id/floor_id/label_id (and device_id) via HA's target helper.
+
+    Used when the call carries any of HA's target-picker keys (populated by
+    a service's ``target:`` block in services.yaml -- see
+    :data:`schemas._TARGET_FIELDS`). ``async_extract_config_entry_ids``
+    expands devices/entities/areas/floors/labels to referenced config entry
+    ids in one pass, including ``device_id`` if it's also present, so the
+    manual device_id loop in :func:`_async_get_target_entries` is skipped
+    entirely for this path.
+    """
+    hass = call.hass
+    resolved_entry_ids = await async_extract_config_entry_ids(call)
+
+    # Ids belonging to other integrations' config entries are silently
+    # dropped here -- an area/label spanning printers and unrelated devices
+    # is expected to only "hit" the printers.
+    our_entry_ids = {
+        entry_id
+        for entry_id in resolved_entry_ids
+        if (entry := hass.config_entries.async_get_entry(entry_id)) is not None
+        and entry.domain == DOMAIN
+    }
+
+    loaded_entries = {e.entry_id: e for e in hass.config_entries.async_loaded_entries(DOMAIN)}
+    not_loaded = our_entry_ids - loaded_entries.keys()
+    if not_loaded:
+        # Mirrors the device_id path: a targeted printer that resolved but
+        # isn't loaded (setup failed / disabled) would otherwise be dropped
+        # silently, making a multi-printer call look fully successful.
+        _LOGGER.warning(
+            "Skipping %d targeted ESC/POS printer(s) that are not currently loaded "
+            "(setup failed or entry disabled): %s",
+            len(not_loaded),
+            sorted(not_loaded),
+        )
+
+    # Iterate loaded-entry order (not the resolved set) so multi-printer
+    # calls print in the same deterministic order as the device_id path.
+    target_entries = [
+        entry for entry_id, entry in loaded_entries.items() if entry_id in our_entry_ids
     ]
 
     if not target_entries:

--- a/custom_components/escpos_printer/strings.json
+++ b/custom_components/escpos_printer/strings.json
@@ -611,15 +611,11 @@
   },
   "services": {
     "beep": {
-      "description": "Trigger the printer buzzer (if supported). Select one or more printer devices as the target.",
+      "description": "Trigger the printer buzzer (if supported). Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers)",
-          "name": "Device"
         },
         "duration": {
           "description": "Duration of each beep (in the printer's buzzer time units, ~100 ms each)",
@@ -633,19 +629,15 @@
       "name": "Beep"
     },
     "calibration_print": {
-      "description": "Print a calibration sheet — a pixel ruler plus a threshold sweep strip — for tuning image dither/threshold settings (not the printer calibration wizard — see the Calibration docs page). Burns ~10 cm of paper.",
+      "description": "Print a calibration sheet — a pixel ruler plus a threshold sweep strip — for tuning image dither/threshold settings (not the printer calibration wizard — see the Calibration docs page). Burns ~10 cm of paper. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Printer device.",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing.",
@@ -655,15 +647,11 @@
       "name": "Print dither test sheet"
     },
     "cut": {
-      "description": "Cut the paper. Select one or more printer devices as the target.",
+      "description": "Cut the paper. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers)",
-          "name": "Device"
         },
         "feed_before_cut": {
           "description": "Force-feed a few lines before cutting (the printer's own behavior). Disable if you've already fed enough paper and want the cut right where the paper currently sits.",
@@ -677,15 +665,11 @@
       "name": "Cut Paper"
     },
     "feed": {
-      "description": "Feed the paper a number of lines. Select one or more printer devices as the target.",
+      "description": "Feed the paper a number of lines. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers)",
-          "name": "Device"
         },
         "lines": {
           "description": "Number of lines to feed",
@@ -839,7 +823,7 @@
       "name": "Preview Table (no paper)"
     },
     "print_barcode": {
-      "description": "Print a barcode. Select one or more printer devices as the target.",
+      "description": "Print a barcode. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Barcode alignment",
@@ -850,7 +834,7 @@
           "name": "Barcode Type"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "check": {
@@ -864,10 +848,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode)",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers)",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing",
@@ -907,23 +887,19 @@
       }
     },
     "print_box": {
-      "description": "Print text wrapped in a printable border (single/double/ASCII glyphs).",
+      "description": "Print text wrapped in a printable border (single/double/ASCII glyphs). If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Text alignment inside the box.",
           "name": "Alignment"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing.",
@@ -949,7 +925,7 @@
       "name": "Print Box"
     },
     "print_camera_snapshot": {
-      "description": "Print a live snapshot from a camera entity. Convenience wrapper around print_image with a camera-entity selector for a friendlier UI.",
+      "description": "Print a live snapshot from a camera entity. Convenience wrapper around print_image with a camera-entity selector for a friendlier UI. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Image alignment on the paper.",
@@ -964,7 +940,7 @@
           "name": "Autocontrast"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "camera_entity": {
@@ -978,10 +954,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "dither": {
           "description": "How to convert to 1-bit B&W. floyd-steinberg works well for photos; threshold gives crisp logos/text; none disables dithering.",
@@ -1041,7 +1013,7 @@
       }
     },
     "print_image": {
-      "description": "Print an image from a URL, file path, camera.[id], image.[id], or base64 data URI. Automations can still use a Jinja template for this field — HA renders it before the service call is dispatched — but the field itself is a plain string, not evaluated server-side. For a friendlier UI, prefer the focused services (Print Image from URL, from Path, Camera Snapshot, Image Entity) — see docs/images.md.",
+      "description": "Print an image from a URL, file path, camera.[id], image.[id], or base64 data URI. Automations can still use a Jinja template for this field — HA renders it before the service call is dispatched — but the field itself is a plain string, not evaluated server-side. For a friendlier UI, prefer the focused services (Print Image from URL, from Path, Camera Snapshot, Image Entity) — see docs/images.md. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Image alignment on the paper.",
@@ -1056,7 +1028,7 @@
           "name": "Autocontrast"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "chunk_delay_ms": {
@@ -1066,10 +1038,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "dither": {
           "description": "How to convert to 1-bit B&W. floyd-steinberg works well for photos; threshold gives crisp logos/text; none disables dithering.",
@@ -1133,7 +1101,7 @@
       }
     },
     "print_image_entity": {
-      "description": "Print the current frame from an HA image entity (weather radar, ML overlay, generated chart, etc).",
+      "description": "Print the current frame from an HA image entity (weather radar, ML overlay, generated chart, etc). If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Image alignment on the paper.",
@@ -1148,7 +1116,7 @@
           "name": "Autocontrast"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "chunk_delay_ms": {
@@ -1158,10 +1126,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "dither": {
           "description": "How to convert to 1-bit B&W. floyd-steinberg works well for photos; threshold gives crisp logos/text; none disables dithering.",
@@ -1225,7 +1189,7 @@
       }
     },
     "print_image_path": {
-      "description": "Print an image from a local file path. The path must lie inside one of Home Assistant's allowlist_external_dirs (typically /config or /media — add directories under homeassistant -> allowlist_external_dirs in configuration.yaml if needed).",
+      "description": "Print an image from a local file path. The path must lie inside one of Home Assistant's allowlist_external_dirs (typically /config or /media — add directories under homeassistant -> allowlist_external_dirs in configuration.yaml if needed). If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Image alignment on the paper.",
@@ -1240,7 +1204,7 @@
           "name": "Autocontrast"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "chunk_delay_ms": {
@@ -1250,10 +1214,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "dither": {
           "description": "How to convert to 1-bit B&W. floyd-steinberg works well for photos; threshold gives crisp logos/text; none disables dithering.",
@@ -1317,7 +1277,7 @@
       }
     },
     "print_image_url": {
-      "description": "Print an image fetched from an HTTP(S) URL. SSRF-aware — private, loopback, and link-local addresses are refused.",
+      "description": "Print an image fetched from an HTTP(S) URL. SSRF-aware — private, loopback, and link-local addresses are refused. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Image alignment on the paper.",
@@ -1332,7 +1292,7 @@
           "name": "Autocontrast"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "chunk_delay_ms": {
@@ -1342,10 +1302,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "dither": {
           "description": "How to convert to 1-bit B&W. floyd-steinberg works well for photos; threshold gives crisp logos/text; none disables dithering.",
@@ -1409,19 +1365,15 @@
       }
     },
     "print_kvtable": {
-      "description": "Print a two-column label/value table — receipt totals, sensor readings, ingredient lists. Labels left-aligned, values per \"value_align\" (default right).",
+      "description": "Print a two-column label/value table — receipt totals, sensor readings, ingredient lists. Labels left-aligned, values per \"value_align\" (default right). If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing.",
@@ -1571,14 +1523,14 @@
       }
     },
     "print_qr": {
-      "description": "Print a QR code. Select one or more printer devices as the target.",
+      "description": "Print a QR code. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "QR code alignment",
           "name": "Alignment"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "cut": {
@@ -1588,10 +1540,6 @@
         "data": {
           "description": "Data to encode in the QR code",
           "name": "Data"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers)",
-          "name": "Device"
         },
         "ec": {
           "description": "Error correction level",
@@ -1609,10 +1557,10 @@
       "name": "Print QR Code"
     },
     "print_separator": {
-      "description": "Print a single decorative rule built by repeating one character to fill the printer's line width. Examples — \"-\" for a single rule, \"=\" for a heavy rule, \"*\" or \"_\" for decorative bars.",
+      "description": "Print a single decorative rule built by repeating one character to fill the printer's line width. Examples — \"-\" for a single rule, \"=\" for a heavy rule, \"*\" or \"_\" for decorative bars. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "char": {
@@ -1622,10 +1570,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing.",
@@ -1643,10 +1587,10 @@
       "name": "Print Separator"
     },
     "print_table": {
-      "description": "Print a multi-column table (receipt-style) with optional borders and header.",
+      "description": "Print a multi-column table (receipt-style) with optional borders and header. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "column_aligns": {
@@ -1660,10 +1604,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing.",
@@ -1693,7 +1633,7 @@
       "name": "Print Table"
     },
     "print_text": {
-      "description": "Print text to the ESC/POS printer using raw encoding. Select one or more printer devices as the target.",
+      "description": "Print text to the ESC/POS printer using raw encoding. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Text alignment",
@@ -1704,16 +1644,12 @@
           "name": "Bold"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode)",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers)",
-          "name": "Device"
         },
         "encoding": {
           "description": "Codepage override for this print — a python-escpos codepage name such as CP437, CP850, or CP858 (not a Python codec name). Leave empty to use the printer's configured codepage.",
@@ -1743,23 +1679,19 @@
       "name": "Print Text (Raw Encoding)"
     },
     "print_text_image": {
-      "description": "Render text to a bitmap with a custom TTF/OTF font, optional rotation, and arbitrary point size. The rendered image is printed through the same dither/threshold pipeline as print_image. Use this when you need bigger or styled text than the printer's built-in 32-column font can produce.",
+      "description": "Render text to a bitmap with a custom TTF/OTF font, optional rotation, and arbitrary point size. The rendered image is printed through the same dither/threshold pipeline as print_image. Use this when you need bigger or styled text than the printer's built-in 32-column font can produce. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Horizontal alignment of each rendered line within the canvas.",
           "name": "Alignment"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing.",
@@ -1847,7 +1779,7 @@
       }
     },
     "print_text_utf8": {
-      "description": "Print UTF-8 text with automatic transcoding to printer codepage. Select one or more printer devices as the target.",
+      "description": "Print UTF-8 text with automatic transcoding to printer codepage. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Text alignment",
@@ -1858,16 +1790,12 @@
           "name": "Bold"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode)",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers)",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing",

--- a/custom_components/escpos_printer/translations/en.json
+++ b/custom_components/escpos_printer/translations/en.json
@@ -611,15 +611,11 @@
   },
   "services": {
     "beep": {
-      "description": "Trigger the printer buzzer (if supported). Select one or more printer devices as the target.",
+      "description": "Trigger the printer buzzer (if supported). Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers)",
-          "name": "Device"
         },
         "duration": {
           "description": "Duration of each beep (in the printer's buzzer time units, ~100 ms each)",
@@ -633,19 +629,15 @@
       "name": "Beep"
     },
     "calibration_print": {
-      "description": "Print a calibration sheet — a pixel ruler plus a threshold sweep strip — for tuning image dither/threshold settings (not the printer calibration wizard — see the Calibration docs page). Burns ~10 cm of paper.",
+      "description": "Print a calibration sheet — a pixel ruler plus a threshold sweep strip — for tuning image dither/threshold settings (not the printer calibration wizard — see the Calibration docs page). Burns ~10 cm of paper. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Printer device.",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing.",
@@ -655,15 +647,11 @@
       "name": "Print dither test sheet"
     },
     "cut": {
-      "description": "Cut the paper. Select one or more printer devices as the target.",
+      "description": "Cut the paper. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers)",
-          "name": "Device"
         },
         "feed_before_cut": {
           "description": "Force-feed a few lines before cutting (the printer's own behavior). Disable if you've already fed enough paper and want the cut right where the paper currently sits.",
@@ -677,15 +665,11 @@
       "name": "Cut Paper"
     },
     "feed": {
-      "description": "Feed the paper a number of lines. Select one or more printer devices as the target.",
+      "description": "Feed the paper a number of lines. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers)",
-          "name": "Device"
         },
         "lines": {
           "description": "Number of lines to feed",
@@ -839,7 +823,7 @@
       "name": "Preview Table (no paper)"
     },
     "print_barcode": {
-      "description": "Print a barcode. Select one or more printer devices as the target.",
+      "description": "Print a barcode. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Barcode alignment",
@@ -850,7 +834,7 @@
           "name": "Barcode Type"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "check": {
@@ -864,10 +848,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode)",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers)",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing",
@@ -907,23 +887,19 @@
       }
     },
     "print_box": {
-      "description": "Print text wrapped in a printable border (single/double/ASCII glyphs).",
+      "description": "Print text wrapped in a printable border (single/double/ASCII glyphs). If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Text alignment inside the box.",
           "name": "Alignment"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing.",
@@ -949,7 +925,7 @@
       "name": "Print Box"
     },
     "print_camera_snapshot": {
-      "description": "Print a live snapshot from a camera entity. Convenience wrapper around print_image with a camera-entity selector for a friendlier UI.",
+      "description": "Print a live snapshot from a camera entity. Convenience wrapper around print_image with a camera-entity selector for a friendlier UI. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Image alignment on the paper.",
@@ -964,7 +940,7 @@
           "name": "Autocontrast"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "camera_entity": {
@@ -978,10 +954,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "dither": {
           "description": "How to convert to 1-bit B&W. floyd-steinberg works well for photos; threshold gives crisp logos/text; none disables dithering.",
@@ -1041,7 +1013,7 @@
       }
     },
     "print_image": {
-      "description": "Print an image from a URL, file path, camera.[id], image.[id], or base64 data URI. Automations can still use a Jinja template for this field — HA renders it before the service call is dispatched — but the field itself is a plain string, not evaluated server-side. For a friendlier UI, prefer the focused services (Print Image from URL, from Path, Camera Snapshot, Image Entity) — see docs/images.md.",
+      "description": "Print an image from a URL, file path, camera.[id], image.[id], or base64 data URI. Automations can still use a Jinja template for this field — HA renders it before the service call is dispatched — but the field itself is a plain string, not evaluated server-side. For a friendlier UI, prefer the focused services (Print Image from URL, from Path, Camera Snapshot, Image Entity) — see docs/images.md. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Image alignment on the paper.",
@@ -1056,7 +1028,7 @@
           "name": "Autocontrast"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "chunk_delay_ms": {
@@ -1066,10 +1038,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "dither": {
           "description": "How to convert to 1-bit B&W. floyd-steinberg works well for photos; threshold gives crisp logos/text; none disables dithering.",
@@ -1133,7 +1101,7 @@
       }
     },
     "print_image_entity": {
-      "description": "Print the current frame from an HA image entity (weather radar, ML overlay, generated chart, etc).",
+      "description": "Print the current frame from an HA image entity (weather radar, ML overlay, generated chart, etc). If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Image alignment on the paper.",
@@ -1148,7 +1116,7 @@
           "name": "Autocontrast"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "chunk_delay_ms": {
@@ -1158,10 +1126,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "dither": {
           "description": "How to convert to 1-bit B&W. floyd-steinberg works well for photos; threshold gives crisp logos/text; none disables dithering.",
@@ -1225,7 +1189,7 @@
       }
     },
     "print_image_path": {
-      "description": "Print an image from a local file path. The path must lie inside one of Home Assistant's allowlist_external_dirs (typically /config or /media — add directories under homeassistant -> allowlist_external_dirs in configuration.yaml if needed).",
+      "description": "Print an image from a local file path. The path must lie inside one of Home Assistant's allowlist_external_dirs (typically /config or /media — add directories under homeassistant -> allowlist_external_dirs in configuration.yaml if needed). If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Image alignment on the paper.",
@@ -1240,7 +1204,7 @@
           "name": "Autocontrast"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "chunk_delay_ms": {
@@ -1250,10 +1214,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "dither": {
           "description": "How to convert to 1-bit B&W. floyd-steinberg works well for photos; threshold gives crisp logos/text; none disables dithering.",
@@ -1317,7 +1277,7 @@
       }
     },
     "print_image_url": {
-      "description": "Print an image fetched from an HTTP(S) URL. SSRF-aware — private, loopback, and link-local addresses are refused.",
+      "description": "Print an image fetched from an HTTP(S) URL. SSRF-aware — private, loopback, and link-local addresses are refused. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Image alignment on the paper.",
@@ -1332,7 +1292,7 @@
           "name": "Autocontrast"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "chunk_delay_ms": {
@@ -1342,10 +1302,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "dither": {
           "description": "How to convert to 1-bit B&W. floyd-steinberg works well for photos; threshold gives crisp logos/text; none disables dithering.",
@@ -1409,19 +1365,15 @@
       }
     },
     "print_kvtable": {
-      "description": "Print a two-column label/value table — receipt totals, sensor readings, ingredient lists. Labels left-aligned, values per \"value_align\" (default right).",
+      "description": "Print a two-column label/value table — receipt totals, sensor readings, ingredient lists. Labels left-aligned, values per \"value_align\" (default right). If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing.",
@@ -1571,14 +1523,14 @@
       }
     },
     "print_qr": {
-      "description": "Print a QR code. Select one or more printer devices as the target.",
+      "description": "Print a QR code. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "QR code alignment",
           "name": "Alignment"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "cut": {
@@ -1588,10 +1540,6 @@
         "data": {
           "description": "Data to encode in the QR code",
           "name": "Data"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers)",
-          "name": "Device"
         },
         "ec": {
           "description": "Error correction level",
@@ -1609,10 +1557,10 @@
       "name": "Print QR Code"
     },
     "print_separator": {
-      "description": "Print a single decorative rule built by repeating one character to fill the printer's line width. Examples — \"-\" for a single rule, \"=\" for a heavy rule, \"*\" or \"_\" for decorative bars.",
+      "description": "Print a single decorative rule built by repeating one character to fill the printer's line width. Examples — \"-\" for a single rule, \"=\" for a heavy rule, \"*\" or \"_\" for decorative bars. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "char": {
@@ -1622,10 +1570,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing.",
@@ -1643,10 +1587,10 @@
       "name": "Print Separator"
     },
     "print_table": {
-      "description": "Print a multi-column table (receipt-style) with optional borders and header.",
+      "description": "Print a multi-column table (receipt-style) with optional borders and header. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "column_aligns": {
@@ -1660,10 +1604,6 @@
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing.",
@@ -1693,7 +1633,7 @@
       "name": "Print Table"
     },
     "print_text": {
-      "description": "Print text to the ESC/POS printer using raw encoding. Select one or more printer devices as the target.",
+      "description": "Print text to the ESC/POS printer using raw encoding. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Text alignment",
@@ -1704,16 +1644,12 @@
           "name": "Bold"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode)",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers)",
-          "name": "Device"
         },
         "encoding": {
           "description": "Codepage override for this print — a python-escpos codepage name such as CP437, CP850, or CP858 (not a Python codec name). Leave empty to use the printer's configured codepage.",
@@ -1743,23 +1679,19 @@
       "name": "Print Text (Raw Encoding)"
     },
     "print_text_image": {
-      "description": "Render text to a bitmap with a custom TTF/OTF font, optional rotation, and arbitrary point size. The rendered image is printed through the same dither/threshold pipeline as print_image. Use this when you need bigger or styled text than the printer's built-in 32-column font can produce.",
+      "description": "Render text to a bitmap with a custom TTF/OTF font, optional rotation, and arbitrary point size. The rendered image is printed through the same dither/threshold pipeline as print_image. Use this when you need bigger or styled text than the printer's built-in 32-column font can produce. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Horizontal alignment of each rendered line within the canvas.",
           "name": "Alignment"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode).",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers).",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing.",
@@ -1847,7 +1779,7 @@
       }
     },
     "print_text_utf8": {
-      "description": "Print UTF-8 text with automatic transcoding to printer codepage. Select one or more printer devices as the target.",
+      "description": "Print UTF-8 text with automatic transcoding to printer codepage. Select a target — printer device, entity, area, floor, or label. If no target is selected, prints to every configured printer (deprecated fallback).",
       "fields": {
         "align": {
           "description": "Text alignment",
@@ -1858,16 +1790,12 @@
           "name": "Bold"
         },
         "broadcast": {
-          "description": "Explicitly print to every configured printer. Mutually exclusive with device_id. Omitting both device_id and broadcast also targets all printers (kept for backward compatibility), but logs a warning when more than one printer is configured — set broadcast: true to make the intent explicit and silence it.",
+          "description": "Explicitly print to every configured printer. Mutually exclusive with any target (device, entity, area, floor, or label). Omitting both a target and broadcast also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — select a target or set broadcast: true.",
           "name": "Broadcast"
         },
         "cut": {
           "description": "Paper cutting mode after printing (defaults to the printer's configured cut mode)",
           "name": "Cut"
-        },
-        "device_id": {
-          "description": "Select one or more printer devices (if omitted, broadcasts to all printers)",
-          "name": "Device"
         },
         "feed": {
           "description": "Number of lines to feed after printing",

--- a/docs/multi-printer.md
+++ b/docs/multi-printer.md
@@ -4,7 +4,9 @@ Add the integration once per printer. Each gets its own device, binary sensor, n
 
 ## Targeting in service calls
 
-Printers are targeted by **`device_id`**: either in a `target:` block or directly in `data:`. Each `device_id` resolves to a config entry; the service runs against each. Targeting by `area_id`, `label_id`, or `entity_id` is **not supported** and is rejected with a validation error.
+Printers are targeted with Home Assistant's standard `target:` block (new in 1.2.0): pick devices, entities, areas, floors, or labels, and every ESC/POS printer they resolve to is printed on. This also means the print services now show up in the entity/device "Add to… → Create as a new action" pickers.
+
+Passing **`device_id`** directly in `data:` (the only form supported before 1.2.0) keeps working exactly as before — existing automations and scripts need no changes.
 
 ### Specific printer
 
@@ -28,6 +30,34 @@ data:
   text: "Sent to both printers"
 ```
 
+### All printers in an area
+
+```yaml
+service: escpos_printer.print_text
+target:
+  area_id: kitchen
+data:
+  text: "Sent to every ESC/POS printer in the Kitchen"
+```
+
+Non-printer devices in the area are ignored. A target that resolves to no
+ESC/POS printer at all (e.g. an empty area) is rejected with a validation
+error. Floors and labels work the same way. Targeting a printer's notify
+entity is equivalent to targeting its device — the entity picker offers the
+same printer either way.
+
+### Legacy `device_id` plus a target: union, not replace
+
+A call can carry a legacy `device_id` in `data:` **and** a picker target
+(entity/area/floor/label) at the same time — the two are **unioned**, not
+one replacing the other, so every printer resolved by either one prints.
+
+This matters for automations built in the UI before 1.2.0: their `device_id`
+was stored inside `data:` (not the newer `target:` block), so opening one of
+those automations in the editor now shows an empty target picker even though
+the call still works exactly as before. Adding a picker target on top of
+that stored `device_id` prints to both, not just the new target.
+
 ### Broadcast to all printers
 
 Omit `target:` (and the `broadcast` field) to send to every loaded entry, kept for backward compatibility:
@@ -39,10 +69,10 @@ data:
 ```
 
 If more than one printer is configured, omitting the target logs a warning
-(`no device_id specified: printing to all N configured printers`) so an
+(`no target specified — printing to all N configured printers`) so an
 automation that only meant to target one printer doesn't silently print
-everywhere. To send to all printers on purpose without the warning, set
-`broadcast: true` instead:
+everywhere. This implicit fallback is deprecated and will be removed in
+2.0.0 — use `broadcast: true` to send to all printers on purpose:
 
 ```yaml
 service: escpos_printer.print_text
@@ -51,8 +81,9 @@ data:
   text: "Broadcast to all printers, explicitly"
 ```
 
-`broadcast: true` and `device_id` are mutually exclusive; combining them
-is rejected before the service runs.
+`broadcast: true` and any target (`device_id`, `entity_id`, `area_id`,
+`floor_id`, `label_id`) are mutually exclusive; combining them is rejected
+before the service runs.
 
 ## Finding device IDs
 
@@ -63,4 +94,4 @@ is rejected before the service runs.
 
 ## Assigning printers to areas
 
-You can assign a printer device to an area for organization (**Settings → Devices & services** → your printer → pencil icon → pick an area), but service calls cannot target by `area_id`: use `device_id`.
+Assign a printer device to an area (**Settings → Devices & services** → your printer → pencil icon → pick an area) and, since 1.2.0, service calls can target that area directly with `target: area_id:`.

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,6 +1,6 @@
 # Services
 
-The integration registers these services. All printer services accept a `device_id` for targeting, plus a `broadcast: true` flag to explicitly print to every configured printer (`broadcast` and `device_id` are mutually exclusive). Omitting both also prints to all printers (kept for backward compatibility), but logs a warning when more than one printer is configured. See [multi-printer.md](multi-printer.md).
+The integration registers these services. All printer services accept Home Assistant's standard `target:` block (devices, entities, areas, floors, labels — new in 1.2.0) and continue to accept the legacy `device_id` field in `data:` — existing automations need no changes. A `broadcast: true` flag explicitly prints to every configured printer (`broadcast` and any target are mutually exclusive). Omitting both also prints to all printers, but that implicit fallback is deprecated and will be removed in 2.0.0 — logging a warning when more than one printer is configured until then. See [multi-printer.md](multi-printer.md).
 
 ## escpos_printer.print_text
 
@@ -249,8 +249,8 @@ choose a `dither` mode and `threshold` for `print_image`.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| device_id | string\|list | Target printer(s); omit to print to all (warns with several printers) |
-| broadcast | boolean | Explicitly print to all printers (mutually exclusive with device_id) |
+| device_id | string\|list | Legacy target field; the standard target picker (device/entity/area/floor/label) also works. Omit to print to all (deprecated fallback, warns with several printers) |
+| broadcast | boolean | Explicitly print to all printers (mutually exclusive with any target: device/entity/area/floor/label) |
 | cut | string | `none`, `partial`, `full` (default `full`) |
 | feed | int | Lines to feed after printing (default 2) |
 

--- a/docs/superpowers/plans/2026-08-15-device-page-actions.md
+++ b/docs/superpowers/plans/2026-08-15-device-page-actions.md
@@ -1,0 +1,915 @@
+# Device Page Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the printer device page a Controls card (Feed / Cut / Beep / Sample test print buttons) and make the calibration wizard discoverable via a fixable Repairs issue.
+
+**Architecture:** A new `button` platform presses through the existing adapter methods (already lock-serialized). A sample-print composer uses the existing `batch_connection()` single-connection API (extended with styled text + QR). A `repairs.py` platform reuses `CalibrationFlowMixin` — already flow-agnostic — so the real wizard runs from Settings → Repairs; `async_setup_entry` raises/clears one issue per never-calibrated entry.
+
+**Tech Stack:** Home Assistant custom integration (Python 3.14, HA floor 2026.5.0), pytest-homeassistant-custom-component, voluptuous, python-escpos.
+
+**Spec:** `docs/superpowers/specs/2026-08-15-device-page-actions-design.md`
+
+## Global Constraints
+
+- Run everything with `uv run …` from the repo root; if tools look stale run `uv sync --all-extras` first.
+- Copy rules (approved wording, use verbatim): issue title **"Printer not yet calibrated"**; issue description **"The optional calibration tool prints test pages to tune print width and character set for this printer and paper. Run it now, or ignore this — printing works without it."**
+- Feed button feeds a fixed **3** lines. Cut button uses the entry's `CONF_DEFAULT_CUT`, falling back to `"full"` when unset or `"none"`.
+- `strings.json` and `translations/en.json` are maintained as identical copies for non-`services` keys — every manual edit to one must be mirrored in the other, then verified with `uv run python scripts/sync_service_translations.py --check`.
+- Every user-visible change gets a CHANGELOG entry under `## [Unreleased]`.
+- Never run `git stash` / `git reset` / anything that discards working-tree state.
+- Unit tests: conftest monkeypatches `PLATFORMS` to `["notify"]`; tests needing the button platform must re-patch (shown in Task 3).
+- Commit after each task with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` in the message.
+
+---
+
+### Task 0: Branch setup
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Create the feature branch**
+
+Check whether PR #151 is merged: `gh pr view 151 --json state -q .state`.
+- If `MERGED`: `git checkout main && git pull && git checkout -b feat/device-page-actions`
+- Otherwise: `git checkout feat/service-action-targets && git pull && git checkout -b feat/device-page-actions`
+
+---
+
+### Task 1: `_BatchPage` styled text passthrough + QR
+
+**Files:**
+- Modify: `custom_components/escpos_printer/printer/base_adapter.py` (class `_BatchPage`, ~line 752)
+- Modify: `custom_components/escpos_printer/printer/print_operations.py` (extract `_qr_under_lock`)
+- Test: `tests/test_batch_page_extensions.py` (create)
+
+**Interfaces:**
+- Consumes: `_print_text_under_lock(adapter, hass, printer, *, text, align, bold, underline, width, height, encoding, wrap)` and `map_align` (already imported/importable in these modules).
+- Produces: `_BatchPage.print_text(*, text, align=None, bold=None, underline=None, width=None, height=None, encoding=None, wrap=True, feed=0)` and `_BatchPage.print_qr(*, data, size=None, ec=None, align="center")` — Task 2 calls both.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Tests for _BatchPage styled-text passthrough and QR printing."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.const import CONF_HOST, CONF_PORT
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.escpos_printer.const import DOMAIN
+
+
+async def _setup_entry(hass, host="1.2.3.4"):  # type: ignore[no-untyped-def]
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: host, CONF_PORT: 9100},
+        title=f"ESC/POS {host}",
+    )
+    entry.add_to_hass(hass)
+    with patch("escpos.printer.Network", return_value=MagicMock()):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+async def test_batch_page_styled_text_and_qr(hass):  # type: ignore[no-untyped-def]
+    """Styled kwargs reach printer.set(); qr() is issued on the held connection."""
+    entry = await _setup_entry(hass)
+    adapter = entry.runtime_data.adapter
+    fake = MagicMock()
+    with patch("escpos.printer.Network", return_value=fake):
+        async with adapter.batch_connection(hass) as page:
+            await page.print_text(text="Loud\n", bold=True, align="center")
+            await page.print_qr(data="https://example.com")
+
+    assert fake.qr.called
+    qr_args, qr_kwargs = fake.qr.call_args
+    assert qr_args[0] == "https://example.com"
+    # bold=True must have been forwarded to printer.set() by the text half
+    set_kwargs = [kw for _, kw in [c for c in fake.set.call_args_list]]
+    assert any(kw.get("bold") for kw in set_kwargs)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_batch_page_extensions.py -v`
+Expected: FAIL — `TypeError: print_text() got an unexpected keyword argument 'bold'` (or `AttributeError: print_qr`).
+
+- [ ] **Step 3: Extract `_qr_under_lock` in print_operations.py**
+
+Move the body of `print_qr`'s validation + `_do_print` (currently inline at `print_operations.py:78-125`) into a module-level helper next to `_print_text_under_lock`, and call it from `print_qr`:
+
+```python
+async def _qr_under_lock(
+    hass: HomeAssistant,
+    printer: Any,
+    *,
+    data: str,
+    size: int | None = None,
+    ec: str | None = None,
+    align: str | None = None,
+) -> None:
+    """Validate + print a QR on an already-acquired connection (lock held by caller)."""
+    data = validate_qr_data(data)
+    align_m = map_align(align)
+    qsize = int(size) if size is not None else 3
+    qsize = max(1, min(16, qsize))
+    qec = (ec or "M").upper()
+    if qec not in ("L", "M", "Q", "H"):
+        qec = "M"
+
+    def _map_qr_ec(level: str) -> Any:
+        try:
+            from escpos import escpos as _esc  # noqa: PLC0415
+
+            return {
+                "L": getattr(_esc, "QR_ECLEVEL_L", "L"),
+                "M": getattr(_esc, "QR_ECLEVEL_M", "M"),
+                "Q": getattr(_esc, "QR_ECLEVEL_Q", "Q"),
+                "H": getattr(_esc, "QR_ECLEVEL_H", "H"),
+            }[level]
+        except Exception:
+            return level
+
+    def _do_print(printer_obj: Any) -> None:
+        if hasattr(printer_obj, "set"):
+            printer_obj.set(align=align_m, normal_textsize=True)
+        printer_obj.qr(data, size=qsize, ec=_map_qr_ec(qec))
+
+    await hass.async_add_executor_job(_do_print, printer)
+```
+
+`print_qr` becomes: acquire lock/printer as today, then `await _qr_under_lock(hass, printer, data=data, size=size, ec=ec, align=align)`, then `_apply_cut_and_feed` — behavior identical.
+
+- [ ] **Step 4: Extend `_BatchPage` in base_adapter.py**
+
+Replace `_BatchPage.print_text`'s hardcoded `None` style args with passthrough parameters, and add `print_qr` (import `_qr_under_lock` alongside the existing `_print_text_under_lock` import):
+
+```python
+    async def print_text(
+        self,
+        *,
+        text: str,
+        align: str | None = None,
+        bold: bool | None = None,
+        underline: str | None = None,
+        width: str | int | None = None,
+        height: str | int | None = None,
+        encoding: str | None = None,
+        wrap: bool = True,
+        feed: int | None = 0,
+    ) -> None:
+        """Print text on the held connection (mirrors ``adapter.print_text``)."""
+        await _print_text_under_lock(
+            self._adapter,
+            self._hass,
+            self._printer,
+            text=text,
+            align=align,
+            bold=bold,
+            underline=underline,
+            width=width,
+            height=height,
+            encoding=encoding,
+            wrap=wrap,
+        )
+        await self._adapter._apply_cut_and_feed(self._hass, self._printer, "none", feed)
+
+    async def print_qr(
+        self,
+        *,
+        data: str,
+        size: int | None = None,
+        ec: str | None = None,
+        align: str | None = "center",
+    ) -> None:
+        """Print a QR code on the held connection (mirrors ``adapter.print_qr``)."""
+        await _qr_under_lock(
+            self._hass, self._printer, data=data, size=size, ec=ec, align=align
+        )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_batch_page_extensions.py -v` → PASS.
+Run: `uv run pytest -q` → no regressions (the existing QR service tests cover the extraction).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/escpos_printer/printer/base_adapter.py \
+        custom_components/escpos_printer/printer/print_operations.py \
+        tests/test_batch_page_extensions.py
+git commit -m "Add styled text and QR to _BatchPage held-connection API"
+```
+
+---
+
+### Task 2: Sample print composer
+
+**Files:**
+- Create: `custom_components/escpos_printer/sample_print.py`
+- Test: `tests/test_sample_print.py` (create)
+
+**Interfaces:**
+- Consumes: `_BatchPage.print_text` / `print_qr` (Task 1), `adapter.batch_connection(hass)`, `adapter.cut(hass, *, mode)`, `_shared_print_config(entry)` from the package `__init__`, `render_box` (`text_effects/box.py:77`), `render_table` (`text_effects/table.py:157`).
+- Produces: `async_print_sample(hass: HomeAssistant, entry: EscposConfigEntry) -> None` — Task 3's button calls it.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Tests for the sample test print composer."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.const import CONF_HOST, CONF_PORT
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.escpos_printer.const import DOMAIN
+from custom_components.escpos_printer.sample_print import async_print_sample
+
+
+async def _setup_entry(hass, host="1.2.3.4"):  # type: ignore[no-untyped-def]
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: host, CONF_PORT: 9100},
+        title=f"ESC/POS {host}",
+    )
+    entry.add_to_hass(hass)
+    with patch("escpos.printer.Network", return_value=MagicMock()):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+async def test_sample_print_composes_one_receipt(hass):  # type: ignore[no-untyped-def]
+    """Logo image, text sections, and QR go out; a cut follows."""
+    entry = await _setup_entry(hass)
+    fake = MagicMock()
+    with patch("escpos.printer.Network", return_value=fake):
+        await async_print_sample(hass, entry)
+
+    assert fake.image.called, "logo did not print"
+    assert fake.qr.called, "QR did not print"
+    assert fake.cut.called, "receipt was not cut"
+    # image (logo) must come before qr on the wire
+    names = [c[0] for c in fake.method_calls]
+    assert names.index("image") < names.index("qr")
+
+
+async def test_sample_print_cut_mode_none_falls_back_to_full(hass):  # type: ignore[no-untyped-def]
+    """An entry whose default cut is 'none' still cuts (full)."""
+    from custom_components.escpos_printer.const import CONF_DEFAULT_CUT
+
+    entry = await _setup_entry(hass)
+    hass.config_entries.async_update_entry(
+        entry, options={**entry.options, CONF_DEFAULT_CUT: "none"}
+    )
+    await hass.async_block_till_done()
+    fake = MagicMock()
+    with patch("escpos.printer.Network", return_value=fake):
+        await async_print_sample(hass, entry)
+    assert fake.cut.called
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_sample_print.py -v`
+Expected: FAIL — `ModuleNotFoundError: custom_components.escpos_printer.sample_print`.
+
+- [ ] **Step 3: Implement `sample_print.py`**
+
+```python
+"""Compose the 'Sample test print' receipt (device page button).
+
+One uninterrupted receipt on a single held connection: logo, boxed
+header, styled text, table, separator, QR. ASCII border style on
+purpose — it renders identically on every codepage, so the sample
+never needs transcoding.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from homeassistant.core import HomeAssistant
+
+from .text_effects.box import render_box
+from .text_effects.table import render_table
+
+if TYPE_CHECKING:
+    from . import EscposConfigEntry
+
+_LOGO_PATH = Path(__file__).parent / "brand" / "logo.png"
+_REPO_URL = "https://github.com/cognitivegears/ha-escpos-thermal-printer"
+
+
+def _logo_data_uri() -> str:
+    """base64 data URI for the bundled logo (blocking; run via executor)."""
+    return "data:image/png;base64," + base64.b64encode(_LOGO_PATH.read_bytes()).decode()
+
+
+async def async_print_sample(hass: HomeAssistant, entry: EscposConfigEntry) -> None:
+    """Print the sample receipt on the entry's printer."""
+    from . import _shared_print_config  # noqa: PLC0415 (avoid import cycle at module load)
+
+    adapter = entry.runtime_data.adapter
+    line_width = _shared_print_config(entry)["line_width"]
+    logo = await hass.async_add_executor_job(_logo_data_uri)
+
+    header = render_box(
+        f"ESC/POS Sample Print\n{entry.title}",
+        inner_width=max(line_width - 2, 10),
+        style="ascii",
+        align="center",
+    )
+    table = render_table(
+        [["Item", "Qty"], ["Receipt demo", "1"], ["Styled text", "3"]],
+        total_width=line_width,
+        style="ascii",
+        header=True,
+    )
+
+    async with adapter.batch_connection(hass) as page:
+        await page.print_image(image=logo, auto_resize=True)
+        await page.print_text(text=header + "\n")
+        await page.print_text(text="Bold text\n", bold=True)
+        await page.print_text(text="Underlined text\n", underline="single")
+        await page.print_text(text="Double size\n", width=2, height=2)
+        await page.print_text(text=table + "\n")
+        await page.print_text(text="=" * line_width + "\n")
+        await page.print_qr(data=_REPO_URL)
+        await page.print_text(text=f"Docs & source:\n{_REPO_URL}\n")
+        await page.feed(2)
+
+    # Batch pages never cut (documented _BatchPage contract) — follow-up
+    # cut like the calibration wizard does. "none" would make the button
+    # print an uncut dangling receipt, so fall back to full.
+    cut_mode = entry.runtime_data.defaults.get("cut") or "full"
+    if cut_mode == "none":
+        cut_mode = "full"
+    await adapter.cut(hass, mode=cut_mode)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_sample_print.py -v` → PASS. If `page.print_image` rejects the data URI or width, check `prepare_image_for_print` error output — calibration already passes generated data URIs through this exact path, so mirror what `calibration.py` does if anything differs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/escpos_printer/sample_print.py tests/test_sample_print.py
+git commit -m "Add sample test print composer"
+```
+
+---
+
+### Task 3: Button platform
+
+**Files:**
+- Create: `custom_components/escpos_printer/button.py`
+- Modify: `custom_components/escpos_printer/__init__.py:83` (`PLATFORMS` list)
+- Modify: `custom_components/escpos_printer/strings.json` + `custom_components/escpos_printer/translations/en.json` (`entity` section — mirror the edit in both files)
+- Modify: `custom_components/escpos_printer/icons.json` (`entity` section)
+- Test: `tests/test_buttons.py` (create)
+
+**Interfaces:**
+- Consumes: `async_print_sample(hass, entry)` (Task 2); `adapter.feed(hass, *, lines)`, `adapter.cut(hass, *, mode)`, `adapter.beep(hass)` (`printer/control_operations.py:54,92,128`); `build_device_info(entry)` (`device.py:61`).
+- Produces: four button entities with translation keys `feed` / `cut` / `beep` / `sample_print`, unique_ids `{entry_id}_{key}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Tests for the printer device-page buttons."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers import entity_registry as er
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.escpos_printer.const import CONF_DEFAULT_CUT, DOMAIN
+
+
+@pytest.fixture(autouse=True)
+def _enable_button_platform(monkeypatch):  # type: ignore[no-untyped-def]
+    """conftest limits unit-test platforms to ['notify']; buttons need theirs."""
+    import custom_components.escpos_printer.__init__ as cc_init
+
+    monkeypatch.setattr(cc_init, "PLATFORMS", ["notify", "button"], raising=False)
+
+
+async def _setup_entry(hass, host="1.2.3.4", options=None):  # type: ignore[no-untyped-def]
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: host, CONF_PORT: 9100},
+        options=options or {},
+        title=f"ESC/POS {host}",
+    )
+    entry.add_to_hass(hass)
+    with patch("escpos.printer.Network", return_value=MagicMock()):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _button_entity_id(hass, entry, key):  # type: ignore[no-untyped-def]
+    registry = er.async_get(hass)
+    entity = registry.async_get_entity_id("button", DOMAIN, f"{entry.entry_id}_{key}")
+    assert entity is not None, f"button {key} not registered"
+    return entity
+
+
+async def _press(hass, entity_id):  # type: ignore[no-untyped-def]
+    await hass.services.async_call(
+        "button", "press", {"entity_id": entity_id}, blocking=True
+    )
+
+
+async def test_feed_button_feeds_three_lines(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass)
+    entry.runtime_data.adapter.feed = AsyncMock()
+    await _press(hass, _button_entity_id(hass, entry, "feed"))
+    entry.runtime_data.adapter.feed.assert_awaited_once_with(hass, lines=3)
+
+
+async def test_cut_button_uses_entry_default(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass, options={CONF_DEFAULT_CUT: "partial"})
+    entry.runtime_data.adapter.cut = AsyncMock()
+    await _press(hass, _button_entity_id(hass, entry, "cut"))
+    entry.runtime_data.adapter.cut.assert_awaited_once_with(hass, mode="partial")
+
+
+async def test_cut_button_none_falls_back_to_full(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass, options={CONF_DEFAULT_CUT: "none"})
+    entry.runtime_data.adapter.cut = AsyncMock()
+    await _press(hass, _button_entity_id(hass, entry, "cut"))
+    entry.runtime_data.adapter.cut.assert_awaited_once_with(hass, mode="full")
+
+
+async def test_beep_button(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass)
+    entry.runtime_data.adapter.beep = AsyncMock()
+    await _press(hass, _button_entity_id(hass, entry, "beep"))
+    entry.runtime_data.adapter.beep.assert_awaited_once_with(hass)
+
+
+async def test_sample_print_button_calls_composer(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass)
+    with patch(
+        "custom_components.escpos_printer.button.async_print_sample",
+        new=AsyncMock(),
+    ) as sample:
+        await _press(hass, _button_entity_id(hass, entry, "sample_print"))
+    sample.assert_awaited_once_with(hass, entry)
+
+
+async def test_buttons_attached_to_printer_device(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass)
+    registry = er.async_get(hass)
+    entity_id = _button_entity_id(hass, entry, "feed")
+    reg_entry = registry.async_get(entity_id)
+    assert reg_entry is not None and reg_entry.device_id is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_buttons.py -v`
+Expected: FAIL — button entities not registered (`assert entity is not None` trips).
+
+- [ ] **Step 3: Implement `button.py` and register the platform**
+
+```python
+"""Button platform: Feed, Cut, Beep, Sample test print on the device page."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+
+from .device import build_device_info
+from .sample_print import async_print_sample
+
+if TYPE_CHECKING:
+    from . import EscposConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 1
+
+# ponytail: fixed tear-off advance; make configurable only if someone asks
+FEED_LINES = 3
+
+
+async def async_setup_entry(  # type: ignore[no-untyped-def]
+    hass: HomeAssistant, entry: EscposConfigEntry, async_add_entities
+) -> None:
+    async_add_entities(
+        [
+            EscposFeedButton(hass, entry),
+            EscposCutButton(hass, entry),
+            EscposBeepButton(hass, entry),
+            EscposSamplePrintButton(hass, entry),
+        ]
+    )
+
+
+class _EscposButton(ButtonEntity):
+    _attr_has_entity_name = True
+
+    def __init__(self, hass: HomeAssistant, entry: EscposConfigEntry) -> None:
+        self._hass = hass
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_{self._attr_translation_key}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return build_device_info(self._entry)
+
+    async def async_press(self) -> None:
+        try:
+            await self._press()
+        except HomeAssistantError:
+            raise
+        except Exception as err:
+            raise HomeAssistantError(
+                f"Printer operation failed: {err.__class__.__name__}"
+            ) from err
+
+    async def _press(self) -> None:
+        raise NotImplementedError
+
+
+class EscposFeedButton(_EscposButton):
+    _attr_translation_key = "feed"
+
+    async def _press(self) -> None:
+        await self._entry.runtime_data.adapter.feed(self._hass, lines=FEED_LINES)
+
+
+class EscposCutButton(_EscposButton):
+    _attr_translation_key = "cut"
+
+    async def _press(self) -> None:
+        # A Cut button that does nothing reads as broken — "none" → full.
+        mode = self._entry.runtime_data.defaults.get("cut") or "full"
+        if mode == "none":
+            mode = "full"
+        await self._entry.runtime_data.adapter.cut(self._hass, mode=mode)
+
+
+class EscposBeepButton(_EscposButton):
+    _attr_translation_key = "beep"
+
+    async def _press(self) -> None:
+        await self._entry.runtime_data.adapter.beep(self._hass)
+
+
+class EscposSamplePrintButton(_EscposButton):
+    _attr_translation_key = "sample_print"
+
+    async def _press(self) -> None:
+        await async_print_sample(self._hass, self._entry)
+```
+
+In `__init__.py:83` change `PLATFORMS: list[str] = ["notify", "binary_sensor", "sensor"]` to `PLATFORMS: list[str] = ["notify", "binary_sensor", "sensor", "button"]`.
+
+- [ ] **Step 4: Add entity names and icons**
+
+In **both** `strings.json` and `translations/en.json`, add to the existing `"entity"` object (alongside `"binary_sensor"` / `"sensor"`):
+
+```json
+"button": {
+  "feed": {"name": "Feed paper"},
+  "cut": {"name": "Cut paper"},
+  "beep": {"name": "Beep"},
+  "sample_print": {"name": "Sample test print"}
+}
+```
+
+In `icons.json`, add to `"entity"`:
+
+```json
+"button": {
+  "feed": {"default": "mdi:arrow-collapse-down"},
+  "cut": {"default": "mdi:content-cut"},
+  "beep": {"default": "mdi:volume-high"},
+  "sample_print": {"default": "mdi:receipt-text-check-outline"}
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_buttons.py -v` → PASS.
+Run: `uv run python scripts/sync_service_translations.py --check` → in sync (proves the mirrored strings/en.json edits stayed identical).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/escpos_printer/button.py custom_components/escpos_printer/__init__.py \
+        custom_components/escpos_printer/strings.json custom_components/escpos_printer/translations/en.json \
+        custom_components/escpos_printer/icons.json tests/test_buttons.py
+git commit -m "Add Feed/Cut/Beep/Sample buttons to the device page"
+```
+
+---
+
+### Task 4: Repairs-based calibration entry
+
+**Files:**
+- Create: `custom_components/escpos_printer/repairs.py`
+- Modify: `custom_components/escpos_printer/__init__.py` (`async_setup_entry`, after `entry.runtime_data` is assigned and platforms forwarded; plus the existing entry-removal cleanup block near line 377-392 that deletes `profile_width_fallback` issues — extend it the same way)
+- Modify: `custom_components/escpos_printer/strings.json` + `translations/en.json` (`issues` section — mirror both)
+- Test: `tests/test_repairs.py` (create)
+
+**Interfaces:**
+- Consumes: `CalibrationFlowMixin` (`_config_flow/calibration_steps.py:113` — needs `hass`, `config_entry`, `_calib`, `_calib_extra`; entry step `async_step_calibrate` aborts with reason `printer_not_ready` unless the entry is LOADED, else shows step `calibrate_confirm`). `_CALIB_TO_CONF` maps to `CONF_IMPL`, `CONF_WIDTH_PIXELS`, `CONF_LINE_WIDTH`, `CONF_CODEPAGE` (import these four from `.const`).
+- Produces: fixable issue id `printer_not_calibrated_{entry_id}` with `data={"entry_id": ...}`; `async_create_fix_flow(hass, issue_id, data)` returning `NotCalibratedRepairFlow`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Tests for the printer-not-calibrated repairs issue and fix flow."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers import issue_registry as ir
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.escpos_printer.const import CONF_LINE_WIDTH, DOMAIN
+
+
+async def _setup_entry(hass, host="1.2.3.4", options=None):  # type: ignore[no-untyped-def]
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: host, CONF_PORT: 9100},
+        options=options or {},
+        title=f"ESC/POS {host}",
+    )
+    entry.add_to_hass(hass)
+    with patch("escpos.printer.Network", return_value=MagicMock()):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _issue(hass, entry):  # type: ignore[no-untyped-def]
+    registry = ir.async_get(hass)
+    return registry.async_get_issue(DOMAIN, f"printer_not_calibrated_{entry.entry_id}")
+
+
+async def test_uncalibrated_entry_raises_issue(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass)
+    issue = _issue(hass, entry)
+    assert issue is not None
+    assert issue.is_fixable
+    assert issue.translation_key == "printer_not_calibrated"
+
+
+async def test_calibrated_entry_has_no_issue(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass, options={CONF_LINE_WIDTH: 42})
+    assert _issue(hass, entry) is None
+
+
+async def test_issue_cleared_after_calibration_reload(hass):  # type: ignore[no-untyped-def]
+    """Saving a calibration option and reloading (what the wizard does) clears the issue."""
+    entry = await _setup_entry(hass)
+    assert _issue(hass, entry) is not None
+    hass.config_entries.async_update_entry(
+        entry, options={**entry.options, CONF_LINE_WIDTH: 42}
+    )
+    with patch("escpos.printer.Network", return_value=MagicMock()):
+        assert await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+    assert _issue(hass, entry) is None
+
+
+async def test_fix_flow_opens_wizard_confirm_step(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass)
+    from custom_components.escpos_printer.repairs import async_create_fix_flow
+
+    flow = await async_create_fix_flow(
+        hass,
+        f"printer_not_calibrated_{entry.entry_id}",
+        {"entry_id": entry.entry_id},
+    )
+    flow.hass = hass
+    result = await flow.async_step_init()
+    assert result["type"] == "form"
+    assert result["step_id"] == "calibrate_confirm"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_repairs.py -v`
+Expected: FAIL — no issue created / `ModuleNotFoundError: ...repairs`.
+
+- [ ] **Step 3: Implement `repairs.py`**
+
+```python
+"""Repairs platform: fix flow for the printer-not-calibrated suggestion.
+
+The fix flow IS the calibration wizard — ``CalibrationFlowMixin`` was
+written flow-agnostic (needs only ``hass`` + ``config_entry``), so it
+runs identically here and in the options flow.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+
+from ._config_flow.calibration_steps import CalibrationFlowMixin
+
+
+class NotCalibratedRepairFlow(CalibrationFlowMixin, RepairsFlow):
+    """Run the calibration wizard from Settings → Repairs."""
+
+    def __init__(self, entry: Any) -> None:
+        self.config_entry = entry
+        self._calib: dict[str, Any] = {}
+        self._calib_extra: dict[str, Any] = {}
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        return await self.async_step_calibrate()  # type: ignore[return-value]
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant, issue_id: str, data: dict[str, Any] | None
+) -> RepairsFlow:
+    entry = hass.config_entries.async_get_entry((data or {})["entry_id"])
+    if entry is None:
+        raise ValueError(f"Unknown config entry for repairs issue {issue_id}")
+    return NotCalibratedRepairFlow(entry)
+```
+
+If mypy complains about the `FlowResult`/`ConfigFlowResult` return-type mismatch between the mixin and `RepairsFlow`, resolve with a targeted `# type: ignore[...]` on the class line — do not restructure the mixin.
+
+- [ ] **Step 4: Raise/clear the issue in `async_setup_entry`**
+
+In `__init__.py`, after platform forwarding succeeds, add (importing `CONF_IMPL`, `CONF_WIDTH_PIXELS`, `CONF_CODEPAGE` alongside the already-imported `CONF_LINE_WIDTH` from `.const`):
+
+```python
+    # Calibration nudge: one fixable Repairs issue per never-calibrated
+    # entry. "Calibrated" = any wizard-saved key present in options; the
+    # settings form writes the same keys, which is fine — a user who
+    # found the options flow doesn't need the pointer.
+    from homeassistant.helpers import issue_registry as ir  # noqa: PLC0415
+
+    calibrated = any(
+        key in entry.options
+        for key in (CONF_IMPL, CONF_WIDTH_PIXELS, CONF_LINE_WIDTH, CONF_CODEPAGE)
+    )
+    issue_id = f"printer_not_calibrated_{entry.entry_id}"
+    if calibrated:
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
+    else:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="printer_not_calibrated",
+            translation_placeholders={"name": entry.title},
+            data={"entry_id": entry.entry_id},
+        )
+```
+
+Extend the existing entry-removal cleanup (the block near `__init__.py:377-392` that deletes `profile_width_fallback` issues) to also call `ir.async_delete_issue(hass, DOMAIN, f"printer_not_calibrated_{entry.entry_id}")`, matching its style.
+
+- [ ] **Step 5: Add issue strings (both strings.json and translations/en.json)**
+
+Add to the existing `"issues"` object, alongside `"profile_width_fallback"`:
+
+```json
+"printer_not_calibrated": {
+  "title": "Printer not yet calibrated",
+  "description": "The optional calibration tool prints test pages to tune print width and character set for this printer and paper. Run it now, or ignore this — printing works without it.",
+  "fix_flow": {
+    "step": {},
+    "abort": {}
+  }
+}
+```
+
+Then populate `fix_flow.step` / `fix_flow.abort` by copying the wizard's existing options-flow translations (repairs flows look up `issues.<translation_key>.fix_flow.*`, not `options.*`). Run this once and inspect the diff:
+
+```python
+# scratch script — run with: uv run python <path>
+import json
+
+for path in (
+    "custom_components/escpos_printer/strings.json",
+    "custom_components/escpos_printer/translations/en.json",
+):
+    with open(path) as f:
+        data = json.load(f)
+    steps = {
+        k: v
+        for k, v in data["options"]["step"].items()
+        if k.startswith("calibrate")
+    }
+    aborts = {
+        k: v
+        for k, v in data["options"].get("abort", {}).items()
+        if "calibrat" in k or k == "printer_not_ready"
+    }
+    fix = data["issues"]["printer_not_calibrated"]["fix_flow"]
+    fix["step"] = steps
+    fix["abort"] = aborts
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+```
+
+Match the files' existing indent style (check `git diff` — if the repo uses a different JSON formatting, adjust the dump call to match; the sync-check in Step 6 plus `git diff` review is the guard).
+
+- [ ] **Step 6: Run tests + validation**
+
+Run: `uv run pytest tests/test_repairs.py -v` → PASS.
+Run: `uv run python scripts/sync_service_translations.py --check` → in sync.
+Run hassfest (validates the issues/strings schema):
+`docker run --rm -v "$(pwd)":/github/workspace ghcr.io/home-assistant/hassfest:latest` → `Invalid integrations: 0`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add custom_components/escpos_printer/repairs.py custom_components/escpos_printer/__init__.py \
+        custom_components/escpos_printer/strings.json custom_components/escpos_printer/translations/en.json \
+        tests/test_repairs.py
+git commit -m "Suggest the calibration wizard via a fixable Repairs issue"
+```
+
+---
+
+### Task 5: Docs, changelog, roadmap, full gates
+
+**Files:**
+- Modify: `CHANGELOG.md` (`## [Unreleased]`)
+- Modify: `README.md`
+- Modify: the calibration doc (find it: `grep -l -i calibration docs/*.md`)
+- Modify: `ROADMAP.md` (item 1)
+
+**Interfaces:** none (prose only).
+
+- [ ] **Step 1: CHANGELOG**
+
+Under `## [Unreleased]` add:
+
+```markdown
+### Added
+
+- Device page buttons: Feed paper, Cut paper, Beep, and Sample test print
+  (a one-tap demo receipt with the integration logo, styled text, a table,
+  and a QR code).
+- Uncalibrated printers now get a dismissible suggestion in Settings →
+  Repairs that launches the calibration wizard directly — no more hunting
+  for it under the integration's Configure menu.
+```
+
+- [ ] **Step 2: README + calibration doc + ROADMAP**
+
+- README: in the features/entities area, one sentence: device page offers Feed / Cut / Beep / Sample test print buttons, and new printers get a Repairs suggestion linking to the calibration wizard.
+- Calibration doc (`grep -l -i calibration docs/*.md`): add a "Starting the wizard" note listing both entry points — Settings → Devices & services → ESC/POS entry → Configure → Calibrate, and the Settings → Repairs suggestion shown while a printer is uncalibrated.
+- ROADMAP item 1 ("Button entities"): rewrite to note Feed/Cut/Beep/Sample buttons shipped (this change); the calibration-sheet button was deliberately not added (Repairs entry covers calibration; `calibration_print` service remains).
+
+- [ ] **Step 3: Full gates**
+
+```
+uv run pytest -q
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy custom_components/
+uv run python scripts/sync_service_translations.py --check
+docker run --rm -v "$(pwd)":/github/workspace ghcr.io/home-assistant/hassfest:latest
+```
+
+All must pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md README.md ROADMAP.md docs/
+git commit -m "Document device page buttons and calibration repairs entry"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: buttons (Task 3), sample print incl. `_BatchPage` prerequisites (Tasks 1-2), repairs entry + trigger + copy (Task 4), docs/changelog/roadmap (Task 5). Out-of-scope items from the spec have no tasks, correctly.
+- The repairs fix-flow translation duplication (Task 4 Step 5) is required because repairs flows resolve translations under `issues.<key>.fix_flow.*`, not `options.*` — hassfest in Task 4 Step 6 validates the result.
+- Type consistency: `async_print_sample(hass, entry)` (Task 2) matches the button's call (Task 3); `_BatchPage.print_text/print_qr` signatures (Task 1) match Task 2's calls; issue id `printer_not_calibrated_{entry_id}` used identically in Task 4 code and tests.

--- a/docs/superpowers/specs/2026-08-15-device-page-actions-design.md
+++ b/docs/superpowers/specs/2026-08-15-device-page-actions-design.md
@@ -1,0 +1,116 @@
+# Device page actions: buttons + repairs-based calibration entry
+
+**Date:** 2026-08-15
+**Status:** Approved (design), pending implementation
+**Problem:** The device page shows nothing actionable (only sensors and the
+notify entity), and the calibration wizard is buried behind Settings →
+Devices & services → integration entry → Configure → "calibrate" — users
+don't find it. HA offers no way to launch an interactive flow from a device
+page, so the wizard needs a sanctioned, visible entry point elsewhere, and
+the device page needs a Controls card.
+
+## Part 1: Button platform
+
+New `custom_components/escpos_printer/button.py` with four `ButtonEntity`
+subclasses per config entry, attached to the printer device via the existing
+`build_device_info()`:
+
+| Button | Action |
+|---|---|
+| Feed | `adapter.feed(lines=3)` — fixed tear-off advance; there is no entry-level feed default to honor |
+| Cut | `adapter.cut(mode=<entry's CONF_DEFAULT_CUT, falling back to "full" when that is "none">)` — a Cut button must always cut |
+| Beep | `adapter.beep()` (adapter defaults: 2 beeps × 4 units) |
+| Sample test print | Composed sample receipt (below) |
+
+- Add `"button"` to `PLATFORMS` in `__init__.py`; entity names in
+  `strings.json` (+ regenerated `translations/en.json`), icons in
+  `icons.json`.
+- Presses run the existing adapter methods
+  (`printer/control_operations.py`) on executor threads under the same
+  per-adapter `asyncio.Lock` the services use. No new I/O paths.
+- Beep on a buzzerless printer behaves exactly like today's `beep`
+  service — no special-casing.
+- No calibration-sheet button (deliberate: the repairs entry covers
+  calibration; `calibration_print` service remains for power users).
+
+### Sample test print
+
+One small shared function (module: `services/` or `printer/` — implementer's
+choice, wherever the box/table layout helpers `_render_box_layout` /
+`_render_table_layout` are importable without cycles) composing one
+uninterrupted receipt:
+
+1. Integration logo `brand/logo.png` (666×256 RGBA) through the standard
+   image dither pipeline
+2. Boxed header: "ESC/POS Sample Print" + printer name (box renderer)
+3. Styled text lines demonstrating bold / underline / double-size
+4. Small two-column table (table renderer)
+5. Separator rule, then a QR code linking to the project repo
+6. Feed + cut per the entry's configured defaults
+
+Button-only for now; the shared function makes a future `print_sample`
+service trivial, but that service is explicitly out of scope (YAGNI).
+
+## Part 2: Repairs-based calibration entry
+
+- New `custom_components/escpos_printer/repairs.py` implementing
+  `async_create_fix_flow`, returning a flow class built as
+  `RepairsFlow + CalibrationFlowMixin` — the real wizard, unchanged,
+  running from Settings → Repairs. `CalibrationFlowMixin`
+  (`_config_flow/calibration_steps.py`) is already flow-agnostic (needs
+  only `hass` + `config_entry`); the repairs flow supplies the
+  `config_entry` from issue data (entry_id).
+- **Trigger:** `async_setup_entry` raises one fixable issue per never-
+  calibrated entry — "never calibrated" = none of the `_CALIB_TO_CONF`
+  option keys (`CONF_IMPL`, `CONF_WIDTH_PIXELS`, `CONF_LINE_WIDTH`,
+  `CONF_CODEPAGE`) present in `entry.options`. The check runs on every
+  setup/reload: condition gone → issue deleted (the wizard's save path
+  already schedules a reload, so completing it self-clears the issue).
+- Issue: `is_fixable=True`, severity `warning` (mildest available),
+  `issue_id` keyed by entry_id, deleted in `async_unload_entry` only on
+  entry removal (not on reload).
+- HA's built-in "Ignore" provides permanent dismissal; we never re-raise
+  an ignored issue (issue registry handles this).
+
+### Copy (approved wording — optional, not width-only)
+
+- Title: **"Printer not yet calibrated"**
+- Description: "The optional calibration tool prints test pages to tune
+  print width and character set for this printer and paper. Run it now,
+  or ignore this — printing works without it."
+- The fix flow opens on the wizard's existing confirm step; no
+  obligation-implying copy anywhere.
+
+## Testing
+
+- **Buttons:** each press calls the right adapter method (Feed → 3 lines;
+  Cut → entry default with "none"→"full" fallback; Beep → adapter
+  defaults); entities registered on the correct device; sample
+  print issues image + text + QR calls in order within a single adapter
+  session.
+- **Repairs:** uncalibrated entry → issue exists after setup; entry with
+  any `_CALIB_TO_CONF` key in options → no issue; completing the fix flow
+  → options saved, entry reloaded, issue gone. Reuse existing
+  calibration-flow test fixtures.
+
+## Docs / changelog
+
+- CHANGELOG `[Unreleased]` → Added: device page buttons (Feed, Cut, Beep,
+  Sample test print); Added: repairs suggestion for uncalibrated printers.
+- Calibration docs: mention the Repairs entry point alongside Configure.
+- README one-liner; ROADMAP item 1 trimmed (buttons shipped; calibration-
+  sheet button noted as not planned).
+
+## Out of scope
+
+- `print_sample` service (function is shared; service can come later).
+- Cash-drawer button (ROADMAP item 2).
+- Any change to the options-flow menu structure.
+- `configuration_url` deep-linking (rejected: conflicts with the
+  printer's own web UI and "Visit device" semantics).
+
+## Branch
+
+New branch based on `main` after PR #151 (target picker / 1.2.0) merges —
+the repairs check and buttons are independent of the target work, but
+CHANGELOG placement assumes 1.2.0 is cut.

--- a/docs/text-effects.md
+++ b/docs/text-effects.md
@@ -73,8 +73,8 @@ Wrap a block of text in a border.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `device_id` | device / [device] | *(all printers)* | Optional target. Omitting it prints to all printers (warns when several are configured). |
-| `broadcast` | bool | `false` | Explicitly print to all printers, without the warning. Mutually exclusive with `device_id`. |
+| `device_id` | device / [device] | *(all printers)* | Legacy target field; the standard target picker (device/entity/area/floor/label) also works. Omitting both prints to all printers (deprecated fallback, warns when several are configured). |
+| `broadcast` | bool | `false` | Explicitly print to all printers, without the warning. Mutually exclusive with any target (device/entity/area/floor/label). |
 | `text` | string | *(required)* | Text to wrap. Supports newlines. Up to 10 000 chars. |
 | `style` | enum | `auto` | One of `auto`, `single`, `double`, `ascii`, `asterisk`, `hash`, `none`. |
 | `padding` | int | `0` | Blank rows added above and below the content (0-4). |
@@ -160,8 +160,8 @@ The same applies to `print_kvtable`'s `items` field.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `device_id` | device / [device] | *(all printers)* | Optional target. Omitting it prints to all printers (warns when several are configured). |
-| `broadcast` | bool | `false` | Explicitly print to all printers, without the warning. Mutually exclusive with `device_id`. |
+| `device_id` | device / [device] | *(all printers)* | Legacy target field; the standard target picker (device/entity/area/floor/label) also works. Omitting both prints to all printers (deprecated fallback, warns when several are configured). |
+| `broadcast` | bool | `false` | Explicitly print to all printers, without the warning. Mutually exclusive with any target (device/entity/area/floor/label). |
 | `rows` | list of lists of strings | *(required)* | The grid. First row is the header when `header: true`. Up to 200 rows × 12 cols. |
 | `style` | enum | `auto` | Same options as `print_box`. `none` gives a borderless aligned grid. |
 | `column_widths` | list of ints | even split | Per-column character widths. Sum + (cols+1) separators must fit `total_width`. |
@@ -300,8 +300,8 @@ and size is capped at 16 MB.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `device_id` | device / [device] | *(all printers)* | Optional target. Omitting it prints to all printers (warns when several are configured). |
-| `broadcast` | bool | `false` | Explicitly print to all printers, without the warning. Mutually exclusive with `device_id`. |
+| `device_id` | device / [device] | *(all printers)* | Legacy target field; the standard target picker (device/entity/area/floor/label) also works. Omitting both prints to all printers (deprecated fallback, warns when several are configured). |
+| `broadcast` | bool | `false` | Explicitly print to all printers, without the warning. Mutually exclusive with any target (device/entity/area/floor/label). |
 | `text` | string | *(required)* | Text to render. Supports newlines (each newline starts a new line on the bitmap). Up to 10 000 chars. |
 | `font` | enum | `dejavu_mono` | Bundled font: `dejavu_mono`, `dejavu_sans`, or `dejavu_serif`. Ignored when `font_path` is set. |
 | `font_path` | string | *(unset)* | Optional path to a `.ttf` / `.otf` file inside `allowlist_external_dirs`. |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -218,7 +218,7 @@ The [calibration wizard](calibration.md) can usually diagnose and fix wrong or m
 
 - **"Service not found"**: restart HA; verify the integration loaded.
 - **"No valid ESC/POS printer targets found"**: wrong device ID, or entry not loaded. Use `broadcast: true` to send to all printers.
-- **"no device_id specified: printing to all N configured printers" warning**: a service call with multiple printers configured named no target. Add a `device_id` to target one printer, or set `broadcast: true` if printing everywhere is intended.
+- **"no target specified — printing to all N configured printers" warning**: a service call with multiple printers configured named no target. This implicit broadcast fallback is deprecated and will be removed in 2.0.0 — select a target (device, entity, area, floor, or label) to print to one printer, or set `broadcast: true` if printing everywhere is intended.
 - **"Printer configuration not found"**: entry was removed. Restart HA or re-add.
 - **Timeout errors during printing**: increase timeout, reduce image size, check network.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-escpos-thermal-printer"
-version = "1.1.0"
+version = "1.2.0"
 description = "Network thermal printer integration for Home Assistant using ESC/POS protocol"
 readme = "README.md"
 requires-python = ">=3.14.2"

--- a/tests/test_services_targeting.py
+++ b/tests/test_services_targeting.py
@@ -9,9 +9,14 @@ Covers:
 
 from unittest.mock import MagicMock, patch
 
+from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import floor_registry as fr
+from homeassistant.helpers import label_registry as lr
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 import voluptuous as vol
@@ -41,6 +46,36 @@ def _get_device_id_for_entry(hass, entry: MockConfigEntry) -> str:  # type: igno
     )
     assert device is not None
     return device.id
+
+
+def _get_notify_entity_id_for_entry(hass, entry: MockConfigEntry) -> str:  # type: ignore[no-untyped-def]
+    """Return the notify entity registered for this entry (unit tests enable the notify platform)."""
+    registry = er.async_get(hass)
+    entity = next(
+        (
+            e
+            for e in registry.entities.values()
+            if e.domain == NOTIFY_DOMAIN and e.config_entry_id == entry.entry_id
+        ),
+        None,
+    )
+    assert entity is not None
+    return entity.entity_id
+
+
+def _network_side_effect(fakes_by_host: dict):  # type: ignore[no-untyped-def]
+    """Return an ``escpos.printer.Network`` side_effect routing by host.
+
+    ``NetworkPrinterAdapter._connect`` calls ``Network(host, port=..., ...)``
+    with ``host`` positional -- keying the returned mock by ``args[0]`` lets
+    a test assert exactly one of two printers was actually written to,
+    rather than relying on a shared mock's aggregate call count.
+    """
+
+    def _side_effect(*args, **_kwargs):  # type: ignore[no-untyped-def]
+        return fakes_by_host[args[0]]
+
+    return _side_effect
 
 
 async def test_print_text_utf8_service_transcodes(hass):  # type: ignore[no-untyped-def]
@@ -325,7 +360,7 @@ async def test_omitted_target_with_two_entries_warns_once(hass, caplog):  # type
                 {"text": "Hello"},
                 blocking=True,
             )
-    warnings = [r for r in caplog.records if "no device_id specified" in r.message]
+    warnings = [r for r in caplog.records if "no target specified" in r.message]
     assert len(warnings) == 1
     assert "print_text" in warnings[0].message
     assert "2" in warnings[0].message
@@ -343,8 +378,227 @@ async def test_omitted_target_with_one_entry_does_not_warn(hass, caplog):  # typ
                 {"text": "Hello"},
                 blocking=True,
             )
-    warnings = [r for r in caplog.records if "no device_id specified" in r.message]
+    warnings = [r for r in caplog.records if "no target specified" in r.message]
     assert not warnings
+
+
+# ---------------------------------------------------------------------------
+# HA target-picker keys (entity_id/area_id/floor_id/label_id): populated by
+# a service's `target:` block (services.yaml) via HA core's device/entity
+# picker, resolved through async_extract_config_entry_ids in
+# target_resolution._async_get_target_entries_from_targets.
+# ---------------------------------------------------------------------------
+
+
+async def test_entity_id_target_resolves_to_printer_entry(hass):  # type: ignore[no-untyped-def]
+    """entity_id targeting one printer's notify entity prints only that printer."""
+    e1 = await _setup_entry(hass, "1.1.1.1")
+    await _setup_entry(hass, "2.2.2.2")
+    entity1 = _get_notify_entity_id_for_entry(hass, e1)
+
+    fake1, fake2 = MagicMock(), MagicMock()
+    with patch(
+        "escpos.printer.Network",
+        side_effect=_network_side_effect({"1.1.1.1": fake1, "2.2.2.2": fake2}),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "print_text",
+            {"text": "Hello", "entity_id": entity1},
+            blocking=True,
+        )
+    assert fake1.text.called
+    assert not fake2.text.called
+
+
+async def test_area_id_target_resolves_to_printer_entry(hass):  # type: ignore[no-untyped-def]
+    """area_id targeting one printer's device area prints only that printer."""
+    e1 = await _setup_entry(hass, "1.1.1.1")
+    await _setup_entry(hass, "2.2.2.2")
+    d1 = _get_device_id_for_entry(hass, e1)
+
+    area_registry = ar.async_get(hass)
+    area = area_registry.async_create("Kitchen")
+    device_registry = dr.async_get(hass)
+    device_registry.async_update_device(d1, area_id=area.id)
+
+    fake1, fake2 = MagicMock(), MagicMock()
+    with patch(
+        "escpos.printer.Network",
+        side_effect=_network_side_effect({"1.1.1.1": fake1, "2.2.2.2": fake2}),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "print_text",
+            {"text": "Hello", "area_id": area.id},
+            blocking=True,
+        )
+    assert fake1.text.called
+    assert not fake2.text.called
+
+
+async def test_floor_id_target_resolves_to_printer_entry(hass):  # type: ignore[no-untyped-def]
+    """floor_id targeting one printer's device (via its area) prints only that printer."""
+    e1 = await _setup_entry(hass, "1.1.1.1")
+    await _setup_entry(hass, "2.2.2.2")
+    d1 = _get_device_id_for_entry(hass, e1)
+
+    floor_registry = fr.async_get(hass)
+    floor = floor_registry.async_create("Upstairs")
+    area_registry = ar.async_get(hass)
+    area = area_registry.async_create("Bedroom", floor_id=floor.floor_id)
+    device_registry = dr.async_get(hass)
+    device_registry.async_update_device(d1, area_id=area.id)
+
+    fake1, fake2 = MagicMock(), MagicMock()
+    with patch(
+        "escpos.printer.Network",
+        side_effect=_network_side_effect({"1.1.1.1": fake1, "2.2.2.2": fake2}),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "print_text",
+            {"text": "Hello", "floor_id": floor.floor_id},
+            blocking=True,
+        )
+    assert fake1.text.called
+    assert not fake2.text.called
+
+
+async def test_label_id_target_resolves_to_printer_entry(hass):  # type: ignore[no-untyped-def]
+    """label_id assigned to one printer's device prints only that printer."""
+    e1 = await _setup_entry(hass, "1.1.1.1")
+    await _setup_entry(hass, "2.2.2.2")
+    d1 = _get_device_id_for_entry(hass, e1)
+
+    label_registry = lr.async_get(hass)
+    label = label_registry.async_create("Receipts")
+    device_registry = dr.async_get(hass)
+    device_registry.async_update_device(d1, labels={label.label_id})
+
+    fake1, fake2 = MagicMock(), MagicMock()
+    with patch(
+        "escpos.printer.Network",
+        side_effect=_network_side_effect({"1.1.1.1": fake1, "2.2.2.2": fake2}),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "print_text",
+            {"text": "Hello", "label_id": label.label_id},
+            blocking=True,
+        )
+    assert fake1.text.called
+    assert not fake2.text.called
+
+
+async def test_target_resolving_to_not_loaded_entry_warns_and_prints_loaded(hass, caplog):  # type: ignore[no-untyped-def]
+    """A target spanning a not-loaded and a loaded printer warns but still prints the loaded one."""
+    e1 = await _setup_entry(hass, "1.1.1.1")
+    e2 = await _setup_entry(hass, "2.2.2.2")
+    d1 = _get_device_id_for_entry(hass, e1)
+    d2 = _get_device_id_for_entry(hass, e2)
+
+    label_registry = lr.async_get(hass)
+    label = label_registry.async_create("Receipts")
+    device_registry = dr.async_get(hass)
+    device_registry.async_update_device(d1, labels={label.label_id})
+    device_registry.async_update_device(d2, labels={label.label_id})
+
+    assert await hass.config_entries.async_unload(e1.entry_id)
+    await hass.async_block_till_done()
+
+    fake2 = MagicMock()
+    with patch("escpos.printer.Network", return_value=fake2):
+        with caplog.at_level("WARNING"):
+            await hass.services.async_call(
+                DOMAIN,
+                "print_text",
+                {"text": "Hello", "label_id": label.label_id},
+                blocking=True,
+            )
+    assert fake2.text.called
+    warnings = [r for r in caplog.records if "not currently loaded" in r.message]
+    assert len(warnings) == 1
+
+
+async def test_target_resolving_only_to_not_loaded_entries_raises(hass):  # type: ignore[no-untyped-def]
+    """A target resolving only to not-loaded printer(s) raises ServiceValidationError."""
+    e1 = await _setup_entry(hass, "1.1.1.1")
+    # A second, unrelated loaded entry keeps the service registered after e1 unloads.
+    await _setup_entry(hass, "2.2.2.2")
+    d1 = _get_device_id_for_entry(hass, e1)
+
+    area_registry = ar.async_get(hass)
+    area = area_registry.async_create("Attic")
+    device_registry = dr.async_get(hass)
+    device_registry.async_update_device(d1, area_id=area.id)
+
+    assert await hass.config_entries.async_unload(e1.entry_id)
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "print_text",
+            {"text": "Hello", "area_id": area.id},
+            blocking=True,
+        )
+
+
+async def test_device_id_and_entity_id_union_prints_both(hass):  # type: ignore[no-untyped-def]
+    """A legacy `device_id` plus a picker `entity_id` union: both printers print."""
+    e1 = await _setup_entry(hass, "1.1.1.1")
+    e2 = await _setup_entry(hass, "2.2.2.2")
+    d1 = _get_device_id_for_entry(hass, e1)
+    entity2 = _get_notify_entity_id_for_entry(hass, e2)
+
+    fake1, fake2 = MagicMock(), MagicMock()
+    with patch(
+        "escpos.printer.Network",
+        side_effect=_network_side_effect({"1.1.1.1": fake1, "2.2.2.2": fake2}),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "print_text",
+            {"text": "Hello", "device_id": d1, "entity_id": entity2},
+            blocking=True,
+        )
+    assert fake1.text.called
+    assert fake2.text.called
+
+
+async def test_target_referencing_no_escpos_printer_raises(hass):  # type: ignore[no-untyped-def]
+    """A target that resolves to no ESC/POS printer config entry raises ServiceValidationError.
+
+    An empty area (no devices assigned) is a target the picker helper can
+    resolve without error but that carries no printer -- the same outcome
+    as an entity_id/area_id belonging entirely to other integrations.
+    """
+    await _setup_entry(hass)
+    area_registry = ar.async_get(hass)
+    empty_area = area_registry.async_create("Empty Room")
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "print_text",
+            {"text": "Hello", "area_id": empty_area.id},
+            blocking=True,
+        )
+
+
+async def test_broadcast_with_entity_id_rejected_by_schema(hass):  # type: ignore[no-untyped-def]
+    """`broadcast: true` + `entity_id` is a schema-layer validation error, like device_id."""
+    entry = await _setup_entry(hass)
+    entity_id = _get_notify_entity_id_for_entry(hass, entry)
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            "print_text",
+            {"text": "Hello", "entity_id": entity_id, "broadcast": True},
+            blocking=True,
+        )
 
 
 async def test_preview_omitted_target_with_two_entries_does_not_warn(hass, caplog):  # type: ignore[no-untyped-def]
@@ -367,5 +621,5 @@ async def test_preview_omitted_target_with_two_entries_does_not_warn(hass, caplo
                     blocking=True,
                     return_response=True,
                 )
-    warnings = [r for r in caplog.records if "no device_id specified" in r.message]
+    warnings = [r for r in caplog.records if "no target specified" in r.message]
     assert not warnings

--- a/tests/test_services_yaml_schema.py
+++ b/tests/test_services_yaml_schema.py
@@ -738,9 +738,11 @@ _TARGETED_SERVICES = frozenset(
 
 _UNTARGETED_WITH_DEVICE_ID = frozenset({"preview_image", "preview_box", "preview_table"})
 
+# Entity-only filter: hassfest rejects device filters on a service target
+# ("use a device selector instead"); devices are still pickable in the UI
+# via their notify entity, matching print_message's long-standing block.
 _EXPECTED_TARGET_BLOCK = {
     "entity": {"domain": "notify", "integration": "escpos_printer"},
-    "device": {"integration": "escpos_printer"},
 }
 
 

--- a/tests/test_services_yaml_schema.py
+++ b/tests/test_services_yaml_schema.py
@@ -355,6 +355,32 @@ def test_preview_image_schema_optional_output_path():  # type: ignore[no-untyped
     assert out2["output_path"] == "/tmp/p.png"  # noqa: S108
 
 
+# ---------------------------------------------------------------------------
+# Target-picker keys (entity_id/area_id/floor_id/label_id): HA core merges
+# these into call.data when a service declares `target:`. The schemas must
+# accept them (str or [str]) and keep them mutually exclusive with
+# broadcast, same as device_id.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("key", ["entity_id", "area_id", "floor_id", "label_id"])
+@pytest.mark.parametrize("shape", ["single", "list"])
+def test_print_text_schema_accepts_target_picker_keys(key, shape):  # type: ignore[no-untyped-def]
+    from custom_components.escpos_printer.services.schemas import PRINT_TEXT_SCHEMA
+
+    value = "abc123" if shape == "single" else ["abc123", "def456"]
+    out = PRINT_TEXT_SCHEMA({"text": "hi", key: value})
+    assert out[key] == value
+
+
+@pytest.mark.parametrize("key", ["entity_id", "area_id"])
+def test_print_text_schema_rejects_broadcast_with_target_key(key):  # type: ignore[no-untyped-def]
+    from custom_components.escpos_printer.services.schemas import PRINT_TEXT_SCHEMA
+
+    with pytest.raises(vol.Invalid):
+        PRINT_TEXT_SCHEMA({"text": "hi", "broadcast": True, key: "abc123"})
+
+
 def test_calibration_print_schema_defaults():  # type: ignore[no-untyped-def]
     from custom_components.escpos_printer.services.schemas import (
         CALIBRATION_PRINT_SCHEMA,
@@ -679,6 +705,67 @@ def test_no_unquoted_hash_in_plain_scalar_descriptions() -> None:
         "value at YAML-parse time — quote the description or use a '>' "
         "folded scalar:\n  " + "\n  ".join(offenders)
     )
+
+
+# ---------------------------------------------------------------------------
+# target: block declaration (1.2.0) -- lets these services be offered from
+# the entity/device "create as a new action" picker while keeping device_id
+# fully supported for backward compatibility.
+# ---------------------------------------------------------------------------
+
+_TARGETED_SERVICES = frozenset(
+    {
+        "print_text_utf8",
+        "print_text",
+        "print_qr",
+        "print_image",
+        "print_image_url",
+        "print_image_path",
+        "print_camera_snapshot",
+        "print_image_entity",
+        "print_barcode",
+        "print_box",
+        "print_table",
+        "print_text_image",
+        "print_separator",
+        "print_kvtable",
+        "feed",
+        "cut",
+        "beep",
+        "calibration_print",
+    }
+)
+
+_UNTARGETED_WITH_DEVICE_ID = frozenset({"preview_image", "preview_box", "preview_table"})
+
+_EXPECTED_TARGET_BLOCK = {
+    "entity": {"domain": "notify", "integration": "escpos_printer"},
+    "device": {"integration": "escpos_printer"},
+}
+
+
+def test_services_declare_target_and_drop_device_id_field() -> None:
+    """The 18 automation-facing services declare `target:` and no longer
+    duplicate device selection as a `device_id` field; the three preview_*
+    services (SupportsResponse.ONLY) keep the old device_id field and stay
+    target-less.
+    """
+    services = _load_services_yaml()
+    assert _TARGETED_SERVICES | _UNTARGETED_WITH_DEVICE_ID | {"print_message"} <= set(services)
+    for svc in _TARGETED_SERVICES:
+        svc_def = services[svc]
+        assert svc_def.get("target") == _EXPECTED_TARGET_BLOCK, (
+            f"{svc}.target missing or wrong: {svc_def.get('target')!r}"
+        )
+        assert "device_id" not in svc_def.get("fields", {}), (
+            f"{svc}.fields still declares device_id; the target picker replaces it"
+        )
+    for svc in _UNTARGETED_WITH_DEVICE_ID:
+        svc_def = services[svc]
+        assert "target" not in svc_def, f"{svc} unexpectedly declares target"
+        assert "device_id" in svc_def.get("fields", {}), (
+            f"{svc}.fields must keep device_id (not offered as an automation action)"
+        )
 
 
 def test_icons_json_services_match_services_yaml() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1170,7 +1170,7 @@ wheels = [
 
 [[package]]
 name = "ha-escpos-thermal-printer"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "dbus-fast" },


### PR DESCRIPTION
## Summary

- All 18 printing services (including `calibration_print`) now declare a `target:` block, so they can be targeted by **device, entity, area, floor, or label** via HA's standard target picker — and appear in the entity/device "Add to… → Create as a new action" pickers. The entity filter is scoped to `domain: notify` so each printer is listed once.
- Full backward compatibility: the legacy `device_id` field in `data:` and `broadcast: true` keep working unchanged. A legacy `device_id` combined with a picker target unions the two (documented in `docs/multi-printer.md`).
- The implicit broadcast-when-no-target fallback is now **deprecated for removal in 2.0.0**: the warning log says so, service descriptions/docs note it, and ROADMAP gained a "Planned for 2.0.0 (breaking)" section.
- Resolution uses `async_extract_config_entry_ids`, filtered to loaded `escpos_printer` entries, warning about targeted-but-not-loaded printers and raising `ServiceValidationError` when nothing resolves.
- Only the three `preview_*` services stay target-less (`SupportsResponse.ONLY`).
- Version cut as **1.2.0** (manifest, pyproject, uv.lock, CHANGELOG with Added/Changed/Deprecated and compare links).

## Review process

Reviewed from engineering, product, and documentation perspectives; all findings applied, then re-verified. Highlights: selectivity tests were hardened to use two printers with per-host mocks and are mutation-verified (a regression that silently broadcasts now fails 7 tests, previously 0); stale "mutually exclusive with device_id" copy replaced across services.yaml, generated translations, and all docs.

## Test plan

- `uv run pytest -q` → 1362 passed
- `uv run ruff check .` / `uv run ruff format --check .` → clean
- `uv run mypy custom_components/` → clean (79 files)
- `uv run python scripts/sync_service_translations.py --check` → in sync
- All 19 `target:` blocks validate against HA's `selector.TargetSelector`
- New coverage: entity/area/floor/label selectivity, not-loaded warning path, `device_id`+`entity_id` union, services.yaml target-block invariant

🤖 Generated with [Claude Code](https://claude.com/claude-code)