### PR TITLE
Add device page buttons and a Repairs entry for the calibration wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Device page buttons: Feed paper, Cut paper, Beep, and Sample test print
+  (a one-tap demo receipt with the integration logo, styled text, a table,
+  and a QR code).
+- Uncalibrated printers now get a dismissible suggestion in Settings →
+  Repairs that launches the calibration wizard directly — no more hunting
+  for it under the integration's Configure menu.
+
 ## [1.2.0] - 2026-08-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ start printing in minutes.
 - UTF-8 text with automatic character conversion
 - 35+ printer profiles with automatic feature detection, plus 23 rebadged/clone models available directly as "(compatible)" dropdown entries
 - Guided calibration wizard: prints test pages to measure image implementation, paper width, columns, and codepage, then saves them for you ([guide](docs/calibration.md))
+- Device page offers Feed / Cut / Beep / Sample test print buttons, and new printers get a Settings → Repairs suggestion linking to the calibration wizard
 - Full UI configuration, no YAML required
 
 ## Quick Start

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,14 +6,21 @@ entity-coverage analysis against HA platform conventions.
 
 ## Planned
 
-### 1. Button entities: Feed, Cut, Calibration print
+### 1. Button entities: Feed, Cut, Beep, Sample print — shipped
 
-The dashboard staples for a receipt printer: tap to advance paper before
-tearing, tap to cut, tap to print a test sheet when debugging alignment.
-Everything needed already exists: `adapter.feed()` / `adapter.cut()`
-(`printer/control_operations.py`) and the `calibration_print` service. Roughly
-three `ButtonEntity` subclasses reusing `build_device_info()`, plus `"button"`
-in `PLATFORMS`, icons, and strings. Beep as a fourth button is optional.
+Device page buttons ship: Feed, Cut, Beep, and Sample test print (a one-tap
+demo receipt with the integration logo, styled text, a table, and a QR
+code), backed by `adapter.feed()` / `adapter.cut()` / `adapter.beep()` and a
+new `sample_print.py` composer built on `batch_connection()`. A
+calibration-sheet button was deliberately **not** added — the new Settings →
+Repairs suggestion (below) already points users at the calibration wizard,
+and the `calibration_print` service remains for the dither/threshold test
+sheet.
+
+New printers also get a fixable Settings → Repairs issue
+("Printer not yet calibrated") that opens the calibration wizard directly,
+so it's discoverable without hunting through the integration's Configure
+menu. See [Calibration wizard](docs/calibration.md).
 
 ### 2. Cash drawer service — and the drawer-kick port as a "geek port"
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ menu. See [Calibration wizard](docs/calibration.md).
 
 **Core functionality**: `open_cash_drawer` (python-escpos `cashdraw`, pin 2/5)
 plus a matching device action, and optionally a button entity alongside the
-planned Feed/Cut/Calibration buttons (item 1). The one classic POS capability
+shipped Feed/Cut/Beep/Sample buttons (item 1). The one classic POS capability
 entirely absent from the integration.
 
 **Investigation: general-purpose I/O.** The drawer-kick connector (RJ11/RJ12)

--- a/custom_components/escpos_printer/__init__.py
+++ b/custom_components/escpos_printer/__init__.py
@@ -358,7 +358,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: EscposConfigEntry) -> bo
             is_fixable=True,
             severity=ir.IssueSeverity.WARNING,
             translation_key="printer_not_calibrated",
-            translation_placeholders={"name": entry.title},
             data={"entry_id": entry.entry_id},
         )
 

--- a/custom_components/escpos_printer/__init__.py
+++ b/custom_components/escpos_printer/__init__.py
@@ -80,7 +80,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
-PLATFORMS: list[str] = ["notify", "binary_sensor", "sensor"]
+PLATFORMS: list[str] = ["notify", "binary_sensor", "sensor", "button"]
 
 # Domain-level singleton flag for one-time service registration.
 # Per-entry state lives on entry.runtime_data (see EscposRuntimeData).

--- a/custom_components/escpos_printer/__init__.py
+++ b/custom_components/escpos_printer/__init__.py
@@ -336,6 +336,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: EscposConfigEntry) -> bo
     if os.environ.get("ESC_POS_DISABLE_PLATFORMS") == "1":
         platforms = []
     await hass.config_entries.async_forward_entry_setups(entry, platforms)
+
+    # Calibration nudge: one fixable Repairs issue per never-calibrated
+    # entry. "Calibrated" = any wizard-saved key present in options; the
+    # settings form writes the same keys, which is fine — a user who
+    # found the options flow doesn't need the pointer.
+    from homeassistant.helpers import issue_registry as ir  # noqa: PLC0415
+
+    calibrated = any(
+        key in entry.options
+        for key in (CONF_IMPL, CONF_WIDTH_PIXELS, CONF_LINE_WIDTH, CONF_CODEPAGE)
+    )
+    issue_id = f"printer_not_calibrated_{entry.entry_id}"
+    if calibrated:
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
+    else:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="printer_not_calibrated",
+            translation_placeholders={"name": entry.title},
+            data={"entry_id": entry.entry_id},
+        )
+
     return True
 
 
@@ -390,6 +416,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: EscposConfigEntry) -> N
         profile = entry.options.get(CONF_PROFILE, entry.data.get(CONF_PROFILE))
         if profile:
             ir.async_delete_issue(hass, DOMAIN, f"profile_width_fallback_{profile}")
