### PR TITLE
Add Bisofice XGR-POS581 alias to POS-5890 (hardware-verified)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Bisofice XGR-POS581 is now recognized in the printer model dropdown,
+  aliased to the bundled POS-5890 profile (hardware-verified via a user's
+  calibration report, #149): 384 px width, 32 columns, Epson-standard
+  codepage indices for CP858/CP1252/CP850/CP437.
 - Device page buttons: Feed paper, Cut paper, Beep, and Sample test print
   (a one-tap demo receipt with the integration logo, styled text, a table,
   and a QR code).

--- a/custom_components/escpos_printer/capabilities/aliases.py
+++ b/custom_components/escpos_printer/capabilities/aliases.py
@@ -23,9 +23,11 @@ escpos-php issues all searched):
   reverse-engineering projects, e.g. eliasweingaertner/peripage-A6-
   bluetooth). Note "MTP-3" is a GOOJPRT model, not PeriPage — a
   different, unverified device; don't conflate the two.
-- Symcode/Bisofice: CLOSED as unmappable — storefront brands over
-  mixed OEM hardware, no FCC identity of record; the generic profile
-  is the right answer for these.
+- Symcode/Bisofice: CLOSED as unmappable at the brand level — storefront
+  brands over mixed OEM hardware, no FCC identity of record; the generic
+  profile is the right answer for these. Exception: a specific SKU earns
+  an alias once hardware-verified via the calibration wizard (Bisofice
+  XGR-POS581, issue #149 — aliased below).
 (Resolved by this pass: TM-m10 — TRG-confirmed geometry, registered as
 its own profile in custom_profiles.py with a borrowed-and-flagged
 codepage table; Bixolon SRP-350III/352III and Citizen CT-S801/851 —
@@ -162,6 +164,12 @@ ALIAS_MODELS: dict[str, str] = {
     # Misc verified 58mm/384dot ESC/POS clones.
     "HOIN HOP-E58": "POS-5890",
     "Goojprt PT-210": "POS-5890",
+    # Bisofice XGR-POS581: hardware-verified via the HA calibration wizard
+    # (issue #149): 384 px / Font A 32 columns, and all four matched
+    # codepages (CP858/CP1252/CP850/CP437) sit at POS-5890's
+    # Epson-standard indices (19/16/2/0). Keyed to this one verified SKU;
+    # the Bisofice brand overall stays closed (see module docstring).
+    "Bisofice XGR-POS581": "POS-5890",
     "Netum NT-1809DD": "NT-5890K",
     # Sunmi: V1 same 58mm class as bundled Sunmi-V2; T2 built-in is
     # 80mm/576dots/203dpi per Sunmi docs.

--- a/tests/test_profile_aliases.py
+++ b/tests/test_profile_aliases.py
@@ -99,6 +99,8 @@ def test_resolve_alias() -> None:
     assert resolve_alias("Bixolon SRP-352III") == "TM-T20II"
     assert resolve_alias("Citizen CT-S801") == "TM-T20II"
     assert resolve_alias("Citizen CT-S851II") == "TM-T20II"
+    assert resolve_alias("Bisofice XGR-POS581") == "POS-5890"
+    assert resolve_alias("XGR-POS581") == "POS-5890"
     assert resolve_alias("nonsense-model") is None
 
 


### PR DESCRIPTION
## Summary
- Adds a printer-model alias `Bisofice XGR-POS581` → bundled `POS-5890` profile, keyed to the one hardware-verified SKU (the Bisofice brand overall stays closed as unmappable per the aliases.py research notes).
- Basis: the calibration report in #149 matches POS-5890 exactly — 384 px printable width, Font A 32 columns, and all four matched codepages (CP858/CP1252/CP850/CP437) at POS-5890's Epson-standard indices (19/16/2/0).
- Updates the module docstring's held-back-models note, adds resolve_alias test assertions (full and bare-model keys), and a CHANGELOG entry.

Closes #149

## Test plan
- `uv run pytest tests/test_profile_aliases.py` — 17 passed (invariant tests cover target existence, pixel width, key collisions, dropdown ordering)
- `uv run ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLhKp42F9ymaKoyGyMxDnD