+        ir.async_delete_issue(hass, DOMAIN, f"printer_not_calibrated_{entry.entry_id}")
     except Exception as err:  # best effort
         _LOGGER.debug(
             "Could not clean up repair issues for entry %s: %s",

--- a/custom_components/escpos_printer/button.py
+++ b/custom_components/escpos_printer/button.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.entity import DeviceInfo
 
 from .device import build_device_info
 from .sample_print import async_print_sample
+from .services._handler_utils import _wrap_unexpected
 
 if TYPE_CHECKING:
     from . import EscposConfigEntry
@@ -55,7 +56,15 @@ class _EscposButton(ButtonEntity):
         except HomeAssistantError:
             raise
         except Exception as err:
-            raise HomeAssistantError(f"Printer operation failed: {err.__class__.__name__}") from err
+            # Mirror the service-handler contract in _handler_utils._for_each_target:
+            # log the full traceback, then raise a sanitised HomeAssistantError so
+            # USB serials / BT MACs / local paths don't leak to the Frontend toast.
+            _LOGGER.exception(
+                "Button %s failed for entry %s",
+                self._attr_translation_key,
+                self._entry.entry_id,
+            )
+            raise _wrap_unexpected(err, str(self._attr_translation_key)) from err
 
     async def _press(self) -> None:
         raise NotImplementedError

--- a/custom_components/escpos_printer/button.py
+++ b/custom_components/escpos_printer/button.py
@@ -1,0 +1,93 @@
+"""Button platform: Feed, Cut, Beep, Sample test print on the device page."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+
+from .device import build_device_info
+from .sample_print import async_print_sample
+
+if TYPE_CHECKING:
+    from . import EscposConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 1
+
+# ponytail: fixed tear-off advance; make configurable only if someone asks
+FEED_LINES = 3
+
+
+async def async_setup_entry(  # type: ignore[no-untyped-def]
+    hass: HomeAssistant, entry: EscposConfigEntry, async_add_entities
+) -> None:
+    async_add_entities(
+        [
+            EscposFeedButton(hass, entry),
+            EscposCutButton(hass, entry),
+            EscposBeepButton(hass, entry),
+            EscposSamplePrintButton(hass, entry),
+        ]
+    )
+
+
+class _EscposButton(ButtonEntity):
+    _attr_has_entity_name = True
+
+    def __init__(self, hass: HomeAssistant, entry: EscposConfigEntry) -> None:
+        self._hass = hass
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_{self._attr_translation_key}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return build_device_info(self._entry)
+
+    async def async_press(self) -> None:
+        try:
+            await self._press()
+        except HomeAssistantError:
+            raise
+        except Exception as err:
+            raise HomeAssistantError(f"Printer operation failed: {err.__class__.__name__}") from err
+
+    async def _press(self) -> None:
+        raise NotImplementedError
+
+
+class EscposFeedButton(_EscposButton):
+    _attr_translation_key = "feed"
+
+    async def _press(self) -> None:
+        await self._entry.runtime_data.adapter.feed(self._hass, lines=FEED_LINES)
+
+
+class EscposCutButton(_EscposButton):
+    _attr_translation_key = "cut"
+
+    async def _press(self) -> None:
+        # A Cut button that does nothing reads as broken — "none" → full.
+        mode = self._entry.runtime_data.defaults.get("cut") or "full"
+        if mode == "none":
+            mode = "full"
+        await self._entry.runtime_data.adapter.cut(self._hass, mode=mode)
+
+
+class EscposBeepButton(_EscposButton):
+    _attr_translation_key = "beep"
+
+    async def _press(self) -> None:
+        await self._entry.runtime_data.adapter.beep(self._hass)
+
+
+class EscposSamplePrintButton(_EscposButton):
+    _attr_translation_key = "sample_print"
+
+    async def _press(self) -> None:
+        await async_print_sample(self._hass, self._entry)

--- a/custom_components/escpos_printer/icons.json
+++ b/custom_components/escpos_printer/icons.json
@@ -3,6 +3,12 @@
     "sensor": {
       "last_image_print": {"default": "mdi:image-outline"},
       "paper_status": {"default": "mdi:paper-roll-outline"}
+    },
+    "button": {
+      "feed": {"default": "mdi:arrow-collapse-down"},
+      "cut": {"default": "mdi:content-cut"},
+      "beep": {"default": "mdi:volume-high"},
+      "sample_print": {"default": "mdi:receipt-text-check-outline"}
     }
   },
   "services": {

--- a/custom_components/escpos_printer/printer/base_adapter.py
+++ b/custom_components/escpos_printer/printer/base_adapter.py
@@ -31,7 +31,7 @@ from .image_operations import (
 )
 from .image_processor import FALLBACK_PROFILE_WIDTH
 from .mapping_utils import cleanup_cut, map_align, map_cut, map_multiplier, map_underline
-from .print_operations import PrintOperationsMixin, _print_text_under_lock
+from .print_operations import PrintOperationsMixin, _print_text_under_lock, _qr_under_lock
 
 if TYPE_CHECKING:
     from homeassistant.core import Context
@@ -767,6 +767,11 @@ class _BatchPage:
         self,
         *,
         text: str,
+        align: str | None = None,
+        bold: bool | None = None,
+        underline: str | None = None,
+        width: str | int | None = None,
+        height: str | int | None = None,
         encoding: str | None = None,
         wrap: bool = True,
         feed: int | None = 0,
@@ -777,15 +782,26 @@ class _BatchPage:
             self._hass,
             self._printer,
             text=text,
-            align=None,
-            bold=None,
-            underline=None,
-            width=None,
-            height=None,
+            align=align,
+            bold=bold,
+            underline=underline,
+            width=width,
+            height=height,
             encoding=encoding,
             wrap=wrap,
         )
         await self._adapter._apply_cut_and_feed(self._hass, self._printer, "none", feed)
+
+    async def print_qr(
+        self,
+        *,
+        data: str,
+        size: int | None = None,
+        ec: str | None = None,
+        align: str | None = "center",
+    ) -> None:
+        """Print a QR code on the held connection (mirrors ``adapter.print_qr``)."""
+        await _qr_under_lock(self._hass, self._printer, data=data, size=size, ec=ec, align=align)
 
     async def print_image(
         self,

--- a/custom_components/escpos_printer/printer/print_operations.py
+++ b/custom_components/escpos_printer/printer/print_operations.py
@@ -99,14 +99,6 @@ class PrintOperationsMixin:
         await self._mark_success()
 
 
-# ---------------------------------------------------------------------------
-# Module-level helper: runs the text-print body assuming the lock is held
-# and ``printer`` is already acquired. Used by both ``print_text`` and the
-# ``print_text_with_image`` adapter method (which needs to keep the lock
-# across two operations for atomicity).
-# ---------------------------------------------------------------------------
-
-
 async def _qr_under_lock(
     hass: HomeAssistant,
     printer: Any,
@@ -144,6 +136,14 @@ async def _qr_under_lock(
         printer_obj.qr(data, size=qsize, ec=_map_qr_ec(qec))
 
     await hass.async_add_executor_job(_do_print, printer)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helper: runs the text-print body assuming the lock is held
+# and ``printer`` is already acquired. Used by both ``print_text`` and the
+# ``print_text_with_image`` adapter method (which needs to keep the lock
+# across two operations for atomicity).
+# ---------------------------------------------------------------------------
 
 
 async def _print_text_under_lock(

--- a/custom_components/escpos_printer/printer/print_operations.py
+++ b/custom_components/escpos_printer/printer/print_operations.py
@@ -87,37 +87,11 @@ class PrintOperationsMixin:
         feed: int | None = 0,
     ) -> None:
         """Print a QR code to the printer."""
-        data = validate_qr_data(data)
-        align_m = map_align(align)
-        qsize = int(size) if size is not None else 3
-        qsize = max(1, min(16, qsize))
-        qec = (ec or "M").upper()
-        if qec not in ("L", "M", "Q", "H"):
-            qec = "M"
-
-        def _map_qr_ec(level: str) -> Any:
-            try:
-                from escpos import escpos as _esc  # noqa: PLC0415
-
-                return {
-                    "L": getattr(_esc, "QR_ECLEVEL_L", "L"),
-                    "M": getattr(_esc, "QR_ECLEVEL_M", "M"),
-                    "Q": getattr(_esc, "QR_ECLEVEL_Q", "Q"),
-                    "H": getattr(_esc, "QR_ECLEVEL_H", "H"),
-                }[level]
-            except Exception:
-                return level
-
-        def _do_print(printer: Any) -> None:
-            if hasattr(printer, "set"):
-                printer.set(align=align_m, normal_textsize=True)
-            printer.qr(data, size=qsize, ec=_map_qr_ec(qec))
-
         async with self._lock:
             printer, owned = await self._acquire_printer_or_offline(hass)
             failed = True
             try:
-                await hass.async_add_executor_job(_do_print, printer)
+                await _qr_under_lock(hass, printer, data=data, size=size, ec=ec, align=align)
                 await self._apply_cut_and_feed(hass, printer, cut, feed)
                 failed = False
             finally:
@@ -131,6 +105,45 @@ class PrintOperationsMixin:
 # ``print_text_with_image`` adapter method (which needs to keep the lock
 # across two operations for atomicity).
 # ---------------------------------------------------------------------------
+
+
+async def _qr_under_lock(
+    hass: HomeAssistant,
+    printer: Any,
+    *,
+    data: str,
+    size: int | None = None,
+    ec: str | None = None,
+    align: str | None = None,
+) -> None:
+    """Validate + print a QR on an already-acquired connection (lock held by caller)."""
+    data = validate_qr_data(data)
+    align_m = map_align(align)
+    qsize = int(size) if size is not None else 3
+    qsize = max(1, min(16, qsize))
+    qec = (ec or "M").upper()
+    if qec not in ("L", "M", "Q", "H"):
+        qec = "M"
+
+    def _map_qr_ec(level: str) -> Any:
+        try:
+            from escpos import escpos as _esc  # noqa: PLC0415
+
+            return {
+                "L": getattr(_esc, "QR_ECLEVEL_L", "L"),
+                "M": getattr(_esc, "QR_ECLEVEL_M", "M"),
+                "Q": getattr(_esc, "QR_ECLEVEL_Q", "Q"),
+                "H": getattr(_esc, "QR_ECLEVEL_H", "H"),
+            }[level]
+        except Exception:
+            return level
+
+    def _do_print(printer_obj: Any) -> None:
+        if hasattr(printer_obj, "set"):
+            printer_obj.set(align=align_m, normal_textsize=True)
+        printer_obj.qr(data, size=qsize, ec=_map_qr_ec(qec))
+
+    await hass.async_add_executor_job(_do_print, printer)
 
 
 async def _print_text_under_lock(

--- a/custom_components/escpos_printer/repairs.py
+++ b/custom_components/escpos_printer/repairs.py
@@ -1,0 +1,37 @@
+"""Repairs platform: fix flow for the printer-not-calibrated suggestion.
+
+The fix flow IS the calibration wizard — ``CalibrationFlowMixin`` was
+written flow-agnostic (needs only ``hass`` + ``config_entry``), so it
+runs identically here and in the options flow.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+
+from ._config_flow.calibration_steps import CalibrationFlowMixin
+
+
+class NotCalibratedRepairFlow(CalibrationFlowMixin, RepairsFlow):
+    """Run the calibration wizard from Settings → Repairs."""
+
+    def __init__(self, entry: Any) -> None:
+        self.config_entry = entry
+        self._calib: dict[str, Any] = {}
+        self._calib_extra: dict[str, Any] = {}
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        return await self.async_step_calibrate()  # type: ignore[return-value]
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant, issue_id: str, data: dict[str, Any] | None
+) -> RepairsFlow:
+    entry = hass.config_entries.async_get_entry((data or {})["entry_id"])
+    if entry is None:
+        raise ValueError(f"Unknown config entry for repairs issue {issue_id}")
+    return NotCalibratedRepairFlow(entry)

--- a/custom_components/escpos_printer/sample_print.py
+++ b/custom_components/escpos_printer/sample_print.py
@@ -1,0 +1,71 @@
+"""Compose the 'Sample test print' receipt (device page button).
+
+One uninterrupted receipt on a single held connection: logo, boxed
+header, styled text, table, separator, QR. ASCII border style on
+purpose — it renders identically on every codepage, so the sample
+never needs transcoding.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from homeassistant.core import HomeAssistant
+
+from .text_effects.box import render_box
+from .text_effects.table import render_table
+
+if TYPE_CHECKING:
+    from . import EscposConfigEntry
+
+_LOGO_PATH = Path(__file__).parent / "brand" / "logo.png"
+_REPO_URL = "https://github.com/cognitivegears/ha-escpos-thermal-printer"
+
+
+def _logo_data_uri() -> str:
+    """base64 data URI for the bundled logo (blocking; run via executor)."""
+    return "data:image/png;base64," + base64.b64encode(_LOGO_PATH.read_bytes()).decode()
+
+
+async def async_print_sample(hass: HomeAssistant, entry: EscposConfigEntry) -> None:
+    """Print the sample receipt on the entry's printer."""
+    from . import _shared_print_config  # noqa: PLC0415 (avoid import cycle at module load)
+
+    adapter = entry.runtime_data.adapter
+    line_width = _shared_print_config(entry)["line_width"]
+    logo = await hass.async_add_executor_job(_logo_data_uri)
+
+    header = render_box(
+        f"ESC/POS Sample Print\n{entry.title}",
+        inner_width=max(line_width - 2, 10),
+        style="ascii",
+        align="center",
+    )
+    table = render_table(
+        [["Item", "Qty"], ["Receipt demo", "1"], ["Styled text", "3"]],
+        total_width=line_width,
+        style="ascii",
+        header=True,
+    )
+
+    async with adapter.batch_connection(hass) as page:
+        await page.print_image(image=logo, auto_resize=True)
+        await page.print_text(text=header + "\n")
+        await page.print_text(text="Bold text\n", bold=True)
+        await page.print_text(text="Underlined text\n", underline="single")
+        await page.print_text(text="Double size\n", width=2, height=2)
+        await page.print_text(text=table + "\n")
+        await page.print_text(text="=" * line_width + "\n")
+        await page.print_qr(data=_REPO_URL)
+        await page.print_text(text=f"Docs & source:\n{_REPO_URL}\n")
+        await page.feed(2)
+
+    # Batch pages never cut (documented _BatchPage contract) — follow-up
+    # cut like the calibration wizard does. "none" would make the button
+    # print an uncut dangling receipt, so fall back to full.
+    cut_mode = entry.runtime_data.defaults.get("cut") or "full"
+    if cut_mode == "none":
+        cut_mode = "full"
+    await adapter.cut(hass, mode=cut_mode)

--- a/custom_components/escpos_printer/strings.json
+++ b/custom_components/escpos_printer/strings.json
@@ -570,6 +570,10 @@
             }
           }
         },
+        "error": {
+          "line_width_missing": "Enter the character count from the first line (16–96), or choose \"Skip this step\".",
+          "calibration_print_failed": "Printing the test page failed. Check the printer and try again."
+        },
         "abort": {
           "calibration_discarded": "Calibration discarded — no options were changed.",
           "printer_not_ready": "The printer is not connected — load the integration before calibrating.",

--- a/custom_components/escpos_printer/strings.json
+++ b/custom_components/escpos_printer/strings.json
@@ -517,6 +517,66 @@
     "profile_width_fallback": {
       "title": "Printer profile is missing the pixel width",
       "description": "The selected printer profile ({profile}) does not expose `media.width.pixels`, so images are being scaled to a generic {fallback}px width. This is usually correct for 58 mm thermals but may print stretched or truncated on 80 mm printers.\n\n**To fix:** open the integration's options and set “Paper width in pixels” (384 for 58 mm, 576 for 80 mm printers), pick a closer matching printer profile, or set `image_width` explicitly in your service calls."
+    },
+    "printer_not_calibrated": {
+      "title": "Printer not yet calibrated",
+      "fix_flow": {
+        "step": {
+          "calibrate_confirm": {
+            "title": "Calibrate printer",
+            "description": "The optional calibration tool prints test pages to tune print width and character set for this printer and paper. Run it now, or ignore this — printing works without it.",
+            "data": {
+              "action": "Action"
+            }
+          },
+          "calibrate_impl": {
+            "title": "Calibrate: image implementation",
+            "description": "Your printer just printed three numbered test patterns. A working pattern is a crisp checkerboard; a failing one prints stray letters or nothing. Check every pattern that printed cleanly. If none of the patterns printed cleanly, leave all boxes unchecked — the width test will be skipped since it needs a working image mode.",
+            "data": {
+              "impls_clean": "Patterns that printed cleanly",
+              "action": "Action"
+            }
+          },
+          "calibrate_width": {
+            "title": "Calibrate: paper width",
+            "description": "Your printer just printed a labeled box for each candidate width. A box that's too wide for your printer loses its right-side border — either cut off or wrapped into garbled fragments. Pick the WIDEST box whose right-side border printed as a clean, unbroken line. If none of the boxes has an intact right border, choose \"None had an intact right edge\".",
+            "data": {
+              "first_equal": "Widest box with an intact right border",
+              "action": "Action"
+            }
+          },
+          "calibrate_ruler": {
+            "title": "Calibrate: characters per line",
+            "description": "Your printer just printed a ruler line of dots with the numbers 10, 20, 30... embedded in it, followed by one or two leftover lines you can ignore. Look at the FIRST printed line only: find the last complete number on it, then add 1 for every dot printed after that number. Example: if the line ends with \"40..\", enter 42. If you're not sure, choose \"Skip this step\".",
+            "data": {
+              "last_marker": "Characters on the first line",
+              "action": "Action"
+            }
+          },
+          "calibrate_codepage": {
+            "title": "Calibrate: character encoding",
+            "description": "Your printer just printed one numbered line per candidate encoding, each attempting to render \"{sample}\", the ideal text. Check every line whose printout matches its own expected text shown in the checkbox label — including any ? marks. A line that prints exactly what its label shows is a working codepage. If none match, or you'd rather leave the character encoding unchanged, choose \"Skip this step\".",
+            "data": {
+              "codepages_match": "Lines that match their own expected text",
+              "action": "Action"
+            }
+          },
+          "calibrate_summary": {
+            "title": "Calibrate: summary",
+            "description": "Measured settings — image implementation: {impl}; paper width: {width_pixels} px; characters per line: {line_width}; character encoding: {codepage}. Save applies these to the printer's options (any setting not measured above is left unchanged). Optionally enter your printer model first — the next screen and a notification will carry a share link to help add this printer to escpos-printer-db.",
+            "data": {
+              "model": "Printer model (optional, for the share link)",
+              "action": "Action"
+            }
+          }
+        },
+        "abort": {
+          "calibration_discarded": "Calibration discarded — no options were changed.",
+          "printer_not_ready": "The printer is not connected — load the integration before calibrating.",
+          "calibration_saved": "Calibration saved and applied. [Open a prefilled GitHub issue]({share_url}) to help add this printer to escpos-printer-db.",
+          "calibration_saved_no_changes": "Calibration finished — no settings were measured, so nothing was changed."
+        }
+      }
     }
   },
   "exceptions": {

--- a/custom_components/escpos_printer/strings.json
+++ b/custom_components/escpos_printer/strings.json
@@ -520,11 +520,12 @@
     },
     "printer_not_calibrated": {
       "title": "Printer not yet calibrated",
+      "description": "The optional calibration tool prints test pages to tune print width and character set for this printer and paper. Run it now, or ignore this — printing works without it.",
       "fix_flow": {
         "step": {
           "calibrate_confirm": {
             "title": "Calibrate printer",
-            "description": "The optional calibration tool prints test pages to tune print width and character set for this printer and paper. Run it now, or ignore this — printing works without it.",
+            "description": "This wizard prints a series of test pages to measure your printer's image implementation, paper width, characters per line, and character encoding — using roughly 15–20 cm of paper in total. Make sure paper is loaded before continuing.",
             "data": {
               "action": "Action"
             }

--- a/custom_components/escpos_printer/strings.json
+++ b/custom_components/escpos_printer/strings.json
@@ -497,6 +497,20 @@
           "out": "Out"
         }
       }
+    },
+    "button": {
+      "feed": {
+        "name": "Feed paper"
+      },
+      "cut": {
+        "name": "Cut paper"
+      },
+      "beep": {
+        "name": "Beep"
+      },
+      "sample_print": {
+        "name": "Sample test print"
+      }
     }
   },
   "issues": {

--- a/custom_components/escpos_printer/strings.json
+++ b/custom_components/escpos_printer/strings.json
@@ -520,12 +520,11 @@
     },
     "printer_not_calibrated": {
       "title": "Printer not yet calibrated",
-      "description": "The optional calibration tool prints test pages to tune print width and character set for this printer and paper. Run it now, or ignore this — printing works without it.",
       "fix_flow": {
         "step": {
           "calibrate_confirm": {
             "title": "Calibrate printer",
-            "description": "This wizard prints a series of test pages to measure your printer's image implementation, paper width, characters per line, and character encoding — using roughly 15–20 cm of paper in total. Make sure paper is loaded before continuing.",
+            "description": "The optional calibration tool prints test pages to tune print width and character set for this printer and paper. Run it now, or ignore this — printing works without it.\n\nThis wizard prints a series of test pages to measure your printer's image implementation, paper width, characters per line, and character encoding — using roughly 15–20 cm of paper in total. Make sure paper is loaded before continuing.",
             "data": {
               "action": "Action"
             }

--- a/custom_components/escpos_printer/translations/en.json
+++ b/custom_components/escpos_printer/translations/en.json
@@ -570,6 +570,10 @@
             }
           }
         },
+        "error": {
+          "line_width_missing": "Enter the character count from the first line (16–96), or choose \"Skip this step\".",
+          "calibration_print_failed": "Printing the test page failed. Check the printer and try again."
+        },
         "abort": {
           "calibration_discarded": "Calibration discarded — no options were changed.",
           "printer_not_ready": "The printer is not connected — load the integration before calibrating.",

--- a/custom_components/escpos_printer/translations/en.json
+++ b/custom_components/escpos_printer/translations/en.json
@@ -517,6 +517,66 @@
     "profile_width_fallback": {
       "title": "Printer profile is missing the pixel width",
       "description": "The selected printer profile ({profile}) does not expose `media.width.pixels`, so images are being scaled to a generic {fallback}px width. This is usually correct for 58 mm thermals but may print stretched or truncated on 80 mm printers.\n\n**To fix:** open the integration's options and set “Paper width in pixels” (384 for 58 mm, 576 for 80 mm printers), pick a closer matching printer profile, or set `image_width` explicitly in your service calls."
+    },
+    "printer_not_calibrated": {
+      "title": "Printer not yet calibrated",
+      "fix_flow": {
+        "step": {
+          "calibrate_confirm": {
+            "title": "Calibrate printer",
+            "description": "The optional calibration tool prints test pages to tune print width and character set for this printer and paper. Run it now, or ignore this — printing works without it.",
+            "data": {
+              "action": "Action"
+            }
+          },
+          "calibrate_impl": {
+            "title": "Calibrate: image implementation",
+            "description": "Your printer just printed three numbered test patterns. A working pattern is a crisp checkerboard; a failing one prints stray letters or nothing. Check every pattern that printed cleanly. If none of the patterns printed cleanly, leave all boxes unchecked — the width test will be skipped since it needs a working image mode.",
+            "data": {
+              "impls_clean": "Patterns that printed cleanly",
+              "action": "Action"
+            }
+          },
+          "calibrate_width": {
+            "title": "Calibrate: paper width",
+            "description": "Your printer just printed a labeled box for each candidate width. A box that's too wide for your printer loses its right-side border — either cut off or wrapped into garbled fragments. Pick the WIDEST box whose right-side border printed as a clean, unbroken line. If none of the boxes has an intact right border, choose \"None had an intact right edge\".",
+            "data": {
+              "first_equal": "Widest box with an intact right border",
+              "action": "Action"
+            }
+          },
+          "calibrate_ruler": {
+            "title": "Calibrate: characters per line",
+            "description": "Your printer just printed a ruler line of dots with the numbers 10, 20, 30... embedded in it, followed by one or two leftover lines you can ignore. Look at the FIRST printed line only: find the last complete number on it, then add 1 for every dot printed after that number. Example: if the line ends with \"40..\", enter 42. If you're not sure, choose \"Skip this step\".",
+            "data": {
+              "last_marker": "Characters on the first line",
+              "action": "Action"
+            }
+          },
+          "calibrate_codepage": {
+            "title": "Calibrate: character encoding",
+            "description": "Your printer just printed one numbered line per candidate encoding, each attempting to render \"{sample}\", the ideal text. Check every line whose printout matches its own expected text shown in the checkbox label — including any ? marks. A line that prints exactly what its label shows is a working codepage. If none match, or you'd rather leave the character encoding unchanged, choose \"Skip this step\".",
+            "data": {
+              "codepages_match": "Lines that match their own expected text",
+              "action": "Action"
+            }
+          },
+          "calibrate_summary": {
+            "title": "Calibrate: summary",
+            "description": "Measured settings — image implementation: {impl}; paper width: {width_pixels} px; characters per line: {line_width}; character encoding: {codepage}. Save applies these to the printer's options (any setting not measured above is left unchanged). Optionally enter your printer model first — the next screen and a notification will carry a share link to help add this printer to escpos-printer-db.",
+            "data": {
+              "model": "Printer model (optional, for the share link)",
+              "action": "Action"
+            }
+          }
+        },
+        "abort": {
+          "calibration_discarded": "Calibration discarded — no options were changed.",
+          "printer_not_ready": "The printer is not connected — load the integration before calibrating.",
+          "calibration_saved": "Calibration saved and applied. [Open a prefilled GitHub issue]({share_url}) to help add this printer to escpos-printer-db.",
+          "calibration_saved_no_changes": "Calibration finished — no settings were measured, so nothing was changed."
+        }
+      }
     }
   },
   "exceptions": {

--- a/custom_components/escpos_printer/translations/en.json
+++ b/custom_components/escpos_printer/translations/en.json
@@ -520,11 +520,12 @@
     },
     "printer_not_calibrated": {
       "title": "Printer not yet calibrated",
+      "description": "The optional calibration tool prints test pages to tune print width and character set for this printer and paper. Run it now, or ignore this — printing works without it.",
       "fix_flow": {
         "step": {
           "calibrate_confirm": {
             "title": "Calibrate printer",
-            "description": "The optional calibration tool prints test pages to tune print width and character set for this printer and paper. Run it now, or ignore this — printing works without it.",
+            "description": "This wizard prints a series of test pages to measure your printer's image implementation, paper width, characters per line, and character encoding — using roughly 15–20 cm of paper in total. Make sure paper is loaded before continuing.",
             "data": {
               "action": "Action"
             }

--- a/custom_components/escpos_printer/translations/en.json
+++ b/custom_components/escpos_printer/translations/en.json
@@ -497,6 +497,20 @@
           "out": "Out"
         }
       }
+    },
+    "button": {
+      "feed": {
+        "name": "Feed paper"
+      },
+      "cut": {
+        "name": "Cut paper"
+      },
+      "beep": {
+        "name": "Beep"
+      },
+      "sample_print": {
+        "name": "Sample test print"
+      }
     }
   },
   "issues": {

--- a/custom_components/escpos_printer/translations/en.json
+++ b/custom_components/escpos_printer/translations/en.json
@@ -520,12 +520,11 @@
     },
     "printer_not_calibrated": {
       "title": "Printer not yet calibrated",
-      "description": "The optional calibration tool prints test pages to tune print width and character set for this printer and paper. Run it now, or ignore this — printing works without it.",
       "fix_flow": {
         "step": {
           "calibrate_confirm": {
             "title": "Calibrate printer",
-            "description": "This wizard prints a series of test pages to measure your printer's image implementation, paper width, characters per line, and character encoding — using roughly 15–20 cm of paper in total. Make sure paper is loaded before continuing.",
+            "description": "The optional calibration tool prints test pages to tune print width and character set for this printer and paper. Run it now, or ignore this — printing works without it.\n\nThis wizard prints a series of test pages to measure your printer's image implementation, paper width, characters per line, and character encoding — using roughly 15–20 cm of paper in total. Make sure paper is loaded before continuing.",
             "data": {
               "action": "Action"
             }

--- a/docs/calibration.md
+++ b/docs/calibration.md
@@ -4,8 +4,16 @@ A guided, print-and-answer wizard that measures four per-printer settings
 and saves them to the entry's options — no manual trial-and-error with the
 options form required.
 
-**Start it from:** Settings → Devices & Services → your printer entry →
-Configure → **"Calibrate printer (prints test pages)"**.
+## Starting the wizard
+
+Two entry points run the same wizard:
+
+- Settings → Devices & Services → your printer entry → Configure →
+  **"Calibrate printer (prints test pages)"**.
+- Settings → Repairs, if a **"Printer not yet calibrated"** suggestion is
+  showing — every printer starts without a saved calibration, so this
+  appears until you either run the wizard or dismiss (ignore) it.
+  Calibrating from either entry point clears the suggestion.
 
 > **Not the same as `calibration_print`.** The `escpos_printer.calibration_print`
 > service prints a one-off dither/threshold test sheet for tuning image

--- a/tests/test_batch_page_extensions.py
+++ b/tests/test_batch_page_extensions.py
@@ -1,0 +1,39 @@
+"""Tests for _BatchPage styled-text passthrough and QR printing."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.const import CONF_HOST, CONF_PORT
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.escpos_printer.const import DOMAIN
+
+
+async def _setup_entry(hass, host="1.2.3.4"):  # type: ignore[no-untyped-def]
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: host, CONF_PORT: 9100},
+        title=f"ESC/POS {host}",
+    )
+    entry.add_to_hass(hass)
+    with patch("escpos.printer.Network", return_value=MagicMock()):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+async def test_batch_page_styled_text_and_qr(hass):  # type: ignore[no-untyped-def]
+    """Styled kwargs reach printer.set(); qr() is issued on the held connection."""
+    entry = await _setup_entry(hass)
+    adapter = entry.runtime_data.adapter
+    fake = MagicMock()
+    with patch("escpos.printer.Network", return_value=fake):
+        async with adapter.batch_connection(hass) as page:
+            await page.print_text(text="Loud\n", bold=True, align="center")
+            await page.print_qr(data="https://example.com")
+
+    assert fake.qr.called
+    qr_args, _qr_kwargs = fake.qr.call_args
+    assert qr_args[0] == "https://example.com"
+    # bold=True must have been forwarded to printer.set() by the text half
+    set_kwargs = [kw for _, kw in fake.set.call_args_list]
+    assert any(kw.get("bold") for kw in set_kwargs)

--- a/tests/test_buttons.py
+++ b/tests/test_buttons.py
@@ -1,0 +1,90 @@
+"""Tests for the printer device-page buttons."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers import entity_registry as er
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.escpos_printer.const import CONF_DEFAULT_CUT, DOMAIN
+
+
+@pytest.fixture(autouse=True)
+def _enable_button_platform(monkeypatch):  # type: ignore[no-untyped-def]
+    """conftest limits unit-test platforms to ['notify']; buttons need theirs."""
+    import custom_components.escpos_printer.__init__ as cc_init
+
+    monkeypatch.setattr(cc_init, "PLATFORMS", ["notify", "button"], raising=False)
+
+
+async def _setup_entry(hass, host="1.2.3.4", options=None):  # type: ignore[no-untyped-def]
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: host, CONF_PORT: 9100},
+        options=options or {},
+        title=f"ESC/POS {host}",
+    )
+    entry.add_to_hass(hass)
+    with patch("escpos.printer.Network", return_value=MagicMock()):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _button_entity_id(hass, entry, key):  # type: ignore[no-untyped-def]
+    registry = er.async_get(hass)
+    entity = registry.async_get_entity_id("button", DOMAIN, f"{entry.entry_id}_{key}")
+    assert entity is not None, f"button {key} not registered"
+    return entity
+
+
+async def _press(hass, entity_id):  # type: ignore[no-untyped-def]
+    await hass.services.async_call("button", "press", {"entity_id": entity_id}, blocking=True)
+
+
+async def test_feed_button_feeds_three_lines(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass)
+    entry.runtime_data.adapter.feed = AsyncMock()
+    await _press(hass, _button_entity_id(hass, entry, "feed"))
+    entry.runtime_data.adapter.feed.assert_awaited_once_with(hass, lines=3)
+
+
+async def test_cut_button_uses_entry_default(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass, options={CONF_DEFAULT_CUT: "partial"})
+    entry.runtime_data.adapter.cut = AsyncMock()
+    await _press(hass, _button_entity_id(hass, entry, "cut"))
+    entry.runtime_data.adapter.cut.assert_awaited_once_with(hass, mode="partial")
+
+
+async def test_cut_button_none_falls_back_to_full(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass, options={CONF_DEFAULT_CUT: "none"})
+    entry.runtime_data.adapter.cut = AsyncMock()
+    await _press(hass, _button_entity_id(hass, entry, "cut"))
+    entry.runtime_data.adapter.cut.assert_awaited_once_with(hass, mode="full")
+
+
+async def test_beep_button(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass)
+    entry.runtime_data.adapter.beep = AsyncMock()
+    await _press(hass, _button_entity_id(hass, entry, "beep"))
+    entry.runtime_data.adapter.beep.assert_awaited_once_with(hass)
+
+
+async def test_sample_print_button_calls_composer(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass)
+    with patch(
+        "custom_components.escpos_printer.button.async_print_sample",
+        new=AsyncMock(),
+    ) as sample:
+        await _press(hass, _button_entity_id(hass, entry, "sample_print"))
+    sample.assert_awaited_once_with(hass, entry)
+
+
+async def test_buttons_attached_to_printer_device(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass)
+    registry = er.async_get(hass)
+    entity_id = _button_entity_id(hass, entry, "feed")
+    reg_entry = registry.async_get(entity_id)
+    assert reg_entry is not None
+    assert reg_entry.device_id is not None

--- a/tests/test_buttons.py
+++ b/tests/test_buttons.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -88,3 +89,33 @@ async def test_buttons_attached_to_printer_device(hass):  # type: ignore[no-unty
     reg_entry = registry.async_get(entity_id)
     assert reg_entry is not None
     assert reg_entry.device_id is not None
+
+
+async def test_button_press_error_is_logged_and_sanitised(hass, caplog):  # type: ignore[no-untyped-def]
+    """A failed press must log via _LOGGER.exception and sanitise the message.
+
+    Mirrors test_control_handler_sanitises_path_in_error in
+    test_services_targeting.py: the pre-fix button.py swallowed the
+    exception into a bare class-name message with no log output at
+    all, so an offline printer produced zero diagnostics. Reusing
+    ``_wrap_unexpected`` restores both the log line and the
+    sanitize_log_message redaction contract shared by every other
+    service handler.
+    """
+    entry = await _setup_entry(hass)
+
+    async def _leak(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        raise OSError("usb open failed at /config/secret/db.sqlite")
+
+    entry.runtime_data.adapter.feed = AsyncMock(side_effect=_leak)
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await _press(hass, _button_entity_id(hass, entry, "feed"))
+
+    msg = str(exc_info.value)
+    assert "secret/db.sqlite" not in msg, f"path leaked through sanitiser: {msg}"
+    assert "[REDACTED]" in msg, f"sanitiser was bypassed: {msg}"
+    assert any("feed" in rec.message and rec.levelname == "ERROR" for rec in caplog.records), (
+        "no exception log emitted for the failed press"
+    )

--- a/tests/test_entity_translations.py
+++ b/tests/test_entity_translations.py
@@ -15,6 +15,12 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from custom_components.escpos_printer.binary_sensor import EscposOnlineSensor
+from custom_components.escpos_printer.button import (
+    EscposBeepButton,
+    EscposCutButton,
+    EscposFeedButton,
+    EscposSamplePrintButton,
+)
 from custom_components.escpos_printer.sensor import (
     BluetoothPrinterBatterySensor,
     LastImagePrintSensor,
@@ -37,11 +43,16 @@ class _FakeEntry:
 def _make_entities() -> dict[str, Any]:
     adapter = MagicMock()
     adapter.get_status.return_value = None
+    hass = MagicMock()
     return {
         "binary_sensor.online": EscposOnlineSensor(MagicMock(), _FakeEntry(), adapter),
         "sensor.last_image_print": LastImagePrintSensor(_FakeEntry()),
         "sensor.battery": BluetoothPrinterBatterySensor(_FakeEntry(), "AA:BB:CC:DD:EE:FF"),
         "sensor.paper_status": PaperStatusSensor(_FakeEntry()),
+        "button.feed": EscposFeedButton(hass, _FakeEntry()),
+        "button.cut": EscposCutButton(hass, _FakeEntry()),
+        "button.beep": EscposBeepButton(hass, _FakeEntry()),
+        "button.sample_print": EscposSamplePrintButton(hass, _FakeEntry()),
     }
 
 

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1,0 +1,67 @@
+"""Tests for the printer-not-calibrated repairs issue and fix flow."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers import issue_registry as ir
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.escpos_printer.const import CONF_LINE_WIDTH, DOMAIN
+
+
+async def _setup_entry(hass, host="1.2.3.4", options=None):  # type: ignore[no-untyped-def]
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: host, CONF_PORT: 9100},
+        options=options or {},
+        title=f"ESC/POS {host}",
+    )
+    entry.add_to_hass(hass)
+    with patch("escpos.printer.Network", return_value=MagicMock()):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _issue(hass, entry):  # type: ignore[no-untyped-def]
+    registry = ir.async_get(hass)
+    return registry.async_get_issue(DOMAIN, f"printer_not_calibrated_{entry.entry_id}")
+
+
+async def test_uncalibrated_entry_raises_issue(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass)
+    issue = _issue(hass, entry)
+    assert issue is not None
+    assert issue.is_fixable
+    assert issue.translation_key == "printer_not_calibrated"
+
+
+async def test_calibrated_entry_has_no_issue(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass, options={CONF_LINE_WIDTH: 42})
+    assert _issue(hass, entry) is None
+
+
+async def test_issue_cleared_after_calibration_reload(hass):  # type: ignore[no-untyped-def]
+    """Saving a calibration option and reloading (what the wizard does) clears the issue."""
+    entry = await _setup_entry(hass)
+    assert _issue(hass, entry) is not None
+    hass.config_entries.async_update_entry(entry, options={**entry.options, CONF_LINE_WIDTH: 42})
+    with patch("escpos.printer.Network", return_value=MagicMock()):
+        assert await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+    assert _issue(hass, entry) is None
+
+
+async def test_fix_flow_opens_wizard_confirm_step(hass):  # type: ignore[no-untyped-def]
+    entry = await _setup_entry(hass)
+    from custom_components.escpos_printer.repairs import async_create_fix_flow
+
+    flow = await async_create_fix_flow(
+        hass,
+        f"printer_not_calibrated_{entry.entry_id}",
+        {"entry_id": entry.entry_id},
+    )
+    flow.hass = hass
+    result = await flow.async_step_init()
+    assert result["type"] == "form"
+    assert result["step_id"] == "calibrate_confirm"

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1,5 +1,7 @@
 """Tests for the printer-not-calibrated repairs issue and fix flow."""
 
+import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from homeassistant.const import CONF_HOST, CONF_PORT
@@ -7,6 +9,15 @@ from homeassistant.helpers import issue_registry as ir
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.escpos_printer.const import CONF_LINE_WIDTH, DOMAIN
+
+_STRINGS_PATH = (
+    Path(__file__).resolve().parent.parent / "custom_components" / "escpos_printer" / "strings.json"
+)
+_APPROVED_PREFIX = (
+    "The optional calibration tool prints test pages to tune print width and "
+    "character set for this printer and paper. Run it now, or ignore this — "
+    "printing works without it.\n\n"
+)
 
 
 async def _setup_entry(hass, host="1.2.3.4", options=None):  # type: ignore[no-untyped-def]
@@ -65,3 +76,23 @@ async def test_fix_flow_opens_wizard_confirm_step(hass):  # type: ignore[no-unty
     result = await flow.async_step_init()
     assert result["type"] == "form"
     assert result["step_id"] == "calibrate_confirm"
+
+
+def test_fix_flow_strings_match_options_counterparts() -> None:
+    """fix_flow.step/error/abort must mirror options.step/error/abort (drift guard)."""
+    strings = json.loads(_STRINGS_PATH.read_text())
+    options = strings["options"]
+    fix_flow = strings["issues"]["printer_not_calibrated"]["fix_flow"]
+
+    for key, step in fix_flow["step"].items():
+        counterpart = options["step"][key]
+        if key == "calibrate_confirm":
+            assert step["title"] == counterpart["title"]
+            assert step["data"] == counterpart["data"]
+            assert step["description"] == _APPROVED_PREFIX + counterpart["description"]
+        else:
+            assert step == counterpart
+
+    for key, message in fix_flow["error"].items():
+        assert message == options["error"][key]
+    assert fix_flow["abort"] == options["abort"]

--- a/tests/test_sample_print.py
+++ b/tests/test_sample_print.py
@@ -32,6 +32,7 @@ async def test_sample_print_composes_one_receipt(hass):  # type: ignore[no-untyp
     assert fake.image.called, "logo did not print"
     assert fake.qr.called, "QR did not print"
     assert fake.cut.called, "receipt was not cut"
+    assert fake.cut.call_args.kwargs.get("mode") == "FULL"
     # image (logo) must come before qr on the wire
     names = [c[0] for c in fake.method_calls]
     assert names.index("image") < names.index("qr")
@@ -50,3 +51,4 @@ async def test_sample_print_cut_mode_none_falls_back_to_full(hass):  # type: ign
     with patch("escpos.printer.Network", return_value=fake):
         await async_print_sample(hass, entry)
     assert fake.cut.called
+    assert fake.cut.call_args.kwargs.get("mode") == "FULL"

--- a/tests/test_sample_print.py
+++ b/tests/test_sample_print.py
@@ -1,0 +1,52 @@
+"""Tests for the sample test print composer."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.const import CONF_HOST, CONF_PORT
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.escpos_printer.const import DOMAIN
+from custom_components.escpos_printer.sample_print import async_print_sample
+
+
+async def _setup_entry(hass, host="1.2.3.4"):  # type: ignore[no-untyped-def]
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: host, CONF_PORT: 9100},
+        title=f"ESC/POS {host}",
+    )
+    entry.add_to_hass(hass)
+    with patch("escpos.printer.Network", return_value=MagicMock()):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+async def test_sample_print_composes_one_receipt(hass):  # type: ignore[no-untyped-def]
+    """Logo image, text sections, and QR go out; a cut follows."""
+    entry = await _setup_entry(hass)
+    fake = MagicMock()
+    with patch("escpos.printer.Network", return_value=fake):
+        await async_print_sample(hass, entry)
+
+    assert fake.image.called, "logo did not print"
+    assert fake.qr.called, "QR did not print"
+    assert fake.cut.called, "receipt was not cut"
+    # image (logo) must come before qr on the wire
+    names = [c[0] for c in fake.method_calls]
+    assert names.index("image") < names.index("qr")
+
+
+async def test_sample_print_cut_mode_none_falls_back_to_full(hass):  # type: ignore[no-untyped-def]
+    """An entry whose default cut is 'none' still cuts (full)."""
+    from custom_components.escpos_printer.const import CONF_DEFAULT_CUT
+
+    entry = await _setup_entry(hass)
+    hass.config_entries.async_update_entry(
+        entry, options={**entry.options, CONF_DEFAULT_CUT: "none"}
+    )
+    await hass.async_block_till_done()
+    fake = MagicMock()
+    with patch("escpos.printer.Network", return_value=fake):
+        await async_print_sample(hass, entry)
+    assert fake.cut.called


### PR DESCRIPTION
> **Stacked on #151** — merge that first; this PR targets `feat/service-action-targets` and should be retargeted to `main` (or will auto-retarget on GitHub) once #151 lands.

## Summary

- **Device page Controls card**: four new button entities per printer — **Feed paper** (3 lines), **Cut paper** (entry default cut, `none` falls back to full), **Beep**, and **Sample test print**, a one-tap demo receipt (integration logo → boxed header → bold/underline/double-size text → table → separator → QR to the repo) printed as one uninterrupted receipt over a single held connection.
- **Calibration wizard discoverability**: printers with no saved calibration raise a fixable **Settings → Repairs** suggestion ("Printer not yet calibrated", explicitly optional wording). Its Fix button runs the real calibration wizard (`CalibrationFlowMixin` reused unchanged in a `RepairsFlow`); the issue self-clears once calibrated and Ignore dismisses it permanently. The Configure → Calibrate path is unchanged.
- Supporting work: `_BatchPage` gained styled-text passthrough and QR printing (extracted `_qr_under_lock` shared with the `print_qr` service); button errors reuse the `_wrap_unexpected` log+sanitize contract; a parity test pins the duplicated repairs/options wizard strings against drift.

## Review process

Built via subagent-driven development with a per-task review gate, fix loops, and a final whole-branch review (all findings fixed and re-verified — including a hassfest schema catch: fixable issues cannot carry a top-level description, so the approved copy opens the fix flow's confirm step instead).

## Test plan

- `uv run pytest -q` → 1377 passed
- `uv run ruff check .` / `ruff format --check` → clean
- `uv run mypy custom_components/` → clean (82 files)
- `uv run python scripts/sync_service_translations.py --check` → in sync
- hassfest (docker, CI image) → Invalid integrations: 0
- New suites: `test_batch_page_extensions`, `test_sample_print` (cut-mode asserted), `test_buttons` (incl. sanitized-error branch), `test_repairs` (issue lifecycle + fix-flow + string parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)